### PR TITLE
Add validation tests

### DIFF
--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -272,7 +272,28 @@ export(TARGETS ${exe} FILE ${exe}Config.cmake)
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     set(DEAC_SMOKE_TEST "${CMAKE_SOURCE_DIR}/../test/deac_smoke_test.py")
-    foreach(test_case help bad_spectra default normalize first_moment track_stats)
+    foreach(test_case
+            help
+            bad_spectra
+            default
+            normalize
+            first_moment
+            track_stats
+            bad_isf_byte_length
+            empty_isf
+            uneven_isf_arrays
+            too_few_timeslices
+            nonfinite_isf
+            positive_isf_single_particle
+            bad_third_moment_error
+            too_few_generations
+            too_small_population
+            too_small_genome
+            bad_omega_max
+            short_frequency_file
+            nonfinite_frequency
+            negative_frequency
+            unsorted_frequency)
         add_test(
             NAME deac_smoke_${test_case}
             COMMAND

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -2068,6 +2068,11 @@ int main (int argc, char *argv[]) {
         if (!std::isfinite(imaginary_time[i]) || !std::isfinite(isf[i]) || !std::isfinite(isf_error[i])) {
             fail_with_error("ISF input file contains non-finite values");
         }
+        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            if (((spectra_type == "spbsf") || (spectra_type == "spfsf")) && (isf[i] > 0.0)) {
+                fail_with_error("positive ISF values are not supported for single-particle spectra");
+            }
+        #endif
         if (isf_error[i] <= 0.0) {
             fail_with_error("ISF input errors must be positive");
         }

--- a/test/deac_smoke_test.py
+++ b/test/deac_smoke_test.py
@@ -6,12 +6,56 @@ import subprocess
 from pathlib import Path
 
 
-def write_fixture(path):
+SMOKE_CASES = [
+    "help",
+    "bad_spectra",
+    "default",
+    "normalize",
+    "first_moment",
+    "track_stats",
+]
+
+VALIDATION_CASES = [
+    "bad_isf_byte_length",
+    "empty_isf",
+    "uneven_isf_arrays",
+    "too_few_timeslices",
+    "nonfinite_isf",
+    "positive_isf_single_particle",
+    "bad_third_moment_error",
+    "too_few_generations",
+    "too_small_population",
+    "too_small_genome",
+    "bad_omega_max",
+    "short_frequency_file",
+    "nonfinite_frequency",
+    "negative_frequency",
+    "unsorted_frequency",
+]
+
+
+def write_doubles(path, values):
+    path.write_bytes(struct.pack("<" + "d" * len(values), *values))
+
+
+def write_fixture(path, tau=None, isf=None, error=None):
+    if tau is None:
+        tau = [0.0, 0.2, 0.4, 0.6]
+    if isf is None:
+        isf = [-1.0, -0.85, -0.72, -0.61]
+    if error is None:
+        error = [0.05, 0.05, 0.05, 0.05]
+    if not (len(tau) == len(isf) == len(error)):
+        raise ValueError("fixture arrays must have equal length")
+    values = tau + isf + error
+    write_doubles(path, values)
+
+
+def write_positive_fixture(path):
     tau = [0.0, 0.2, 0.4, 0.6]
     isf = [1.0, 0.85, 0.72, 0.61]
     error = [0.05, 0.05, 0.05, 0.05]
-    values = tau + isf + error
-    path.write_bytes(struct.pack("<" + "d" * len(values), *values))
+    write_fixture(path, tau=tau, isf=isf, error=error)
 
 
 def run_command(command, workdir, expected_returncode=0, expected_output=None):
@@ -37,6 +81,40 @@ def run_command(command, workdir, expected_returncode=0, expected_output=None):
     return result
 
 
+def deac_command(
+    exe,
+    workdir,
+    fixture,
+    number_of_generations="2",
+    population_size="8",
+    genome_size="8",
+    omega_max="4.0",
+    seed="7",
+    extra_args=None,
+):
+    command = [
+        exe,
+        "-T",
+        "1.0",
+        "-N",
+        number_of_generations,
+        "-P",
+        population_size,
+        "-M",
+        genome_size,
+        "--omega_max",
+        omega_max,
+        "--save_directory",
+        str(workdir / "results"),
+        "--seed",
+        seed,
+    ]
+    if extra_args:
+        command.extend(extra_args)
+    command.append(str(fixture))
+    return command
+
+
 def assert_file_size(path, expected_size):
     if not path.exists():
         raise AssertionError(f"expected output file {path} to exist")
@@ -58,31 +136,23 @@ def run_deac_case(exe, workdir, case_name):
         "track_stats": "4",
     }[case_name]
 
-    command = [
-        exe,
-        "-T",
-        "1.0",
-        "-N",
-        "2",
-        "-P",
-        "8",
-        "-M",
-        "8",
-        "--omega_max",
-        "4.0",
-        "--save_directory",
-        str(save_dir),
-        "--seed",
-        seed,
-    ]
+    extra_args = []
+    number_of_generations = "2"
     if case_name == "normalize":
-        command.append("--normalize")
+        extra_args.append("--normalize")
     elif case_name == "first_moment":
-        command.extend(["--first_moment", "0.5"])
+        extra_args.extend(["--first_moment", "0.5"])
     elif case_name == "track_stats":
-        command[command.index("-N") + 1] = "3"
-        command.append("--track_stats")
-    command.append(str(fixture))
+        number_of_generations = "3"
+        extra_args.append("--track_stats")
+    command = deac_command(
+        exe,
+        workdir,
+        fixture,
+        number_of_generations=number_of_generations,
+        seed=seed,
+        extra_args=extra_args,
+    )
 
     run_command(command, workdir, expected_output="minimum_fitness:")
 
@@ -107,6 +177,88 @@ def run_deac_case(exe, workdir, case_name):
             raise AssertionError("tracked-stat filenames were not written to the log")
 
 
+def run_validation_case(exe, workdir, case_name):
+    fixture = workdir / "invalid-isf.bin"
+    frequency_file = workdir / "frequency.bin"
+    command_options = {}
+    extra_args = None
+
+    if case_name == "bad_isf_byte_length":
+        fixture.write_bytes(b"not-a-double")
+        expected_output = "does not contain a whole number of doubles"
+    elif case_name == "empty_isf":
+        fixture.write_bytes(b"")
+        expected_output = "is empty"
+    elif case_name == "uneven_isf_arrays":
+        write_doubles(fixture, [0.0, 0.2, -1.0, 0.05])
+        expected_output = "ISF input file must contain tau, isf, and error arrays of equal length"
+    elif case_name == "too_few_timeslices":
+        write_fixture(fixture, tau=[0.0], isf=[-1.0], error=[0.05])
+        expected_output = "ISF input file must contain at least two timeslices"
+    elif case_name == "nonfinite_isf":
+        write_fixture(fixture, isf=[-1.0, float("nan"), -0.72, -0.61])
+        expected_output = "ISF input file contains non-finite values"
+    elif case_name == "positive_isf_single_particle":
+        write_positive_fixture(fixture)
+        expected_output = "positive ISF values are not supported for single-particle spectra"
+    elif case_name == "bad_third_moment_error":
+        write_fixture(fixture)
+        extra_args = ["--third_moment", "1.0", "--third_moment_error", "0.0"]
+        expected_output = "third_moment_error must be positive when third_moment is used"
+    elif case_name == "too_few_generations":
+        write_fixture(fixture)
+        command_options["number_of_generations"] = "1"
+        expected_output = "number_of_generations must be at least 2"
+    elif case_name == "too_small_population":
+        write_fixture(fixture)
+        command_options["population_size"] = "3"
+        expected_output = "population_size must be at least 4"
+    elif case_name == "too_small_genome":
+        write_fixture(fixture)
+        command_options["genome_size"] = "1"
+        expected_output = "genome_size must be at least 2"
+    elif case_name == "bad_omega_max":
+        write_fixture(fixture)
+        command_options["omega_max"] = "0.0"
+        expected_output = "omega_max must be positive"
+    elif case_name == "short_frequency_file":
+        write_fixture(fixture)
+        write_doubles(frequency_file, [0.0])
+        extra_args = ["--frequency_file", str(frequency_file)]
+        expected_output = "frequency_file must contain at least two frequencies"
+    elif case_name == "nonfinite_frequency":
+        write_fixture(fixture)
+        write_doubles(frequency_file, [0.0, float("inf")])
+        extra_args = ["--frequency_file", str(frequency_file)]
+        expected_output = "frequencies must be finite and non-negative"
+    elif case_name == "negative_frequency":
+        write_fixture(fixture)
+        write_doubles(frequency_file, [0.0, -1.0])
+        extra_args = ["--frequency_file", str(frequency_file)]
+        expected_output = "frequencies must be finite and non-negative"
+    elif case_name == "unsorted_frequency":
+        write_fixture(fixture)
+        write_doubles(frequency_file, [0.0, 2.0, 1.0])
+        extra_args = ["--frequency_file", str(frequency_file)]
+        expected_output = "frequencies must be sorted in non-decreasing order"
+    else:
+        raise AssertionError(f"unknown validation case {case_name}")
+
+    command = deac_command(
+        exe,
+        workdir,
+        fixture,
+        extra_args=extra_args,
+        **command_options,
+    )
+    run_command(
+        command,
+        workdir,
+        expected_returncode=1,
+        expected_output=expected_output,
+    )
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exe", required=True)
@@ -114,7 +266,7 @@ def main():
     parser.add_argument(
         "--case",
         required=True,
-        choices=["help", "bad_spectra", "default", "normalize", "first_moment", "track_stats"],
+        choices=SMOKE_CASES + VALIDATION_CASES,
     )
     args = parser.parse_args()
 
@@ -142,6 +294,8 @@ def main():
             expected_returncode=1,
             expected_output="Please choose spectra_type",
         )
