### PR TITLE
Fix model variants and SYCL correctness paths

### DIFF
--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -273,11 +273,16 @@ find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     set(DEAC_SMOKE_TEST "${CMAKE_SOURCE_DIR}/../test/deac_smoke_test.py")
     set(DEAC_PARITY_TEST "${CMAKE_SOURCE_DIR}/../test/deac_parity_test.py")
-    foreach(test_case
+    set(DEAC_SMOKE_VARIANT_ARGS)
+    if(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF)
+        list(APPEND DEAC_SMOKE_VARIANT_ARGS --detailed-balance)
+    endif()
+    set(DEAC_SMOKE_CASES
             help
             bad_spectra
             default
             normalize
+            normalize_large_population
             first_moment
             track_stats
             bad_isf_byte_length
@@ -295,6 +300,12 @@ if(Python3_Interpreter_FOUND)
             nonfinite_frequency
             negative_frequency
             unsorted_frequency)
+    if(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF)
+        list(APPEND DEAC_SMOKE_CASES negative_first_moment)
+    else()
+        list(APPEND DEAC_SMOKE_CASES unsupported_negative_first_moment)
+    endif()
+    foreach(test_case IN LISTS DEAC_SMOKE_CASES)
         add_test(
             NAME deac_smoke_${test_case}
             COMMAND
@@ -303,6 +314,7 @@ if(Python3_Interpreter_FOUND)
                 --exe $<TARGET_FILE:${exe}>
                 --workdir ${CMAKE_CURRENT_BINARY_DIR}/smoke/${test_case}
                 --case ${test_case}
+                ${DEAC_SMOKE_VARIANT_ARGS}
         )
     endforeach()
     set(DEAC_PARITY_REFERENCE_EXE "" CACHE FILEPATH "Reference deac executable for backend parity tests.")
@@ -315,6 +327,7 @@ if(Python3_Interpreter_FOUND)
                 --reference-exe ${DEAC_PARITY_REFERENCE_EXE}
                 --candidate-exe $<TARGET_FILE:${exe}>
                 --workdir ${CMAKE_CURRENT_BINARY_DIR}/parity/reference
+                ${DEAC_SMOKE_VARIANT_ARGS}
         )
     endif()
 else()

--- a/src/deac/include/common_gpu.hpp
+++ b/src/deac/include/common_gpu.hpp
@@ -89,7 +89,7 @@
         #define deac_malloc_device(T, x, y, z) x = sycl::malloc_device< T >( y, z )
         #define deac_memcpy_host_to_device(w, x, y, z) z.memcpy(w, x, y)
         #define deac_memcpy_device_to_host(w, x, y, z) z.memcpy(w, x, y)
-        #define deac_wait(x) x.wait()
+        #define deac_wait(x) x.wait_and_throw()
         #define deac_memset(w, x, y, z) z.memset(w, x, y)
         #define deac_free(x, y) sycl::free(x, y)
         #ifdef USE_BLAS

--- a/src/deac/include/deac_gpu.sycl.h
+++ b/src/deac/include/deac_gpu.sycl.h
@@ -271,7 +271,8 @@ void gpu_dot(sycl::queue q, double* __restrict__ C, double* __restrict__ B, doub
             sycl::group_barrier(item.get_group());
 
             // Reduce _c (using shared local memory)
-            gpu_reduce_add(_c.get_pointer(), item);
+            gpu_reduce_add(
+                    _c.template get_multi_ptr<sycl::access::decorated::no>().get(), item);
 
             //Set C
             if (local_idx == 0) {
@@ -359,7 +360,11 @@ void gpu_deac_gemv_simple(sycl::queue q, int m, int n, double alpha, double* __r
                 for (int j = 0; j < n; j++) {
                     sum += A[row + j*lda] * x[j*incx];
                 }
-                y[row*incy] = alpha * sum + beta * y[row*incy];
+                if (beta == 0.0) {
+                    y[row*incy] = alpha * sum;
+                } else {
+                    y[row*incy] = alpha * sum + beta * y[row*incy];
+                }
             }
         });
     });
