### PR TITLE
Block CPU population projection rows

### DIFF
--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -285,6 +285,14 @@ add_test(
     NAME deac_unit_evolution_controls
     COMMAND deac_evolution_controls_test)
 
+add_executable(deac_population_projection_test
+    ${CMAKE_SOURCE_DIR}/../test/population_projection_test.cpp)
+target_include_directories(deac_population_projection_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_test(
+    NAME deac_unit_population_projection
+    COMMAND deac_population_projection_test)
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     set(DEAC_SMOKE_TEST "${CMAKE_SOURCE_DIR}/../test/deac_smoke_test.py")

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <rng.hpp>
 #include "evolution_controls.hpp"
+#include "population_projection.hpp"
 #include "trapezoidal_weights.hpp"
 #include <memory> // string_format
 #include <string> // string_format
@@ -108,16 +109,6 @@ void matrix_multiply_MxN_by_Nx1(double * C, double * A, double * B, size_t M, si
     for (size_t i=0; i<M; i++) {
         for (size_t j=0; j<N; j++) {
             C[i] += A[i*N + j]*B[j];
-        }
-    }
-}
-
-void matrix_multiply_LxM_by_MxN(double * C, double * A, double * B, size_t L, size_t M, size_t N) {
-    for (size_t i=0; i<N; i++) {
-        for (size_t j=0; j<L; j++) {
-            for (size_t k=0; k<M; k++) {
-                C[i*L + j] += A[j*M + k]*B[i*M + k];
-            }
         }
     }
 }
@@ -858,10 +849,12 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         for (size_t i=0; i<population_size*number_of_timeslices; i++) {
             isf_model[i] = 0.0;
         }
-        matrix_multiply_LxM_by_MxN(isf_model, isf_term_positive_frequency, population_old_positive_frequency,
+        deac_numerics::accumulate_population_projection(
+                isf_model, isf_term_positive_frequency, population_old_positive_frequency,
                 number_of_timeslices, genome_size, population_size);
         #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-            matrix_multiply_LxM_by_MxN(isf_model, isf_term_negative_frequency, population_old_negative_frequency,
+            deac_numerics::accumulate_population_projection(
+                    isf_model, isf_term_negative_frequency, population_old_negative_frequency,
                     number_of_timeslices, genome_size, population_size);
         #endif
     #endif
@@ -1387,10 +1380,12 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             for (size_t i=0; i<population_size*number_of_timeslices; i++) {
                 isf_model[i] = 0.0;
             }
-            matrix_multiply_LxM_by_MxN(isf_model, isf_term_positive_frequency, population_new_positive_frequency,
+            deac_numerics::accumulate_population_projection(
+                    isf_model, isf_term_positive_frequency, population_new_positive_frequency,
                     number_of_timeslices, genome_size, population_size);
             #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-                matrix_multiply_LxM_by_MxN(isf_model, isf_term_negative_frequency, population_new_negative_frequency,
+                deac_numerics::accumulate_population_projection(
+                        isf_model, isf_term_negative_frequency, population_new_negative_frequency,
                         number_of_timeslices, genome_size, population_size);
             #endif
         #endif

--- a/src/deac/src/population_projection.hpp
+++ b/src/deac/src/population_projection.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstddef>
+
+namespace deac_numerics {
+
+// Accumulate the projection of each population row onto every kernel row.
+//
+// projection is a population_size-by-output_rows row-major matrix, kernel is
+// output_rows-by-genome_size, and population is
+// population_size-by-genome_size. All three ranges must be valid for those
+// positive dimensions and must not overlap. Their element-count products must
+// fit in std::size_t.
+inline void accumulate_population_projection(
+        double* projection,
+        const double* kernel,
+        const double* population,
+        std::size_t output_rows,
+        std::size_t genome_size,
+        std::size_t population_size) {
+    for (std::size_t population_index=0;
+            population_index<population_size;
+            ++population_index) {
+        double* const projection_row = projection + population_index*output_rows;
+        const double* const population_row = population + population_index*genome_size;
+
+        std::size_t output_row=0;
+        for (; output_rows - output_row >= 4; output_row += 4) {
+            const double* const kernel_row0 = kernel + output_row*genome_size;
+            const double* const kernel_row1 = kernel_row0 + genome_size;
+            const double* const kernel_row2 = kernel_row1 + genome_size;
+            const double* const kernel_row3 = kernel_row2 + genome_size;
+            double projection0 = projection_row[output_row];
+            double projection1 = projection_row[output_row + 1];
+            double projection2 = projection_row[output_row + 2];
+            double projection3 = projection_row[output_row + 3];
+
+            for (std::size_t genome_index=0;
+                    genome_index<genome_size;
+                    ++genome_index) {
+                const double population_value = population_row[genome_index];
+                projection0 += kernel_row0[genome_index]*population_value;
+                projection1 += kernel_row1[genome_index]*population_value;
+                projection2 += kernel_row2[genome_index]*population_value;
+                projection3 += kernel_row3[genome_index]*population_value;
+            }
+
+            projection_row[output_row] = projection0;
+            projection_row[output_row + 1] = projection1;
+            projection_row[output_row + 2] = projection2;
+            projection_row[output_row + 3] = projection3;
+        }
+
+        for (; output_row<output_rows; ++output_row) {
+            const double* const kernel_row = kernel + output_row*genome_size;
+            double accumulated_projection = projection_row[output_row];
+            for (std::size_t genome_index=0;
+                    genome_index<genome_size;
+                    ++genome_index) {
+                accumulated_projection +=
+                        kernel_row[genome_index]*population_row[genome_index];
+            }
+            projection_row[output_row] = accumulated_projection;
+        }
+    }
+}
+
+} // namespace deac_numerics

--- a/test/population_projection_test.cpp
+++ b/test/population_projection_test.cpp
@@ -1,0 +1,106 @@
+#include "population_projection.hpp"
+
+#include <array>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+void reference_accumulate_population_projection(
+        double* projection,
+        const double* kernel,
+        const double* population,
+        std::size_t output_rows,
+        std::size_t genome_size,
+        std::size_t population_size) {
+    for (std::size_t population_index=0;
+            population_index<population_size;
+            ++population_index) {
+        for (std::size_t output_row=0; output_row<output_rows; ++output_row) {
+            for (std::size_t genome_index=0;
+                    genome_index<genome_size;
+                    ++genome_index) {
+                projection[population_index*output_rows + output_row] +=
+                        kernel[output_row*genome_size + genome_index]
+                        *population[population_index*genome_size + genome_index];
+            }
+        }
+    }
+}
+
+double initial_projection_value(std::size_t index) {
+    const double magnitude = static_cast<double>((index*7)%19 + 1)/32.0;
+    return index%2 == 0 ? magnitude : -magnitude;
+}
+
+double kernel_value(std::size_t index) {
+    const double magnitude = static_cast<double>((index*5)%23 + 1)/16.0;
+    return index%3 == 0 ? -magnitude : magnitude;
+}
+
+double population_value(std::size_t index) {
+    const double magnitude = static_cast<double>((index*11)%29 + 1)/8.0;
+    return index%5 == 0 ? -magnitude : magnitude;
+}
+
+bool check_dimensions(
+        std::size_t output_rows,
+        std::size_t genome_size,
+        std::size_t population_size) {
+    std::vector<double> kernel(output_rows*genome_size);
+    std::vector<double> population(population_size*genome_size);
+    std::vector<double> expected(population_size*output_rows);
+
+    for (std::size_t index=0; index<kernel.size(); ++index) {
+        kernel[index] = kernel_value(index);
+    }
+    for (std::size_t index=0; index<population.size(); ++index) {
+        population[index] = population_value(index);
+    }
+    for (std::size_t index=0; index<expected.size(); ++index) {
+        expected[index] = initial_projection_value(index);
+    }
+
+    std::vector<double> actual = expected;
+    reference_accumulate_population_projection(
+            expected.data(), kernel.data(), population.data(),
+            output_rows, genome_size, population_size);
+    deac_numerics::accumulate_population_projection(
+            actual.data(), kernel.data(), population.data(),
+            output_rows, genome_size, population_size);
+
+    for (std::size_t index=0; index<actual.size(); ++index) {
+        if (actual[index] != expected[index]) {
+            std::cerr << "projection mismatch for L=" << output_rows
+                      << ", M=" << genome_size
+                      << ", N=" << population_size
+                      << " at flat index " << index
+                      << ": expected " << std::hexfloat << expected[index]
+                      << ", got " << actual[index] << '\n';
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    constexpr std::array<std::size_t, 9> output_row_counts{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    constexpr std::array<std::size_t, 4> genome_sizes{1, 2, 3, 7};
+    constexpr std::array<std::size_t, 3> population_sizes{1, 3, 6};
+
+    for (const std::size_t output_rows : output_row_counts) {
+        for (const std::size_t genome_size : genome_sizes) {
+            for (const std::size_t population_size : population_sizes) {
+                if (!check_dimensions(output_rows, genome_size, population_size)) {
+                    return 1;
+                }
+            }
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- extract the CPU population-to-ISF projection into a focused, const-correct helper
- process four independent output rows per population pass so each population value is reused
- preserve the exact accumulation order within every output row, including 1–3 row remainders
- test exact equality across every output-row count from 1 through 9; genome sizes 1, 2, 3, and 7; and population sizes 1, 3, and 6 (108 combinations)

Fixes #21.

## Performance

Baseline `18a627ed78f0f5c80f6c0b401d50bde90affe837`; candidate `e7e77668cea80753c9b609f34e2e96fb652a4810`.

- hardware: Intel Xeon CPU Max 9470C, pinned to allowed logical CPU 1
- compiler: GCC 14.3.0, CMake Release, `GPU_BACKEND=none` (`-O3 -march=native -fno-math-errno` supplied by the project)
- workload: temperature 1, 2,000 generations, population 256, genome 1,024, omega max 60, stop fitness 0, seed 123, four-timeslice fixture
- protocol: one baseline/candidate warm-up, then five pairs with execution order reversed on alternating pairs
- baseline seconds: 6.47, 6.85, 6.51, 6.47, 6.50; median 6.50
- candidate seconds: 5.59, 5.61, 5.68, 6.16, 5.91; median 5.68
- median improvement: 12.6%
- maximum RSS: 11,648 KiB on every measured run for both revisions

Every paired frequency and spectrum artifact was byte-identical. SHA-256 values were `f3d6afee724bba706c79a960042adcf836e505a575db703aa24a7f23f997a8e2` for frequency and `0d7ea92acf57ad33f8997b2be477205ee2eb8c568a64306ed62cc959e68e2732` for the GCC spectrum. An additional IntelLLVM full-workload pre/post comparison was byte-identical (`c6b6c46d78a487fbed267e884b8d1d467c96aeb03f63409ba1a3fd7f63f3d796` spectrum SHA-256).

## Validation

- IntelLLVM 2026.1 CPU standard: 34/34
- IntelLLVM 2026.1 CPU hyperbolic: 34/34
- IntelLLVM 2026.1 CPU detailed balance: 34/34
- GCC 14.3 CPU standard: 34/34
- GCC 14.3 ASan + UBSan: 34/34
- IntelLLVM 2026.1 SYCL standard on Intel Data Center GPU Max 1550: 35/35, including CPU parity
- IntelLLVM 2026.1 SYCL detailed balance on the same GPU: 35/35, including CPU parity
- `git diff --check`: clean

The SYCL configurations used Level Zero, `-fsycl`, block size 256, and subgroup size 16. Independent review repeated all three IntelLLVM CPU variants, GCC ASan/UBSan, and both SYCL/parity suites with the same passing counts.

## Numerical scope

The helper retains ascending genome-index accumulation independently for each output row, but a deliberately rounding-sensitive diagnostic differed by one ULP under IntelLLVM because the compiler optimized the scalar reference and blocked forms differently. No tolerance, compiler flag, or production arithmetic policy was changed. The exact unit fixtures use representable values, and both the GCC and IntelLLVM fixed-seed full solver artifacts remained byte-identical. This PR therefore claims compatibility for the tested seeded workloads, not a cross-compiler bitwise guarantee for arbitrary floating-point inputs.
