### PR TITLE
Centralize trapezoidal integration weights

### DIFF
--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -269,6 +269,14 @@ install(EXPORT ${exe}Config DESTINATION share/${exe}/cmake)
 export(TARGETS ${exe} FILE ${exe}Config.cmake)
 
 # Unit tests
+add_executable(deac_trapezoidal_weights_test
+    ${CMAKE_SOURCE_DIR}/../test/trapezoidal_weights_test.cpp)
+target_include_directories(deac_trapezoidal_weights_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_test(
+    NAME deac_unit_trapezoidal_weights
+    COMMAND deac_trapezoidal_weights_test)
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     set(DEAC_SMOKE_TEST "${CMAKE_SOURCE_DIR}/../test/deac_smoke_test.py")

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -8,7 +8,10 @@
 #include <algorithm> // std::none_of
 #include <cmath>
 #include <cstdint>
+#include <span>
+#include <vector>
 #include <rng.hpp>
+#include "trapezoidal_weights.hpp"
 #include <memory> // string_format
 #include <string> // string_format
 #include <stdexcept> // throw
@@ -325,6 +328,8 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     double zeroth_moment = isf[0];
     bool use_first_moment = first_moment >= 0.0;
     bool use_third_moment = third_moment >= 0.0;
+    const std::vector<double> frequency_weights = deac_numerics::trapezoidal_weights(
+            std::span<const double>(frequency, genome_size));
 
     //Set isf term for trapezoidal rule integration with dsf (population members)
     size_t bytes_isf_term = sizeof(double)*genome_size*number_of_timeslices;
@@ -367,14 +372,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         for (size_t j=0; j<genome_size; j++) {
             double f = frequency[j];
             (void) f;
-            double df;
-            if (j==0) {
-                df = 0.5*(frequency[j+1] - frequency[j]);
-            } else if (j == genome_size - 1) {
-                df = 0.5*(frequency[j] - frequency[j-1]);
-            } else {
-                df = 0.5*(frequency[j+1] - frequency[j-1]);
-            }
+            const double df = frequency_weights[j];
             size_t isf_term_idx = i*genome_size + j;
             #ifndef ZEROT
                 #ifdef USE_HYPERBOLIC_MODEL
@@ -518,14 +516,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         for (size_t j=0; j<genome_size; j++) {
             double f = frequency[j];
             (void) f;
-            double df;
-            if (j==0) {
-                df = 0.5*(frequency[j+1] - frequency[j]);
-            } else if (j == genome_size - 1) {
-                df = 0.5*(frequency[j] - frequency[j-1]);
-            } else {
-                df = 0.5*(frequency[j+1] - frequency[j-1]);
-            }
+            const double df = frequency_weights[j];
             #ifndef ZEROT
                 #ifdef USE_HYPERBOLIC_MODEL
                     #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
@@ -655,14 +646,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         #endif
         for (size_t j=0; j<genome_size; j++) {
             double f = frequency[j];
-            double df;
-            if (j==0) {
-                df = 0.5*(frequency[j+1] - frequency[j]);
-            } else if (j == genome_size - 1) {
-                df = 0.5*(frequency[j] - frequency[j-1]);
-            } else {
-                df = 0.5*(frequency[j+1] - frequency[j-1]);
-            }
+            const double df = frequency_weights[j];
             #ifndef ZEROT
                 #ifdef USE_HYPERBOLIC_MODEL
                     #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
@@ -764,14 +748,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         #endif
         for (size_t j=0; j<genome_size; j++) {
             double f = frequency[j];
-            double df;
-            if (j==0) {
-                df = 0.5*(frequency[j+1] - frequency[j]);
-            } else if (j == genome_size - 1) {
-                df = 0.5*(frequency[j] - frequency[j-1]);
-            } else {
-                df = 0.5*(frequency[j+1] - frequency[j-1]);
-            }
+            const double df = frequency_weights[j];
             #ifndef ZEROT
                 #ifdef USE_HYPERBOLIC_MODEL
                     #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
@@ -901,15 +878,10 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         double negative_first_moment_error = 0.0;
         if (use_negative_first_moment) {
             negative_first_moments_term = (double*) malloc(bytes_negative_first_moments_term);
+            const std::vector<double> imaginary_time_weights = deac_numerics::trapezoidal_weights(
+                    std::span<const double>(imaginary_time, number_of_timeslices));
             for (size_t j=0; j<number_of_timeslices; j++) {
-                double dt;
-                if (j==0) {
-                    dt = 0.5*(imaginary_time[j+1] - imaginary_time[j]);
-                } else if (j == number_of_timeslices - 1) {
-                    dt = 0.5*(imaginary_time[j] - imaginary_time[j-1]);
-                } else {
-                    dt = 0.5*(imaginary_time[j+1] - imaginary_time[j-1]);
-                }
+                const double dt = imaginary_time_weights[j];
                 negative_first_moments_term[j] = dt;
                 negative_first_moment += isf[j]*dt;
                 negative_first_moment_error += pow(isf_error[j],2) * pow(dt,2);

--- a/src/deac/src/trapezoidal_weights.hpp
+++ b/src/deac/src/trapezoidal_weights.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace deac_numerics {
+
+// Return the per-sample weights for trapezoidal integration on an arbitrary
+// coordinate grid. Coordinate validation remains the caller's responsibility.
+inline std::vector<double> trapezoidal_weights(std::span<const double> coordinates) {
+    if (coordinates.size() < 2) {
+        throw std::invalid_argument("trapezoidal integration requires at least two coordinates");
+    }
+
+    std::vector<double> weights(coordinates.size());
+    weights.front() = 0.5*(coordinates[1] - coordinates[0]);
+    for (std::size_t i=1; i + 1 < coordinates.size(); ++i) {
+        weights[i] = 0.5*(coordinates[i+1] - coordinates[i-1]);
+    }
+    weights.back() = 0.5*(coordinates.back() - coordinates[coordinates.size()-2]);
+    return weights;
+}
+
+} // namespace deac_numerics

--- a/test/trapezoidal_weights_test.cpp
+++ b/test/trapezoidal_weights_test.cpp
@@ -1,0 +1,71 @@
+#include "trapezoidal_weights.hpp"
+
+#include <array>
+#include <cstddef>
+#include <iostream>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+bool check_weights(std::span<const double> coordinates, std::span<const double> expected) {
+    const std::vector<double> actual = deac_numerics::trapezoidal_weights(coordinates);
+    if (actual.size() != expected.size()) {
+        std::cerr << "weight count differs: expected " << expected.size()
+                  << ", got " << actual.size() << '\n';
+        return false;
+    }
+
+    for (std::size_t i=0; i<actual.size(); ++i) {
+        if (actual[i] != expected[i]) {
+            std::cerr << "weight " << i << " differs: expected " << expected[i]
+                      << ", got " << actual[i] << '\n';
+            return false;
+        }
+    }
+    return true;
+}
+
+bool rejects_too_few_coordinates(std::span<const double> coordinates) {
+    try {
+        (void) deac_numerics::trapezoidal_weights(coordinates);
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    std::cerr << "expected fewer than two coordinates to be rejected\n";
+    return false;
+}
+
+} // namespace
+
+int main() {
+    const std::array<double, 2> two_point_grid{1.0, 5.0};
+    const std::array<double, 2> two_point_weights{2.0, 2.0};
+    if (!check_weights(two_point_grid, two_point_weights)) {
+        return 1;
+    }
+
+    const std::array<double, 4> nonuniform_grid{0.0, 1.0, 4.0, 10.0};
+    const std::array<double, 4> nonuniform_weights{0.5, 2.0, 4.5, 3.0};
+    if (!check_weights(nonuniform_grid, nonuniform_weights)) {
+        return 1;
+    }
+
+    // Repeated coordinates are accepted because solver input validation permits
+    // a non-decreasing grid; the helper only applies the integration formula.
+    const std::array<double, 3> repeated_grid{0.0, 0.0, 2.0};
+    const std::array<double, 3> repeated_weights{0.0, 1.0, 1.0};
+    if (!check_weights(repeated_grid, repeated_weights)) {
+        return 1;
+    }
+
+    const std::array<double, 0> empty_grid{};
+    const std::array<double, 1> singleton_grid{0.0};
+    if (!rejects_too_few_coordinates(empty_grid)
+            || !rejects_too_few_coordinates(singleton_grid)) {
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- replace five duplicated endpoint/interior quadrature branches with one internal helper
- precompute frequency-grid weights once for kernel, normalization, first-moment, and third-moment setup
- reuse the same helper for detailed-balance imaginary-time inverse-moment setup
- add a standalone C++ unit test for two-point, nonuniform, repeated-coordinate, empty, and singleton grids

## Behavior preservation

Exact commit: 7087bc2

Seeded pre/post comparisons were byte-identical:

- standard: 39 non-log artifacts
- hyperbolic: 39 non-log artifacts
- detailed balance: 43 non-log artifacts
- all 17 logs matched after normalizing absolute build paths

The helper intentionally owns only quadrature-weight construction. Finiteness and ordering remain input-validation responsibilities, so repeated coordinates retain existing behavior.

## Validation

- IntelLLVM 2026.1 CPU Release: standard 24/24, hyperbolic 24/24, detailed balance 24/24
- GCC 14.3 CPU Release: standard 24/24
- Intel Data Center GPU Max 1550 via Level Zero: standard SYCL 25/25, detailed-balance SYCL 25/25, including CPU parity
- git diff --check: clean

Fixes #17