+    elif args.case in VALIDATION_CASES:
+        run_validation_case(exe, workdir, args.case)
     else:
         run_deac_case(exe, workdir, args.case)
 


### PR DESCRIPTION
# Summary

Adds focused regression coverage for invalid input handling introduced by the program-structure rescue work.

The test harness remains Python-stdlib-only and continues to use the existing `deac_smoke_test.py` plus CTest registration pattern. This expands the smoke suite from basic execution checks to explicit validation checks for malformed files, invalid numeric inputs, unsupported data combinations, and bad frequency grids.

# What Changed

- Added validation cases for:
  - malformed ISF byte length
  - empty ISF files
  - unequal tau/isf/error array lengths
  - too few time slices
  - non-finite ISF values
  - positive ISF values for unsupported single-particle spectra
  - invalid `--third_moment_error`
  - too-small `-N`, `-P`, and `-M`
  - invalid `--omega_max`
  - too-short, non-finite, negative, and unsorted frequency files
- Registered each validation path as an individual CTest case.
- Added a runtime guard for positive ISF values in unsupported single-particle spectra.

# Validation

Locally verified:

```text
git diff --check
cmake --build /tmp/deac-cpp-build-cpu-gcc --parallel
ctest --test-dir /tmp/deac-cpp-build-cpu-gcc --output-on-failure
cmake --build /tmp/deac-cpp-build-sycl --parallel
ctest --test-dir /tmp/deac-cpp-build-sycl --output-on-failure
cmake --build /tmp/deac-cpp-build-sycl-blas --parallel
ctest --test-dir /tmp/deac-cpp-build-sycl-blas --output-on-failure
```

Results:

```text
CPU:          21/21 tests passed
SYCL:         21/21 tests passed
SYCL + BLAS:  21/21 tests passed
```

# Notes

The SYCL builds still emit the existing `local_accessor::get_pointer()` deprecation warnings. This PR does not address those warnings; they are part of a planned SYCL cleanup follow-up.