### PR TITLE
Add parity tests

### DIFF
--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -272,6 +272,7 @@ export(TARGETS ${exe} FILE ${exe}Config.cmake)
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     set(DEAC_SMOKE_TEST "${CMAKE_SOURCE_DIR}/../test/deac_smoke_test.py")
+    set(DEAC_PARITY_TEST "${CMAKE_SOURCE_DIR}/../test/deac_parity_test.py")
     foreach(test_case
             help
             bad_spectra
@@ -304,6 +305,18 @@ if(Python3_Interpreter_FOUND)
                 --case ${test_case}
         )
     endforeach()
+    set(DEAC_PARITY_REFERENCE_EXE "" CACHE FILEPATH "Reference deac executable for backend parity tests.")
+    if(NOT "${DEAC_PARITY_REFERENCE_EXE}" STREQUAL "")
+        add_test(
+            NAME deac_parity_reference
+            COMMAND
+                ${Python3_EXECUTABLE}
+                ${DEAC_PARITY_TEST}
+                --reference-exe ${DEAC_PARITY_REFERENCE_EXE}
+                --candidate-exe $<TARGET_FILE:${exe}>
+                --workdir ${CMAKE_CURRENT_BINARY_DIR}/parity/reference
+        )
+    endif()
 else()
     message(WARNING "Python3 interpreter not found; deac smoke tests will not be registered.")
 endif()

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -356,11 +356,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             } else {
                 df = 0.5*(frequency[j+1] - frequency[j-1]);
             }
-            #ifdef USE_GPU
-                size_t isf_term_idx = j*number_of_timeslices + i; //column-major storage
-            #else
-                size_t isf_term_idx = i*genome_size + j; //row-major storage
-            #endif
+            size_t isf_term_idx = i*genome_size + j;
             #ifndef ZEROT
                 #ifdef USE_HYPERBOLIC_MODEL
                     #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
@@ -431,21 +427,33 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         population_old_negative_frequency = (double*) malloc(bytes_population);
         population_new_negative_frequency = (double*) malloc(bytes_population);
     #endif
-    for (size_t i=0; i<genome_size*population_size; i++) {
-        population_old_positive_frequency[i] = (xoshiro256p(rng) >> 11) * 0x1.0p-53; // to_double2
-        #ifdef ALLOW_NEGATIVE_SPECTRAL_WEIGHT
-            population_old_positive_frequency[i] -= 0.5; 
-        #endif
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-            population_old_negative_frequency[i] = (xoshiro256p(rng) >> 11) * 0x1.0p-53; // to_double2
-            #ifdef ALLOW_NEGATIVE_SPECTRAL_WEIGHT
-                population_old_negative_frequency[i] -= 0.5; 
+    for (size_t i=0; i<population_size; i++) {
+        for (size_t j=0; j<genome_size; j++) {
+            #ifdef USE_GPU
+                size_t population_idx = j*population_size + i;
+            #else
+                size_t population_idx = i*genome_size + j;
             #endif
-        #endif
+            population_old_positive_frequency[population_idx] = (xoshiro256p(rng) >> 11) * 0x1.0p-53; // to_double2
+            #ifdef ALLOW_NEGATIVE_SPECTRAL_WEIGHT
+                population_old_positive_frequency[population_idx] -= 0.5;
+            #endif
+            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                population_old_negative_frequency[population_idx] = (xoshiro256p(rng) >> 11) * 0x1.0p-53; // to_double2
+                #ifdef ALLOW_NEGATIVE_SPECTRAL_WEIGHT
+                    population_old_negative_frequency[population_idx] -= 0.5;
+                #endif
+            #endif
+        }
     }
     #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
         for (size_t i=0; i<population_size; i++) {
-            population_new_negative_frequency[i*genome_size] = population_new_positive_frequency[i*genome_size]; // Match up zero (always take value from positive result)
+            #ifdef USE_GPU
+                size_t zero_frequency_idx = i;
+            #else
+                size_t zero_frequency_idx = i*genome_size;
+            #endif
+            population_old_negative_frequency[zero_frequency_idx] = population_old_positive_frequency[zero_frequency_idx]; // Match up zero (always take value from positive result)
         }
     #endif
 
@@ -841,7 +849,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_old_positive_frequency, d_isf_term_positive_frequency, 0.0, d_isf_model);
             GPU_ASSERT(deac_wait(default_stream));
             #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-                gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_old_negative_frequency, d_isf_term_negative_frequency, 0.0, d_isf_model);