@@ -390,41 +395,12 @@ void gpu_deac_gemv_atomic(sycl::queue q, int m, int n, double alpha, double* __r
 }
 
 void gpu_deac_gemv(sycl::queue q, int m, int n, double alpha, double* __restrict__ A, int lda, double* __restrict__ x, int incx, double beta, double* __restrict__ y, int incy) {
-    q.submit([&](sycl::handler& cgh) {
-        size_t grid_size_x = (n + TILE_WIDTH - 1) / TILE_WIDTH;
-        size_t grid_size_y = (m + TILE_WIDTH - 1) / TILE_WIDTH;
-        sycl::local_accessor<double, 2> As(sycl::range<2>(TILE_WIDTH, TILE_WIDTH), cgh);
-        cgh.parallel_for(sycl::nd_range<2>(sycl::range<2>(grid_size_x*TILE_WIDTH, grid_size_y*TILE_WIDTH), sycl::range<2>(TILE_WIDTH, TILE_WIDTH)),
-                [=](sycl::nd_item<2> item) [[sycl::reqd_sub_group_size(SUB_GROUP_SIZE)]] {
-            int tx = item.get_local_id(0);
-            int by = item.get_group(1), ty = item.get_local_id(1);
-            int row = by * item.get_local_range(1) + ty;
-
-            double sum = 0.0;
-            if (row < m) {
-                for (int i = 0; i < (n + TILE_WIDTH - 1) / TILE_WIDTH; ++i) {
-                    if (i*TILE_WIDTH + tx < n && row < m) {
-                        As[ty][tx] = A[row + (i*TILE_WIDTH + tx) * lda];
-                    } else {
-                        As[ty][tx] = 0.0;
-                    }
-                    sycl::group_barrier(item.get_group());
-
-                    for (int k = 0; k < TILE_WIDTH; ++k) {
-                        if (i*TILE_WIDTH + k < n) {
-                            sum += As[ty][k] * x[(i*TILE_WIDTH + k)*incx];
-                        }
-                    }
-                    sycl::group_barrier(item.get_group());
-                }
-                if (beta == 0.0) {
-                    y[row * incy] = alpha * sum;
-                } else {
-                    y[row * incy] = alpha * sum + beta * y[row * incy];
-                }
-            }
-        });
-    });
+    // One work-item owns each output row.  The former tiled implementation
+    // placed work-group barriers inside `row < m`; a partial final row group
+    // therefore deadlocked because only some work-items reached the barriers.
+    // It also launched an unused x dimension whose work-items raced to write
+    // the same output row.  The row-wise kernel has neither hazard.
+    gpu_deac_gemv_simple(q, m, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 void gpu_matmul(sycl::queue q, int m, int n, int k, double alpha, double* __restrict__ A, double* __restrict__ B, double beta, double* __restrict__ C) {
@@ -459,7 +435,8 @@ void gpu_get_minimum(sycl::queue q, double* __restrict__ minimum, double* __rest
             sycl::group_barrier(item.get_group());
 
             // Reduce _c (using shared local memory)
-            gpu_reduce_min(_c.get_pointer(), item);
+            gpu_reduce_min(
+                    _c.template get_multi_ptr<sycl::access::decorated::no>().get(), item);
 
             //Set minimum
             if (local_idx == 0) {
@@ -560,7 +537,8 @@ void gpu_set_fitness_mean(sycl::queue q, double* __restrict__ fitness_mean, doub
             sycl::group_barrier(item.get_group());
             
             // Reduce _fm (using shared local memory)
-            gpu_reduce_add(_fm.get_pointer(), item);
+            gpu_reduce_add(
+                    _fm.template get_multi_ptr<sycl::access::decorated::no>().get(), item);
 
             //Set fitness_mean
             if (local_idx == 0) {
@@ -592,7 +570,8 @@ void gpu_set_fitness_squared_mean(sycl::queue q, double* __restrict__ fitness_sq
             sycl::group_barrier(item.get_group());
             
             // Reduce _fsm (using shared local memory)
-            gpu_reduce_add(_fsm.get_pointer(), item);
+            gpu_reduce_add(
+                    _fsm.template get_multi_ptr<sycl::access::decorated::no>().get(), item);
 
             //Set fitness_squared_mean
             if (local_idx == 0) {

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -236,14 +236,16 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         use_negative_first_moment = false; //FIXME disabling inverse first moment for zero temperature (needs further investigation)
         temperature = 0.0;
     #else
-        //Use beta periodicity in imaginary time to reduce numerical instabilities
-        double periodicity = 1.0; // Periodic for bosnonic systems
-        if (
-            (spectra_type == "spfsf") ||
-            (spectra_type == "ffull")
-           ) {
-           periodicity = -1.0; // Antiperiodic for fermionic systems
-        }
+        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            //Use beta periodicity in imaginary time to reduce numerical instabilities
+            double periodicity = 1.0; // Periodic for bosnonic systems
+            if (
+                (spectra_type == "spfsf") ||
+                (spectra_type == "ffull")
+               ) {
+               periodicity = -1.0; // Antiperiodic for fermionic systems
+            }
+        #endif
     #endif
 
     #ifdef USE_GPU
@@ -480,11 +482,15 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     size_t bytes_normalization_term = sizeof(double)*genome_size;
     double * normalization = nullptr;
     double * normalization_term_positive_frequency = nullptr;
-    double * normalization_term_negative_frequency = nullptr;
+    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        double * normalization_term_negative_frequency = nullptr;
+    #endif
     #ifdef USE_GPU
         double* d_normalization;
         double* d_normalization_term_positive_frequency;
-        double* d_normalization_term_negative_frequency;
+        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            double* d_normalization_term_negative_frequency;
+        #endif
     #endif
     if (normalize) {
         normalization = (double*) malloc(bytes_normalization);
@@ -889,7 +895,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 }
                 negative_first_moments_term[j] = dt;
                 negative_first_moment += isf[j]*dt;
-                negative_first_moment_error = pow(isf_error[j],2) * pow(dt,2);
+                negative_first_moment_error += pow(isf_error[j],2) * pow(dt,2);
             }
             negative_first_moment_error = sqrt(negative_first_moment_error);
 
@@ -901,14 +907,13 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 GPU_ASSERT(deac_memcpy_host_to_device(d_negative_first_moments_term, negative_first_moments_term, bytes_negative_first_moments_term, default_stream));
                 GPU_ASSERT(deac_wait(default_stream));
 
-                size_t grid_size_set_negative_first_moments = (number_of_timeslices + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE;
                 GPU_ASSERT(deac_memset(d_negative_first_moments, 0, bytes_negative_first_moments, default_stream));
                 GPU_ASSERT(deac_wait(default_stream));
                 #ifdef USE_BLAS
                     gpu_blas_gemv(default_blas_handle, population_size, number_of_timeslices, 1.0, d_isf_model, d_negative_first_moments_term, 0.0, d_negative_first_moments);
                     GPU_ASSERT(deac_wait(default_stream));
                 #else
-                    gpu_deac_gemv(default_stream, population_size, number_of_timeslices, 1.0, d_population_old_positive_frequency, d_negative_first_moments_term_positive_frequency, 0.0, d_negative_first_moments);
+                    gpu_deac_gemv(default_stream, population_size, number_of_timeslices, 1.0, d_isf_model, d_negative_first_moments_term, 0.0, d_negative_first_moments);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
             #else
@@ -1398,12 +1403,11 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         if (use_negative_first_moment) {
             #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
                 #ifdef USE_GPU
-                    size_t grid_size_set_negative_first_moments = (number_of_timeslices + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE;
                     #ifdef USE_BLAS
                         gpu_blas_gemv(default_blas_handle, population_size, number_of_timeslices, 1.0, d_isf_model, d_negative_first_moments_term, 0.0, d_negative_first_moments);
                         GPU_ASSERT(deac_wait(default_stream));
                     #else
-                        gpu_deac_gemv(default_stream, population_size, number_of_timeslices, 1.0, d_population_new_positive_frequency, d_negative_first_moments_term_positive_frequency, 0.0, d_negative_first_moments);
+                        gpu_deac_gemv(default_stream, population_size, number_of_timeslices, 1.0, d_isf_model, d_negative_first_moments_term, 0.0, d_negative_first_moments);
                         GPU_ASSERT(deac_wait(default_stream));
                     #endif
                 #else
@@ -1623,11 +1627,11 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                      best_dsf[idx_p] = 0.5*population_old_positive_frequency[idx_dsf]*exp(0.5*beta*f);
                 #else
                     if (spectra_type == "spbsf") {
-                        best_dsf[idx_p] = -2.0*M_PI*population_old_positive_frequency[idx_dsf]*sinh(b*f/2); // 0.5*exp(0.5*beta*f)*(-2.0*M_PI*(1 - exp(-beta*f)))
-                        best_dsf[idx_n] = 2.0*M_PI*population_old_negative_frequency[idx_dsf]*sinh(b*f/2);  // 0.5*exp(-0.5*beta*f)*(-2.0*M_PI*(1 - exp(beta*f))) <-- f is negative here
+                        best_dsf[idx_p] = -2.0*M_PI*population_old_positive_frequency[idx_dsf]*sinh(beta*f/2); // 0.5*exp(0.5*beta*f)*(-2.0*M_PI*(1 - exp(-beta*f)))
+                        best_dsf[idx_n] = 2.0*M_PI*population_old_negative_frequency[idx_dsf]*sinh(beta*f/2);  // 0.5*exp(-0.5*beta*f)*(-2.0*M_PI*(1 - exp(beta*f))) <-- f is negative here
                     } else if (spectra_type == "spfsf") {
-                        best_dsf[idx_p] = -2.0*M_PI*population_old_positive_frequency[idx_dsf]*cosh(b*f/2); // 0.5*exp(0.5*beta*f)*(-2.0*M_PI*(1 + exp(-beta*f)))
-                        best_dsf[idx_n] = -2.0*M_PI*population_old_negative_frequency[idx_dsf]*cosh(b*f/2);  // 0.5*exp(-0.5*beta*f)*(-2.0*M_PI*(1 + exp(beta*f))) <-- f is negative here
+                        best_dsf[idx_p] = -2.0*M_PI*population_old_positive_frequency[idx_dsf]*cosh(beta*f/2); // 0.5*exp(0.5*beta*f)*(-2.0*M_PI*(1 + exp(-beta*f)))
+                        best_dsf[idx_n] = -2.0*M_PI*population_old_negative_frequency[idx_dsf]*cosh(beta*f/2);  // 0.5*exp(-0.5*beta*f)*(-2.0*M_PI*(1 + exp(beta*f))) <-- f is negative here
                     } else {
                         best_dsf[idx_p] = 0.5*population_old_positive_frequency[idx_dsf]*exp(0.5*beta*f);
                         best_dsf[idx_n] = 0.5*population_old_negative_frequency[idx_dsf]*exp(-0.5*beta*f);
@@ -1741,6 +1745,12 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     log_ofs << "genome_size: " << genome_size << std::endl;
     log_ofs << "normalize: " << normalize << std::endl;
     log_ofs << "use_negative_first_moment: " << use_negative_first_moment << std::endl;
+    #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        if (use_negative_first_moment) {
+            log_ofs << "negative_first_moment: " << negative_first_moment << std::endl;
+            log_ofs << "negative_first_moment_error: " << negative_first_moment_error << std::endl;
+        }
+    #endif
     log_ofs << "first_moment: " << first_moment << std::endl;
     log_ofs << "third_moment: " << third_moment << std::endl;
     log_ofs << "third_moment_error: " << third_moment_error << std::endl;
@@ -1799,7 +1809,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
         //FIXME need to add inverse first moment functionality then can remove this ifdef
         if (use_negative_first_moment) {
-            free(negative_first_moments_term_positive_frequency);
+            free(negative_first_moments_term);
             free(negative_first_moments);
         }
     #endif
@@ -1871,7 +1881,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             //FIXME need to add inverse first moment functionality, then can remove this ifdef
             if (use_negative_first_moment) {
                 GPU_ASSERT(deac_free(d_negative_first_moments,                         stream_array[20 % MAX_GPU_STREAMS]));
-                GPU_ASSERT(deac_free(d_negative_first_moments_term_positive_frequency, stream_array[21 % MAX_GPU_STREAMS]));
+                GPU_ASSERT(deac_free(d_negative_first_moments_term, stream_array[21 % MAX_GPU_STREAMS]));
             }
         #endif
         GPU_ASSERT(deac_free(d_crossover_probabilities_old_positive_frequency, stream_array[22 % MAX_GPU_STREAMS]));
@@ -2139,6 +2149,13 @@ int main (int argc, char *argv[]) {
 
     bool normalize = program.get<bool>("--normalize");
     bool use_negative_first_moment = program.get<bool>("--use_negative_first_moment");
+    #if !defined(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF) || defined(ZEROT)
+        if (use_negative_first_moment) {
+            fail_with_error(
+                    "use_negative_first_moment requires a finite-temperature "
+                    "bosonic detailed-balance build");
+        }
+    #endif
     double first_moment = program.get<double>("--first_moment");
     double third_moment = program.get<double>("--third_moment");
     double third_moment_error = program.get<double>("--third_moment_error");

--- a/test/deac_parity_test.py
+++ b/test/deac_parity_test.py
@@ -42,7 +42,17 @@ def run_command(command, workdir):
     return result
 
 
-def run_deac(exe, fixture, frequency_file, workdir, seed):
+def run_deac(
+    exe,
+    fixture,
+    frequency_file,
+    workdir,
+    seed,
+    *,
+    normalize=False,
+    negative_first_moment=False,
+    population_size="8",
+):
     workdir.mkdir(parents=True)
     save_dir = workdir / "results"
     command = [
@@ -52,7 +62,7 @@ def run_deac(exe, fixture, frequency_file, workdir, seed):
         "-N",
         "2",
         "-P",
-        "8",
+        population_size,
         "-M",
         "4",
         "--frequency_file",
@@ -67,8 +77,12 @@ def run_deac(exe, fixture, frequency_file, workdir, seed):
         # Stop before mutation; CPU and GPU use different parallel RNG streams after initialization.
         "1e300",
         "--track_stats",
-        str(fixture),
     ]
+    if normalize:
+        command.append("--normalize")
+    if negative_first_moment:
+        command.append("--use_negative_first_moment")
+    command.append(str(fixture))
     run_command(command, workdir)
     return save_dir
 
@@ -107,8 +121,15 @@ def read_log_value(log_path, key):
     return match.group(1)
 
 
-def assert_outputs_match(reference_dir, candidate_dir, seed, absolute_tolerance, relative_tolerance):
-    prefix = "deac-spfsf"
+def assert_outputs_match(
+    reference_dir,
+    candidate_dir,
+    seed,
+    absolute_tolerance,
+    relative_tolerance,
+    detailed_balance=False,
+):
+    prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
     for suffix in [
         "frequency",
         "dsf",
@@ -154,6 +175,7 @@ def main():
     parser.add_argument("--workdir", required=True)
     parser.add_argument("--absolute-tolerance", type=float, default=1e-9)
     parser.add_argument("--relative-tolerance", type=float, default=1e-9)
+    parser.add_argument("--detailed-balance", action="store_true")
     args = parser.parse_args()
 
     reference_exe = str(Path(args.reference_exe))
@@ -177,16 +199,43 @@ def main():
     frequency_file = workdir / "frequency.bin"
     write_doubles(frequency_file, [0.0, 0.7, 1.8, 3.0])
 
-    seed = "17"
-    reference_dir = run_deac(reference_exe, fixture, frequency_file, workdir / "reference", seed)
-    candidate_dir = run_deac(candidate_exe, fixture, frequency_file, workdir / "candidate", seed)
-    assert_outputs_match(
-        reference_dir,
-        candidate_dir,
-        seed,
-        args.absolute_tolerance,
-        args.relative_tolerance,
-    )
+    cases = [
+        ("default", "17", False, False, "8"),
+        # Exercise both GEMV beta paths and a partial second work-group even
+        # with the default GPU_BLOCK_SIZE=1024.
+        ("normalize_large_population", "19", True, False, "1028"),
+    ]
+    if args.detailed_balance:
+        cases.append(("negative_first_moment", "23", False, True, "8"))
+    for case_name, seed, normalize, negative_first_moment, population_size in cases:
+        reference_dir = run_deac(
+            reference_exe,
+            fixture,
+            frequency_file,
+            workdir / case_name / "reference",
+            seed,
+            normalize=normalize,
+            negative_first_moment=negative_first_moment,
+            population_size=population_size,
+        )
+        candidate_dir = run_deac(
+            candidate_exe,
+            fixture,
+            frequency_file,
+            workdir / case_name / "candidate",
+            seed,
+            normalize=normalize,
+            negative_first_moment=negative_first_moment,
+            population_size=population_size,
+        )
+        assert_outputs_match(
+            reference_dir,
+            candidate_dir,
+            seed,
+            args.absolute_tolerance,
+            args.relative_tolerance,
+            args.detailed_balance,
+        )
 
 
 if __name__ == "__main__":

--- a/test/deac_smoke_test.py
+++ b/test/deac_smoke_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import math
 import shutil
 import struct
 import subprocess
@@ -11,7 +12,9 @@ SMOKE_CASES = [
     "bad_spectra",
     "default",
     "normalize",
+    "normalize_large_population",
     "first_moment",
+    "negative_first_moment",
     "track_stats",
 ]
 
@@ -31,6 +34,7 @@ VALIDATION_CASES = [
     "nonfinite_frequency",
     "negative_frequency",
     "unsorted_frequency",
+    "unsupported_negative_first_moment",
 ]
 
 
@@ -125,23 +129,30 @@ def assert_file_size(path, expected_size):
         )
 
 
-def run_deac_case(exe, workdir, case_name):
+def run_deac_case(exe, workdir, case_name, detailed_balance=False):
     fixture = workdir / "tiny-isf.bin"
     write_fixture(fixture)
     save_dir = workdir / "results"
     seed = {
         "default": "1",
         "normalize": "2",
+        "normalize_large_population": "6",
         "first_moment": "3",
+        "negative_first_moment": "5",
         "track_stats": "4",
     }[case_name]
 
     extra_args = []
     number_of_generations = "2"
-    if case_name == "normalize":
+    population_size = "8"
+    if case_name in ("normalize", "normalize_large_population"):
         extra_args.append("--normalize")
+        if case_name == "normalize_large_population":
+            population_size = "1028"
     elif case_name == "first_moment":
         extra_args.extend(["--first_moment", "0.5"])
+    elif case_name == "negative_first_moment":
+        extra_args.append("--use_negative_first_moment")
     elif case_name == "track_stats":
         number_of_generations = "3"
         extra_args.append("--track_stats")
@@ -150,14 +161,15 @@ def run_deac_case(exe, workdir, case_name):
         workdir,
         fixture,
         number_of_generations=number_of_generations,
+        population_size=population_size,
         seed=seed,
         extra_args=extra_args,
     )
 
     run_command(command, workdir, expected_output="minimum_fitness:")
 
-    expected_spectrum_bytes = (2 * 8 - 1) * 8
-    prefix = f"deac-spfsf"
+    expected_spectrum_bytes = (8 if detailed_balance else 2 * 8 - 1) * 8
+    prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
     assert_file_size(save_dir / f"{prefix}_dsf_{seed}.bin", expected_spectrum_bytes)
     assert_file_size(save_dir / f"{prefix}_frequency_{seed}.bin", expected_spectrum_bytes)
 
@@ -168,6 +180,29 @@ def run_deac_case(exe, workdir, case_name):
     if "minimum_fitness:" not in log_text:
         raise AssertionError(f"expected {log_path} to contain minimum_fitness")
 
+    if detailed_balance and case_name == "negative_first_moment":
+        error_line = next(
+            (
+                line
+                for line in log_text.splitlines()
+                if line.startswith("negative_first_moment_error: ")
+            ),
+            None,
+        )
+        if error_line is None:
+            raise AssertionError(
+                f"expected {log_path} to contain negative_first_moment_error"
+            )
+        actual_error = float(error_line.split(": ", 1)[1])
+        # Trapezoid weights for tau=[0.0, 0.2, 0.4, 0.6] are
+        # [0.1, 0.2, 0.2, 0.1].  Every sample has sigma=0.05.
+        expected_error = 0.05 * math.sqrt(0.1**2 + 0.2**2 + 0.2**2 + 0.1**2)
+        if not math.isclose(actual_error, expected_error, rel_tol=1e-5):
+            raise AssertionError(
+                f"expected accumulated negative first-moment error "
+                f"{expected_error}, got {actual_error}"
+            )
+
     if case_name == "track_stats":
         expected_stats_bytes = 3 * 8
         assert_file_size(save_dir / f"{prefix}_stats_fitness-mean_{seed}.bin", expected_stats_bytes)
@@ -177,11 +212,12 @@ def run_deac_case(exe, workdir, case_name):
             raise AssertionError("tracked-stat filenames were not written to the log")
 
 
-def run_validation_case(exe, workdir, case_name):
+def run_validation_case(exe, workdir, case_name, detailed_balance=False):
     fixture = workdir / "invalid-isf.bin"
     frequency_file = workdir / "frequency.bin"
     command_options = {}
     extra_args = None
+    expected_returncode = 1
 
     if case_name == "bad_isf_byte_length":
         fixture.write_bytes(b"not-a-double")
@@ -200,7 +236,11 @@ def run_validation_case(exe, workdir, case_name):
         expected_output = "ISF input file contains non-finite values"
     elif case_name == "positive_isf_single_particle":
         write_positive_fixture(fixture)
-        expected_output = "positive ISF values are not supported for single-particle spectra"
+        if detailed_balance:
+            expected_returncode = 0
+            expected_output = "minimum_fitness:"
+        else:
+            expected_output = "positive ISF values are not supported for single-particle spectra"
     elif case_name == "bad_third_moment_error":
         write_fixture(fixture)
         extra_args = ["--third_moment", "1.0", "--third_moment_error", "0.0"]
@@ -241,6 +281,13 @@ def run_validation_case(exe, workdir, case_name):
         write_doubles(frequency_file, [0.0, 2.0, 1.0])
         extra_args = ["--frequency_file", str(frequency_file)]
         expected_output = "frequencies must be sorted in non-decreasing order"
+    elif case_name == "unsupported_negative_first_moment":
+        write_fixture(fixture)
+        extra_args = ["--use_negative_first_moment"]
+        expected_output = (
+            "use_negative_first_moment requires a finite-temperature "
+            "bosonic detailed-balance build"
+        )
     else:
         raise AssertionError(f"unknown validation case {case_name}")
 
@@ -254,7 +301,7 @@ def run_validation_case(exe, workdir, case_name):
     run_command(
         command,
         workdir,
-        expected_returncode=1,
+        expected_returncode=expected_returncode,
         expected_output=expected_output,
     )
 
@@ -263,6 +310,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exe", required=True)
     parser.add_argument("--workdir", required=True)
+    parser.add_argument("--detailed-balance", action="store_true")
     parser.add_argument(
         "--case",
         required=True,
@@ -295,9 +343,9 @@ def main():
             expected_output="Please choose spectra_type",
         )
     elif args.case in VALIDATION_CASES:
-        run_validation_case(exe, workdir, args.case)
+        run_validation_case(exe, workdir, args.case, args.detailed_balance)
     else:
-        run_deac_case(exe, workdir, args.case)
+        run_deac_case(exe, workdir, args.case, args.detailed_balance)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- restore compilation of the hyperbolic kernel variant
- correct detailed-balance negative-first-moment allocation and accumulation
- reject the unsupported negative-first-moment option outside detailed balance
- replace the divergent-barrier SYCL GEMV kernel with a row-wise kernel
- preserve beta=0 GEMV semantics without reading the input vector
- add variant-aware smoke, large-population normalization, and CPU/SYCL parity coverage

## Validation

Exact commit: a5844067e5b8dcf03beeb3f179b20e74f9d8377d

- IntelLLVM 2026.1 Release CPU: standard 23/23, hyperbolic 23/23, detailed balance 23/23
- Intel Data Center GPU Max 1550 via Level Zero: standard SYCL 23/23 and detailed-balance SYCL 23/23
- CPU-to-SYCL parity: standard and detailed-balance suites pass at the configured 1e-9 tolerances
- 1,028-member SYCL normalization regression: passes in approximately 0.34 seconds
- git diff --check: clean

## Deliberate follow-ups

- ZeroT physics semantics remain tracked in #8
- analogous CUDA/HIP barrier behavior remains tracked in #14 and needs hardware validation

Fixes #7
Fixes #9
Fixes #10
Fixes #12
Fixes #13