### PR TITLE
Validate evolution controls before I/O

### DIFF
--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -277,6 +277,14 @@ add_test(
     NAME deac_unit_trapezoidal_weights
     COMMAND deac_trapezoidal_weights_test)
 
+add_executable(deac_evolution_controls_test
+    ${CMAKE_SOURCE_DIR}/../test/evolution_controls_test.cpp)
+target_include_directories(deac_evolution_controls_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_test(
+    NAME deac_unit_evolution_controls
+    COMMAND deac_evolution_controls_test)
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     set(DEAC_SMOKE_TEST "${CMAKE_SOURCE_DIR}/../test/deac_smoke_test.py")
@@ -287,8 +295,11 @@ if(Python3_Interpreter_FOUND)
     endif()
     set(DEAC_SMOKE_CASES
             help
+            version
             bad_spectra
             default
+            evolution_control_lower_boundaries
+            evolution_control_upper_boundaries
             normalize
             normalize_large_population
             first_moment
@@ -300,6 +311,11 @@ if(Python3_Interpreter_FOUND)
             nonfinite_isf
             positive_isf_single_particle
             bad_third_moment_error
+            bad_crossover_probability
+            bad_self_adapting_crossover_probability
+            bad_differential_weight
+            bad_self_adapting_differential_weight_probability
+            bad_stop_minimum_fitness
             too_few_generations
             too_small_population
             too_small_genome

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -11,6 +11,7 @@
 #include <span>
 #include <vector>
 #include <rng.hpp>
+#include "evolution_controls.hpp"
 #include "trapezoidal_weights.hpp"
 #include <memory> // string_format
 #include <string> // string_format
@@ -1972,19 +1973,19 @@ int main (int argc, char *argv[]) {
         .default_value(0.0)
         .action([](const std::string& value) { return std::stod(value); });
     program.add_argument("-r","--crossover_probability")
-        .help("Initial probability for parent gene to become mutant vector gene.")
+        .help("Initial probability for parent gene to become mutant vector gene. Must be finite and in [0, 1].")
         .default_value(0.9)
         .action([](const std::string& value) { return std::stod(value); });
     program.add_argument("-u","--self_adapting_crossover_probability")
-        .help("Probability for `crossover_probability` to mutate.")
+        .help("Probability for `crossover_probability` to mutate. Must be finite and in [0, 1].")
         .default_value(0.1)
         .action([](const std::string& value) { return std::stod(value); });
     program.add_argument("-F","--differential_weight")
-        .help("Initial weight factor when creating mutant vector.")
+        .help("Initial weight factor when creating mutant vector. Must be finite and in [0, 2].")
         .default_value(0.9)
         .action([](const std::string& value) { return std::stod(value); });
-    program.add_argument("-v","--self_adapting_differential_weight_probability")
-        .help("Probability for `differential_weight` to mutate.")
+    program.add_argument("--self_adapting_differential_weight_probability")
+        .help("Probability for `differential_weight` to mutate. Must be finite and in [0, 1].")
         .default_value(0.1)
         .action([](const std::string& value) { return std::stod(value); });
     program.add_argument("-l","--self_adapting_differential_weight_shift")
@@ -1996,7 +1997,7 @@ int main (int argc, char *argv[]) {
         .default_value(0.9)
         .action([](const std::string& value) { return std::stod(value); });
     program.add_argument("--stop_minimum_fitness")
-        .help("Stopping criteria, if minimum fitness is below `stop_minimum_fitness` stop evolving.")
+        .help("Stop evolving when minimum fitness is at or below this finite value. Negative values are allowed.")
         .default_value(1.0)
         .action([](const std::string& value) { return std::stod(value); });
     program.add_argument("--seed")
@@ -2034,6 +2035,22 @@ int main (int argc, char *argv[]) {
         std::cout << err.what() << std::endl;
         std::cout << program << std::endl;
         exit(1);
+    }
+
+    double crossover_probability = program.get<double>("--crossover_probability");
+    double self_adapting_crossover_probability = program.get<double>("--self_adapting_crossover_probability");
+    double differential_weight = program.get<double>("--differential_weight");
+    double self_adapting_differential_weight_probability = program.get<double>("--self_adapting_differential_weight_probability");
+    double stop_minimum_fitness = program.get<double>("--stop_minimum_fitness");
+    try {
+        deac_configuration::validate_evolution_controls({
+                crossover_probability,
+                self_adapting_crossover_probability,
+                differential_weight,
+                self_adapting_differential_weight_probability,
+                stop_minimum_fitness});
+    } catch (const std::invalid_argument& error) {
+        fail_with_error(error.what());
     }
 
     std::string uuid_str = program.get<std::string>("--uuid");
@@ -2164,14 +2181,8 @@ int main (int argc, char *argv[]) {
         fail_with_error("third_moment_error must be positive when third_moment is used");
     }
 
-    double crossover_probability = program.get<double>("--crossover_probability");
-    double self_adapting_crossover_probability = program.get<double>("--self_adapting_crossover_probability");
-    double differential_weight = program.get<double>("--differential_weight");
-    double self_adapting_differential_weight_probability = program.get<double>("--self_adapting_differential_weight_probability");
     double self_adapting_differential_weight_shift = program.get<double>("--self_adapting_differential_weight_shift");
     double self_adapting_differential_weight = program.get<double>("--self_adapting_differential_weight");
-    
-    double stop_minimum_fitness = program.get<double>("--stop_minimum_fitness");
 
     bool track_stats = program.get<bool>("--track_stats");
     std::string save_directory_str = program.get<std::string>("--save_directory");

--- a/src/deac/src/evolution_controls.hpp
+++ b/src/deac/src/evolution_controls.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cmath>
+#include <stdexcept>
+
+namespace deac_configuration {
+
+struct EvolutionControls {
+    double crossover_probability;
+    double self_adapting_crossover_probability;
+    double differential_weight;
+    double self_adapting_differential_weight_probability;
+    double stop_minimum_fitness;
+};
+
+inline void require_finite_closed_interval(
+        double value, double lower, double upper, const char* error_message) {
+    if (!std::isfinite(value) || value < lower || value > upper) {
+        throw std::invalid_argument(error_message);
+    }
+}
+
+inline void validate_evolution_controls(const EvolutionControls& controls) {
+    require_finite_closed_interval(
+            controls.crossover_probability, 0.0, 1.0,
+            "crossover_probability must be finite and in [0, 1]");
+    require_finite_closed_interval(
+            controls.self_adapting_crossover_probability, 0.0, 1.0,
+            "self_adapting_crossover_probability must be finite and in [0, 1]");
+    require_finite_closed_interval(
+            controls.differential_weight, 0.0, 2.0,
+            "differential_weight must be finite and in [0, 2]");
+    require_finite_closed_interval(
+            controls.self_adapting_differential_weight_probability, 0.0, 1.0,
+            "self_adapting_differential_weight_probability must be finite and in [0, 1]");
+
+    // A negative threshold is useful when callers want every configured
+    // generation to run; only non-finite values are invalid.
+    if (!std::isfinite(controls.stop_minimum_fitness)) {
+        throw std::invalid_argument("stop_minimum_fitness must be finite");
+    }
+}
+
+} // namespace deac_configuration

--- a/test/deac_smoke_test.py
+++ b/test/deac_smoke_test.py
@@ -9,8 +9,11 @@ from pathlib import Path
 
 SMOKE_CASES = [
     "help",
+    "version",
     "bad_spectra",
     "default",
+    "evolution_control_lower_boundaries",
+    "evolution_control_upper_boundaries",
     "normalize",
     "normalize_large_population",
     "first_moment",
@@ -26,6 +29,11 @@ VALIDATION_CASES = [
     "nonfinite_isf",
     "positive_isf_single_particle",
     "bad_third_moment_error",
+    "bad_crossover_probability",
+    "bad_self_adapting_crossover_probability",
+    "bad_differential_weight",
+    "bad_self_adapting_differential_weight_probability",
+    "bad_stop_minimum_fitness",
     "too_few_generations",
     "too_small_population",
     "too_small_genome",
@@ -135,6 +143,8 @@ def run_deac_case(exe, workdir, case_name, detailed_balance=False):
     save_dir = workdir / "results"
     seed = {
         "default": "1",
+        "evolution_control_lower_boundaries": "8",
+        "evolution_control_upper_boundaries": "9",
         "normalize": "2",
         "normalize_large_population": "6",
         "first_moment": "3",
@@ -156,6 +166,32 @@ def run_deac_case(exe, workdir, case_name, detailed_balance=False):
     elif case_name == "track_stats":
         number_of_generations = "3"
         extra_args.append("--track_stats")
+    elif case_name in (
+        "evolution_control_lower_boundaries",
+        "evolution_control_upper_boundaries",
+    ):
+        if case_name == "evolution_control_lower_boundaries":
+            probability = "0"
+            differential_weight = "0"
+            stop_minimum_fitness = "-1"
+        else:
+            probability = "1"
+            differential_weight = "2"
+            stop_minimum_fitness = "1"
+        extra_args.extend(
+            [
+                "--crossover_probability",
+                probability,
+                "--self_adapting_crossover_probability",
+                probability,
+                "--differential_weight",
+                differential_weight,
+                "--self_adapting_differential_weight_probability",
+                probability,
+                "--stop_minimum_fitness",
+                stop_minimum_fitness,
+            ]
+        )
     command = deac_command(
         exe,
         workdir,
@@ -245,6 +281,32 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
         write_fixture(fixture)
         extra_args = ["--third_moment", "1.0", "--third_moment_error", "0.0"]
         expected_output = "third_moment_error must be positive when third_moment is used"
+    elif case_name == "bad_crossover_probability":
+        write_fixture(fixture)
+        extra_args = ["--crossover_probability", "1.01"]
+        expected_output = "crossover_probability must be finite and in [0, 1]"
+    elif case_name == "bad_self_adapting_crossover_probability":
+        write_fixture(fixture)
+        extra_args = ["--self_adapting_crossover_probability", "-0.01"]
+        expected_output = (
+            "self_adapting_crossover_probability must be finite and in "
+            "[0, 1]"
+        )
+    elif case_name == "bad_differential_weight":
+        write_fixture(fixture)
+        extra_args = ["--differential_weight", "2.01"]
+        expected_output = "differential_weight must be finite and in [0, 2]"
+    elif case_name == "bad_self_adapting_differential_weight_probability":
+        write_fixture(fixture)
+        extra_args = ["--self_adapting_differential_weight_probability", "nan"]
+        expected_output = (
+            "self_adapting_differential_weight_probability must be finite and in "
+            "[0, 1]"
+        )
+    elif case_name == "bad_stop_minimum_fitness":
+        write_fixture(fixture)
+        extra_args = ["--stop_minimum_fitness", "inf"]
+        expected_output = "stop_minimum_fitness must be finite"
     elif case_name == "too_few_generations":
         write_fixture(fixture)
         command_options["number_of_generations"] = "1"
@@ -298,12 +360,33 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
         extra_args=extra_args,
         **command_options,
     )
+    save_dir = workdir / "results"
+    if case_name == "bad_stop_minimum_fitness":
+        # Exercise the no-log guarantee independently of the no-directory
+        # guarantee covered by the other invalid evolution controls.
+        save_dir.mkdir()
     run_command(
         command,
         workdir,
         expected_returncode=expected_returncode,
         expected_output=expected_output,
     )
+    if case_name.startswith("bad_") and case_name in {
+        "bad_crossover_probability",
+        "bad_self_adapting_crossover_probability",
+        "bad_differential_weight",
+        "bad_self_adapting_differential_weight_probability",
+        "bad_stop_minimum_fitness",
+    }:
+        if case_name == "bad_stop_minimum_fitness":
+            if any(save_dir.iterdir()):
+                raise AssertionError(
+                    f"invalid evolution controls wrote output under {save_dir}"
+                )
+        elif save_dir.exists():
+            raise AssertionError(
+                f"invalid evolution controls created output directory {save_dir}"
+            )
 
 
 def main():
@@ -325,7 +408,25 @@ def main():
 
     exe = str(Path(args.exe))
     if args.case == "help":
-        run_command([exe, "--help"], workdir, expected_output="Usage: deac-cpp")
+        result = run_command(
+            [exe, "--help"], workdir, expected_output="Usage: deac-cpp"
+        )
+        for expected_output in (
+            "--self_adapting_differential_weight_probability",
+            "Must be finite and in [0, 2].",
+            "Negative values are allowed.",
+        ):
+            if expected_output not in result.stdout:
+                raise AssertionError(
+                    f"expected --help to contain {expected_output!r}\n"
+                    f"output:\n{result.stdout}"
+                )
+    elif args.case == "version":
+        result = run_command([exe, "-v"], workdir)
+        if result.stdout.strip() != "2.0.0-rc1":
+            raise AssertionError(
+                f"expected -v to print only the version, got {result.stdout!r}"
+            )
     elif args.case == "bad_spectra":
         fixture = workdir / "tiny-isf.bin"
         write_fixture(fixture)

--- a/test/evolution_controls_test.cpp
+++ b/test/evolution_controls_test.cpp
@@ -1,0 +1,99 @@
+#include "evolution_controls.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using deac_configuration::EvolutionControls;
+using deac_configuration::validate_evolution_controls;
+
+bool accepts(const EvolutionControls& controls, const char* description) {
+    try {
+        validate_evolution_controls(controls);
+    } catch (const std::invalid_argument& error) {
+        std::cerr << "expected " << description << " to be accepted, got: "
+                  << error.what() << '\n';
+        return false;
+    }
+    return true;
+}
+
+bool rejects(
+        const EvolutionControls& controls,
+        const char* expected_parameter,
+        const char* description) {
+    try {
+        validate_evolution_controls(controls);
+    } catch (const std::invalid_argument& error) {
+        if (std::string(error.what()).find(expected_parameter) == std::string::npos) {
+            std::cerr << "expected " << description << " to identify "
+                      << expected_parameter << ", got: " << error.what() << '\n';
+            return false;
+        }
+        return true;
+    }
+    std::cerr << "expected " << description << " to be rejected\n";
+    return false;
+}
+
+} // namespace
+
+int main() {
+    const EvolutionControls defaults{0.9, 0.1, 0.9, 0.1, 1.0};
+    const EvolutionControls lower_boundaries{0.0, 0.0, 0.0, 0.0, -42.0};
+    const EvolutionControls upper_boundaries{1.0, 1.0, 2.0, 1.0, 42.0};
+    if (!accepts(defaults, "default controls")
+            || !accepts(lower_boundaries, "lower boundaries and negative stop threshold")
+            || !accepts(upper_boundaries, "upper boundaries")) {
+        return 1;
+    }
+
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const double infinity = std::numeric_limits<double>::infinity();
+
+    EvolutionControls controls = defaults;
+    controls.crossover_probability = -0.01;
+    if (!rejects(controls, "crossover_probability", "negative crossover probability")) return 1;
+    controls.crossover_probability = 1.01;
+    if (!rejects(controls, "crossover_probability", "crossover probability above one")) return 1;
+    controls.crossover_probability = nan;
+    if (!rejects(controls, "crossover_probability", "non-finite crossover probability")) return 1;
+
+    controls = defaults;
+    controls.self_adapting_crossover_probability = -0.01;
+    if (!rejects(controls, "self_adapting_crossover_probability", "negative crossover adaptation probability")) return 1;
+    controls.self_adapting_crossover_probability = 1.01;
+    if (!rejects(controls, "self_adapting_crossover_probability", "crossover adaptation probability above one")) return 1;
+    controls.self_adapting_crossover_probability = infinity;
+    if (!rejects(controls, "self_adapting_crossover_probability", "non-finite crossover adaptation probability")) return 1;
+
+    controls = defaults;
+    controls.differential_weight = -0.01;
+    if (!rejects(controls, "differential_weight", "negative differential weight")) return 1;
+    controls.differential_weight = 2.01;
+    if (!rejects(controls, "differential_weight", "differential weight above two")) return 1;
+    controls.differential_weight = -infinity;
+    if (!rejects(controls, "differential_weight", "non-finite differential weight")) return 1;
+
+    controls = defaults;
+    controls.self_adapting_differential_weight_probability = -0.01;
+    if (!rejects(controls, "self_adapting_differential_weight_probability", "negative differential-weight adaptation probability")) return 1;
+    controls.self_adapting_differential_weight_probability = 1.01;
+    if (!rejects(controls, "self_adapting_differential_weight_probability", "differential-weight adaptation probability above one")) return 1;
+    controls.self_adapting_differential_weight_probability = nan;
+    if (!rejects(controls, "self_adapting_differential_weight_probability", "non-finite differential-weight adaptation probability")) return 1;
+
+    controls = defaults;
+    controls.stop_minimum_fitness = nan;
+    if (!rejects(controls, "stop_minimum_fitness", "NaN stop threshold")) return 1;
+    controls.stop_minimum_fitness = infinity;
+    if (!rejects(controls, "stop_minimum_fitness", "infinite stop threshold")) return 1;
+    controls.stop_minimum_fitness = -infinity;
+    if (!rejects(controls, "stop_minimum_fitness", "negative-infinite stop threshold")) return 1;
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- restore `-v` exclusively to the built-in version action
- retain the differential-weight adaptation probability through its long option
- centralize the valid domains for evolution controls in a small tested configuration boundary
- reject invalid controls before UUID output, input loading, directory creation, or log writes
- document domains in CLI help and test both accepted endpoints

## Validated contract

- crossover and both adaptation probabilities: finite values in [0,1]
- initial differential weight: finite value in [0,2]
- stopping fitness: any finite value, including negative values used to force all generations

Exact commit: 06e8a5a

## Validation

IntelLLVM 2026.1:

- standard CPU: 33/33
- hyperbolic CPU: 33/33
- detailed-balance CPU: 33/33
- standard SYCL on Intel Data Center GPU Max 1550: 34/34, including CPU parity
- detailed-balance SYCL: 34/34, including CPU parity
- fixed-seed stdout, spectrum, frequency, and statistics artifacts: byte-identical to main
- invalid-control cases: no output directory or log side effects
- git diff --check: clean

The separate inactive `--save_state`, `-l`, and `-m` contracts remain unchanged and tracked in #20.

Fixes #19