+                gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_old_negative_frequency, d_isf_term_negative_frequency, 1.0, d_isf_model);
                 GPU_ASSERT(deac_wait(default_stream));
             #endif
         #endif
@@ -1370,7 +1378,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_new_positive_frequency, d_isf_term_positive_frequency, 0.0, d_isf_model);
                 GPU_ASSERT(deac_wait(default_stream));
                 #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-                    gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_new_negative_frequency, d_isf_term_negative_frequency, 0.0, d_isf_model);
+                    gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_new_negative_frequency, d_isf_term_negative_frequency, 1.0, d_isf_model);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
             #endif

--- a/test/deac_parity_test.py
+++ b/test/deac_parity_test.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+import argparse
+import math
+import re
+import shutil
+import struct
+import subprocess
+from pathlib import Path
+
+
+def write_doubles(path, values):
+    path.write_bytes(struct.pack("<" + "d" * len(values), *values))
+
+
+def read_doubles(path):
+    data = path.read_bytes()
+    if len(data) % 8 != 0:
+        raise AssertionError(f"{path} does not contain a whole number of doubles")
+    return struct.unpack("<" + "d" * (len(data) // 8), data)
+
+
+def run_command(command, workdir):
+    result = subprocess.run(
+        command,
+        cwd=workdir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"expected command to succeed, got {result.returncode}\n"
+            f"command: {' '.join(map(str, command))}\n"
+            f"output:\n{result.stdout}"
+        )
+    if "minimum_fitness:" not in result.stdout:
+        raise AssertionError(
+            f"expected command output to contain minimum_fitness\n"
+            f"command: {' '.join(map(str, command))}\n"
+            f"output:\n{result.stdout}"
+        )
+    return result
+
+
+def run_deac(exe, fixture, frequency_file, workdir, seed):
+    workdir.mkdir(parents=True)
+    save_dir = workdir / "results"
+    command = [
+        exe,
+        "-T",
+        "1.0",
+        "-N",
+        "2",
+        "-P",
+        "8",
+        "-M",
+        "4",
+        "--frequency_file",
+        str(frequency_file),
+        "--save_directory",
+        str(save_dir),
+        "--seed",
+        seed,
+        "--uuid",
+        seed,
+        "--stop_minimum_fitness",
+        # Stop before mutation; CPU and GPU use different parallel RNG streams after initialization.
+        "1e300",
+        "--track_stats",
+        str(fixture),
+    ]
+    run_command(command, workdir)
+    return save_dir
+
+
+def assert_close_sequence(name, reference, candidate, absolute_tolerance, relative_tolerance):
+    if len(reference) != len(candidate):
+        raise AssertionError(
+            f"{name} length mismatch: reference has {len(reference)}, "
+            f"candidate has {len(candidate)}"
+        )
+
+    max_abs_diff = 0.0
+    max_rel_diff = 0.0
+    for idx, (expected, actual) in enumerate(zip(reference, candidate)):
+        if not math.isfinite(expected) or not math.isfinite(actual):
+            raise AssertionError(
+                f"{name}[{idx}] is not finite: reference={expected}, candidate={actual}"
+            )
+        abs_diff = abs(expected - actual)
+        rel_diff = abs_diff / max(abs(expected), abs(actual), 1.0)
+        max_abs_diff = max(max_abs_diff, abs_diff)
+        max_rel_diff = max(max_rel_diff, rel_diff)
+        if abs_diff > absolute_tolerance and rel_diff > relative_tolerance:
+            raise AssertionError(
+                f"{name}[{idx}] mismatch: reference={expected}, candidate={actual}, "
+                f"abs_diff={abs_diff}, rel_diff={rel_diff}, "
+                f"max_abs_diff={max_abs_diff}, max_rel_diff={max_rel_diff}"
+            )
+
+
+def read_log_value(log_path, key):
+    pattern = re.compile(rf"^{re.escape(key)}: (.+)$", re.MULTILINE)
+    match = pattern.search(log_path.read_text())
+    if not match:
+        raise AssertionError(f"expected {log_path} to contain {key}")
+    return match.group(1)
+
+
+def assert_outputs_match(reference_dir, candidate_dir, seed, absolute_tolerance, relative_tolerance):
+    prefix = "deac-spfsf"
+    for suffix in [
+        "frequency",
+        "dsf",
+        "stats_fitness-mean",
+        "stats_fitness-minimum",
+        "stats_fitness-squared-mean",
+    ]:
+        reference = read_doubles(reference_dir / f"{prefix}_{suffix}_{seed}.bin")
+        candidate = read_doubles(candidate_dir / f"{prefix}_{suffix}_{seed}.bin")
+        assert_close_sequence(
+            suffix,
+            reference,
+            candidate,
+            absolute_tolerance,
+            relative_tolerance,
+        )
+
+    reference_log = reference_dir / f"{prefix}_log_{seed}.dat"
+    candidate_log = candidate_dir / f"{prefix}_log_{seed}.dat"
+    reference_generation = read_log_value(reference_log, "generation")
+    candidate_generation = read_log_value(candidate_log, "generation")
+    if reference_generation != candidate_generation:
+        raise AssertionError(
+            f"generation mismatch: reference={reference_generation}, "
+            f"candidate={candidate_generation}"
+        )
+
+    reference_fitness = float(read_log_value(reference_log, "minimum_fitness"))
+    candidate_fitness = float(read_log_value(candidate_log, "minimum_fitness"))
+    assert_close_sequence(
+        "minimum_fitness",
+        [reference_fitness],
+        [candidate_fitness],
+        absolute_tolerance,
+        relative_tolerance,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reference-exe", required=True)
+    parser.add_argument("--candidate-exe", required=True)
+    parser.add_argument("--workdir", required=True)
+    parser.add_argument("--absolute-tolerance", type=float, default=1e-9)
+    parser.add_argument("--relative-tolerance", type=float, default=1e-9)
+    args = parser.parse_args()
+
+    reference_exe = str(Path(args.reference_exe))
+    candidate_exe = str(Path(args.candidate_exe))
+    for exe in [reference_exe, candidate_exe]:
+        if not Path(exe).is_file():
+            raise AssertionError(f"expected executable {exe} to exist")
+
+    workdir = Path(args.workdir)
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+
+    fixture = workdir / "tiny-isf.bin"
+    write_doubles(
+        fixture,
+        [0.0, 0.2, 0.4, 0.6]
+        + [-1.0, -0.85, -0.72, -0.61]
+        + [0.05, 0.05, 0.05, 0.05],
+    )
+    frequency_file = workdir / "frequency.bin"
+    write_doubles(frequency_file, [0.0, 0.7, 1.8, 3.0])
+
+    seed = "17"
+    reference_dir = run_deac(reference_exe, fixture, frequency_file, workdir / "reference", seed)
+    candidate_dir = run_deac(candidate_exe, fixture, frequency_file, workdir / "candidate", seed)
+    assert_outputs_match(
+        reference_dir,
+        candidate_dir,
+        seed,
+        args.absolute_tolerance,
+        args.relative_tolerance,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

Adds deterministic CPU-vs-SYCL parity coverage and fixes the backend layout issues exposed by that test.

The new parity test is Python-stdlib-only. It runs a small stopped reconstruction with the same fixture, frequency grid, seed, and UUID through a reference executable and the current build executable, then compares frequency output, spectrum output, tracked stats, generation, and minimum fitness within a tight tolerance.

# What Changed

- Added `test/deac_parity_test.py`.
- Added optional CMake registration via `DEAC_PARITY_REFERENCE_EXE`.
- Registered `deac_parity_reference` only when a reference executable is explicitly provided.
- Fixed GPU layout handling so deterministic CPU and SYCL runs compare meaningfully:
  - Use the expected ISF-term layout for GPU matmul input.
  - Initialize GPU population arrays in column-major order while preserving CPU row-major order.
  - Match the zero-frequency negative population entry on the initialized population.
  - Accumulate the non-BLAS GPU negative-frequency matmul contribution instead of overwriting the positive-frequency contribution.

# Validation

Locally verified:

```text
git diff --check
cmake --build /tmp/deac-cpp-build-cpu-gcc --parallel
ctest --test-dir /tmp/deac-cpp-build-cpu-gcc --output-on-failure
cmake --build /tmp/deac-cpp-build-sycl --parallel
ctest --test-dir /tmp/deac-cpp-build-sycl --output-on-failure
cmake --build /tmp/deac-cpp-build-sycl-blas --parallel
ctest --test-dir /tmp/deac-cpp-build-sycl-blas --output-on-failure
```

Results:

```text
CPU:          21/21 tests passed
SYCL:         22/22 tests passed
SYCL + BLAS:  22/22 tests passed
```

# Notes

The parity test intentionally uses `--stop_minimum_fitness 1e300` to stop before mutation. CPU and GPU use different parallel RNG streams after initialization, so this keeps the run deterministic while still comparing generated spectra, frequency output, tracked stats, generation, and minimum fitness.

The SYCL builds still emit the existing `local_accessor::get_pointer()` deprecation warnings. This PR does not address those warnings; they remain part of the planned SYCL cleanup follow-up.