### PR TITLE
Centralize checked binary and result I/O

### DIFF
--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -293,6 +293,15 @@ add_test(
     NAME deac_unit_population_projection
     COMMAND deac_population_projection_test)
 
+add_executable(deac_result_io_test
+    ${CMAKE_SOURCE_DIR}/../test/result_io_test.cpp)
+target_include_directories(deac_result_io_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_test(
+    NAME deac_unit_result_io
+    COMMAND deac_result_io_test)
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     set(DEAC_SMOKE_TEST "${CMAKE_SOURCE_DIR}/../test/deac_smoke_test.py")
@@ -317,6 +326,7 @@ if(Python3_Interpreter_FOUND)
             uneven_isf_arrays
             too_few_timeslices
             nonfinite_isf
+            missing_isf
             positive_isf_single_particle
             bad_third_moment_error
             bad_crossover_probability
@@ -328,10 +338,16 @@ if(Python3_Interpreter_FOUND)
             too_small_population
             too_small_genome
             bad_omega_max
+            missing_frequency
             short_frequency_file
             nonfinite_frequency
             negative_frequency
-            unsorted_frequency)
+            unsorted_frequency
+            nested_output
+            save_directory_is_file
+            unwritable_save_directory
+            log_destination_is_directory
+            result_destination_is_directory)
     if(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF)
         list(APPEND DEAC_SMOKE_CASES negative_first_moment)
     else()

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -8,16 +8,17 @@
 #include <algorithm> // std::none_of
 #include <cmath>
 #include <cstdint>
+#include <exception>
 #include <span>
 #include <vector>
 #include <rng.hpp>
 #include "evolution_controls.hpp"
 #include "population_projection.hpp"
+#include "result_io.hpp"
 #include "trapezoidal_weights.hpp"
 #include <memory> // string_format
 #include <string> // string_format
 #include <stdexcept> // throw
-#include <fstream> // std::ofstream
 #include <cassert>
 #include <fs.h> //fs namespace (std::filesystem or std::experimental::filesystem)
 
@@ -32,15 +33,8 @@
     #include "deac_gpu.sycl.h"
 #endif
 
-void write_to_logfile(fs::path filename, std::string log_message ) {
-    std::ofstream ofs(filename.c_str(), std::ios_base::out | std::ios_base::app );
-    ofs << log_message << std::endl;
-    ofs.close();
-}
-
-void fail_with_error(const std::string& error_message) {
-    std::cerr << error_message << std::endl;
-    exit(1);
+[[noreturn]] void fail_with_error(const std::string& error_message) {
+    throw std::runtime_error(error_message);
 }
 
 template<typename ... Args>
@@ -52,57 +46,6 @@ std::string string_format( const std::string& format, Args ... args ) {
     auto buf = std::make_unique<char[]>( size );
     snprintf( buf.get(), size, format.c_str(), args ... );
     return std::string( buf.get(), buf.get() + size - 1 ); // We don't want the '\0' inside
-}
-
-void write_array(fs::path filename, double * buffer, size_t length) {
-    FILE * output_file;
-    output_file = fopen (filename.c_str(), "wb");
-    fwrite (buffer , sizeof(double), static_cast<size_t>(length), output_file);
-    fclose (output_file);
-}
-
-std::tuple <double*, size_t> load_numpy_array(std::string data_file) {
-    FILE * input_file;
-    long file_size_bytes;
-    double * buffer;
-    size_t result;
-  
-    input_file = fopen( data_file.c_str(), "rb" );
-    if (input_file==NULL) {
-        std::string error_str = string_format("File error: %s\n", data_file.c_str());
-        fputs(error_str.c_str(), stderr);
-        exit(1);
-    }
-  
-    // obtain file size:
-    fseek(input_file , 0 , SEEK_END);
-    file_size_bytes = ftell(input_file);
-    rewind(input_file);
-
-    if ((file_size_bytes < 0) || (file_size_bytes % sizeof(double) != 0)) {
-        fclose(input_file);
-        fail_with_error(string_format("File error: %s does not contain a whole number of doubles", data_file.c_str()));
-    }
-    
-    size_t number_of_elements = static_cast<size_t> (file_size_bytes/sizeof(double));
-    if (number_of_elements == 0) {
-        fclose(input_file);
-        fail_with_error(string_format("File error: %s is empty", data_file.c_str()));
-    }
-  
-    // allocate memory to contain the whole file:
-    buffer = (double*) malloc(sizeof(double)*number_of_elements);
-    if (buffer == NULL) {fputs("Memory error",stderr); exit(2);}
-  
-    // copy the file into the buffer:
-    result = fread(buffer, 1, static_cast<size_t>(file_size_bytes), input_file);
-    if (result != static_cast<size_t>(file_size_bytes)) {fputs("Reading error",stderr); exit(3);}
-  
-    /* the whole file is now loaded in the memory buffer. */
-    fclose (input_file);
-
-    std::tuple <double*, size_t> numpy_data_tuple(buffer, number_of_elements);
-    return numpy_data_tuple;
 }
 
 void matrix_multiply_MxN_by_Nx1(double * C, double * A, double * B, size_t M, size_t N) {
@@ -1679,95 +1622,113 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         }
     }
 
-    //Save data
-    #ifndef ZEROT
-        std::string deac_prefix = "deac-" + spectra_type;
-    #else
-        std::string deac_prefix = "deac-zT" + spectra_type;
-    #endif
-    std::string best_dsf_filename_str = string_format("%s_dsf_%s.bin",deac_prefix.c_str(),uuid_str.c_str());
-    fs::path best_dsf_filename = save_directory / best_dsf_filename_str;
-    std::string frequency_filename_str = string_format("%s_frequency_%s.bin",deac_prefix.c_str(),uuid_str.c_str());
-    fs::path frequency_filename = save_directory / frequency_filename_str;
-    #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-        write_array(best_dsf_filename, best_dsf, genome_size);
-        write_array(frequency_filename, best_frequency, genome_size);
-    #else
-        write_array(best_dsf_filename, best_dsf, 2*genome_size - 1);
-        write_array(frequency_filename, best_frequency, 2*genome_size - 1);
-    #endif
-    fs::path fitness_mean_filename;
-    fs::path fitness_minimum_filename;
-    fs::path fitness_squared_mean_filename;
-    if (track_stats) {
-        std::string fitness_mean_filename_str = string_format("%s_stats_fitness-mean_%s.bin",deac_prefix.c_str(),uuid_str.c_str());
-        std::string fitness_minimum_filename_str = string_format("%s_stats_fitness-minimum_%s.bin",deac_prefix.c_str(),uuid_str.c_str());
-        std::string fitness_squared_mean_filename_str = string_format("%s_stats_fitness-squared-mean_%s.bin",deac_prefix.c_str(),uuid_str.c_str());
-        fitness_mean_filename = save_directory / fitness_mean_filename_str;
-        fitness_minimum_filename = save_directory / fitness_minimum_filename_str;
-        fitness_squared_mean_filename = save_directory / fitness_squared_mean_filename_str;
-        write_array(fitness_mean_filename, fitness_mean, generation + 1);
-        write_array(fitness_minimum_filename, fitness_minimum, generation + 1);
-        write_array(fitness_squared_mean_filename, fitness_squared_mean, generation + 1);
-    }
-
-    //Write to log file
-    std::string log_filename_str = string_format("%s_log_%s.dat",deac_prefix.c_str(),uuid_str.c_str());
-    fs::path log_filename = save_directory / log_filename_str;
-    std::ofstream log_ofs(log_filename.c_str(), std::ios_base::out | std::ios_base::app );
-
-    //Build Type
-    #ifdef USE_HYPERBOLIC_MODEL
-        log_ofs << "build: USE_HYPERBOLIC_MODEL" << std::endl;
-    #endif
-    #ifdef USE_STANDARD_MODEL
-        log_ofs << "build: USE_STANDARD_MODEL" << std::endl;
-    #endif
-    #ifdef USE_NORMALIZATION_MODEL
-        log_ofs << "build: USE_NORMALIZATION_MODEL" << std::endl;
-    #endif
-    log_ofs << "kernel: " << spectra_type << std::endl;
-
-    //Input parameters
-    log_ofs << "temperature: " << temperature << std::endl;
-    log_ofs << "number_of_generations: " << number_of_generations << std::endl;
-    log_ofs << "number_of_timeslices: " << number_of_timeslices << std::endl;
-    log_ofs << "population_size: " << population_size << std::endl;
-    log_ofs << "genome_size: " << genome_size << std::endl;
-    log_ofs << "normalize: " << normalize << std::endl;
-    log_ofs << "use_negative_first_moment: " << use_negative_first_moment << std::endl;
-    #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-        if (use_negative_first_moment) {
-            log_ofs << "negative_first_moment: " << negative_first_moment << std::endl;
-            log_ofs << "negative_first_moment_error: " << negative_first_moment_error << std::endl;
+    std::exception_ptr result_io_error;
+    try {
+        // Save data.
+        #ifndef ZEROT
+            std::string deac_prefix = "deac-" + spectra_type;
+        #else
+            std::string deac_prefix = "deac-zT" + spectra_type;
+        #endif
+        std::string best_dsf_filename_str = string_format("%s_dsf_%s.bin",deac_prefix.c_str(),uuid_str.c_str());
+        fs::path best_dsf_filename = save_directory / best_dsf_filename_str;
+        std::string frequency_filename_str = string_format("%s_frequency_%s.bin",deac_prefix.c_str(),uuid_str.c_str());
+        fs::path frequency_filename = save_directory / frequency_filename_str;
+        #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            deac_io::write_binary_doubles(
+                    best_dsf_filename, std::span<const double>(best_dsf, genome_size));
+            deac_io::write_binary_doubles(
+                    frequency_filename, std::span<const double>(best_frequency, genome_size));
+        #else
+            const size_t output_size = 2*genome_size - 1;
+            deac_io::write_binary_doubles(
+                    best_dsf_filename, std::span<const double>(best_dsf, output_size));
+            deac_io::write_binary_doubles(
+                    frequency_filename, std::span<const double>(best_frequency, output_size));
+        #endif
+        fs::path fitness_mean_filename;
+        fs::path fitness_minimum_filename;
+        fs::path fitness_squared_mean_filename;
+        if (track_stats) {
+            std::string fitness_mean_filename_str = string_format("%s_stats_fitness-mean_%s.bin",deac_prefix.c_str(),uuid_str.c_str());
+            std::string fitness_minimum_filename_str = string_format("%s_stats_fitness-minimum_%s.bin",deac_prefix.c_str(),uuid_str.c_str());
+            std::string fitness_squared_mean_filename_str = string_format("%s_stats_fitness-squared-mean_%s.bin",deac_prefix.c_str(),uuid_str.c_str());
+            fitness_mean_filename = save_directory / fitness_mean_filename_str;
+            fitness_minimum_filename = save_directory / fitness_minimum_filename_str;
+            fitness_squared_mean_filename = save_directory / fitness_squared_mean_filename_str;
+            deac_io::write_binary_doubles(
+                    fitness_mean_filename,
+                    std::span<const double>(fitness_mean, generation + 1));
+            deac_io::write_binary_doubles(
+                    fitness_minimum_filename,
+                    std::span<const double>(fitness_minimum, generation + 1));
+            deac_io::write_binary_doubles(
+                    fitness_squared_mean_filename,
+                    std::span<const double>(fitness_squared_mean, generation + 1));
         }
-    #endif
-    log_ofs << "first_moment: " << first_moment << std::endl;
-    log_ofs << "third_moment: " << third_moment << std::endl;
-    log_ofs << "third_moment_error: " << third_moment_error << std::endl;
-    log_ofs << "crossover_probability: " << crossover_probability << std::endl;
-    log_ofs << "self_adapting_crossover_probability: " << self_adapting_crossover_probability << std::endl;
-    log_ofs << "differential_weight: " << differential_weight << std::endl;
-    log_ofs << "self_adapting_differential_weight_probability: " << self_adapting_differential_weight_probability << std::endl;
-    log_ofs << "self_adapting_differential_weight_shift: " << self_adapting_differential_weight_shift << std::endl;
-    log_ofs << "self_adapting_differential_weight: " << self_adapting_differential_weight << std::endl;
-    log_ofs << "stop_minimum_fitness: " << stop_minimum_fitness << std::endl;
-    log_ofs << "track_stats: " << track_stats << std::endl;
-    log_ofs << "seed: " << seed << std::endl;
 
-    //Generated variables
-    log_ofs << "best_dsf_filename: " << best_dsf_filename << std::endl;
-    log_ofs << "frequency_filename: " << frequency_filename << std::endl;
-    log_ofs << "generation: " << generation << std::endl;
-    std::cout << "generation: " << generation << std::endl;
-    log_ofs << "minimum_fitness: " << minimum_fitness << std::endl;
-    std::cout << "minimum_fitness: " << minimum_fitness << std::endl;
-    if (track_stats) {
-        log_ofs << "fitness_mean_filename: " << fitness_mean_filename << std::endl;
-        log_ofs << "fitness_minimum_filename: " << fitness_minimum_filename << std::endl;
-        log_ofs << "fitness_squared_mean_filename: " << fitness_squared_mean_filename << std::endl;
+        // Append the final run record only after all binary artifacts are
+        // successfully flushed and closed.
+        std::string log_filename_str = string_format("%s_log_%s.dat",deac_prefix.c_str(),uuid_str.c_str());
+        fs::path log_filename = save_directory / log_filename_str;
+        std::ostringstream log;
+
+        // Build Type
+        #ifdef USE_HYPERBOLIC_MODEL
+            log << "build: USE_HYPERBOLIC_MODEL" << std::endl;
+        #endif
+        #ifdef USE_STANDARD_MODEL
+            log << "build: USE_STANDARD_MODEL" << std::endl;
+        #endif
+        #ifdef USE_NORMALIZATION_MODEL
+            log << "build: USE_NORMALIZATION_MODEL" << std::endl;
+        #endif
+        log << "kernel: " << spectra_type << std::endl;
+
+        // Input parameters
+        log << "temperature: " << temperature << std::endl;
+        log << "number_of_generations: " << number_of_generations << std::endl;
+        log << "number_of_timeslices: " << number_of_timeslices << std::endl;
+        log << "population_size: " << population_size << std::endl;
+        log << "genome_size: " << genome_size << std::endl;
+        log << "normalize: " << normalize << std::endl;
+        log << "use_negative_first_moment: " << use_negative_first_moment << std::endl;
+        #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            if (use_negative_first_moment) {
+                log << "negative_first_moment: " << negative_first_moment << std::endl;
+                log << "negative_first_moment_error: " << negative_first_moment_error << std::endl;
+            }
+        #endif
+        log << "first_moment: " << first_moment << std::endl;
+        log << "third_moment: " << third_moment << std::endl;
+        log << "third_moment_error: " << third_moment_error << std::endl;
+        log << "crossover_probability: " << crossover_probability << std::endl;
+        log << "self_adapting_crossover_probability: " << self_adapting_crossover_probability << std::endl;
+        log << "differential_weight: " << differential_weight << std::endl;
+        log << "self_adapting_differential_weight_probability: " << self_adapting_differential_weight_probability << std::endl;
+        log << "self_adapting_differential_weight_shift: " << self_adapting_differential_weight_shift << std::endl;
+        log << "self_adapting_differential_weight: " << self_adapting_differential_weight << std::endl;
+        log << "stop_minimum_fitness: " << stop_minimum_fitness << std::endl;
+        log << "track_stats: " << track_stats << std::endl;
+        log << "seed: " << seed << std::endl;
+
+        // Generated variables
+        log << "best_dsf_filename: " << best_dsf_filename << std::endl;
+        log << "frequency_filename: " << frequency_filename << std::endl;
+        log << "generation: " << generation << std::endl;
+        log << "minimum_fitness: " << minimum_fitness << std::endl;
+        if (track_stats) {
+            log << "fitness_mean_filename: " << fitness_mean_filename << std::endl;
+            log << "fitness_minimum_filename: " << fitness_minimum_filename << std::endl;
+            log << "fitness_squared_mean_filename: " << fitness_squared_mean_filename << std::endl;
+        }
+        deac_io::append_text(log_filename, log.str());
+        std::cout << "generation: " << generation << std::endl;
+        std::cout << "minimum_fitness: " << minimum_fitness << std::endl;
+    } catch (...) {
+        // Keep the original I/O failure while still releasing all solver resources.
+        result_io_error = std::current_exception();
     }
-    log_ofs.close();
 
     //Free memory
     if (track_stats) {
@@ -1921,9 +1882,13 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             }
         #endif
     #endif
+
+    if (result_io_error) {
+        std::rethrow_exception(result_io_error);
+    }
 }
 
-int main (int argc, char *argv[]) {
+int deac_main (int argc, char *argv[]) {
     argparse::ArgumentParser program("deac-cpp", "2.0.0-rc1");
     program.add_argument("-T", "--temperature")
         .help("Temperature of system.")
@@ -2029,7 +1994,7 @@ int main (int argc, char *argv[]) {
     catch (const std::runtime_error& err) {
         std::cout << err.what() << std::endl;
         std::cout << program << std::endl;
-        exit(1);
+        return 1;
     }
 
     double crossover_probability = program.get<double>("--crossover_probability");
@@ -2071,13 +2036,12 @@ int main (int argc, char *argv[]) {
          #endif
         )) {
         std::cout << "Please choose spectra_type from the following options: " << valid_spectra_type << std::endl;
-        exit(1);
+        return 1;
     }
 
-    size_t number_of_elements;
-    double* numpy_data;
     std::string isf_file = program.get<std::string>("isf_file");
-    std::tie(numpy_data, number_of_elements) = load_numpy_array(isf_file);
+    std::vector<double> numpy_data = deac_io::read_binary_doubles(isf_file);
+    const size_t number_of_elements = numpy_data.size();
     if (number_of_elements % 3 != 0) {
         fail_with_error("ISF input file must contain tau, isf, and error arrays of equal length");
     }
@@ -2086,9 +2050,9 @@ int main (int argc, char *argv[]) {
         fail_with_error("ISF input file must contain at least two timeslices");
     }
 
-    double * const imaginary_time = numpy_data;
-    double * const isf = numpy_data + number_of_timeslices;
-    double * const isf_error = numpy_data + 2*number_of_timeslices;
+    double * const imaginary_time = numpy_data.data();
+    double * const isf = numpy_data.data() + number_of_timeslices;
+    double * const isf_error = numpy_data.data() + 2*number_of_timeslices;
     for (size_t i=0; i<number_of_timeslices; i++) {
         if (!std::isfinite(imaginary_time[i]) || !std::isfinite(isf[i]) || !std::isfinite(isf_error[i])) {
             fail_with_error("ISF input file contains non-finite values");
@@ -2123,9 +2087,10 @@ int main (int argc, char *argv[]) {
     }
 
     size_t genome_size;
-    double * frequency;
+    std::vector<double> frequency_data;
     if (auto frequency_filename = program.present("--frequency_file")) {
-        std::tie(frequency,genome_size) = load_numpy_array(*frequency_filename);
+        frequency_data = deac_io::read_binary_doubles(*frequency_filename);
+        genome_size = frequency_data.size();
     } else{
         genome_size = static_cast<size_t>(program.get<unsigned long>("--genome_size"));
         double max_frequency = program.get<double>("--omega_max");
@@ -2136,12 +2101,13 @@ int main (int argc, char *argv[]) {
             fail_with_error("omega_max must be positive");
         }
 
-        frequency = (double*) malloc(sizeof(double)*genome_size);
+        frequency_data.resize(genome_size);
         double dfrequency = max_frequency/(genome_size - 1);
         for (size_t i=0; i<genome_size; i++) {
-            frequency[i] = i*dfrequency;
+            frequency_data[i] = i*dfrequency;
         }
     }
+    double* const frequency = frequency_data.data();
     if (genome_size < 2) {
         fail_with_error("frequency_file must contain at least two frequencies");
     }
@@ -2182,7 +2148,7 @@ int main (int argc, char *argv[]) {
     bool track_stats = program.get<bool>("--track_stats");
     std::string save_directory_str = program.get<std::string>("--save_directory");
     fs::path save_directory(save_directory_str);
-    fs::create_directory(save_directory);
+    deac_io::ensure_result_directory(save_directory);
 
     //Write to log file
     #ifndef ZEROT
@@ -2192,12 +2158,10 @@ int main (int argc, char *argv[]) {
     #endif
     std::string log_filename_str = string_format("%s_log_%s.dat",deac_prefix.c_str(),uuid_str.c_str());
     fs::path log_filename = save_directory / log_filename_str;
-    std::ofstream log_ofs(log_filename.c_str(), std::ios_base::out | std::ios_base::app );
-
-    //Input parameters
-    log_ofs << "uuid: " << uuid_str << std::endl;
-    log_ofs << "isf_file: " << isf_file << std::endl;
-    log_ofs.close();
+    std::ostringstream initial_log;
+    initial_log << "uuid: " << uuid_str << std::endl;
+    initial_log << "isf_file: " << isf_file << std::endl;
+    deac_io::append_text(log_filename, initial_log.str());
 
     deac( &rng, imaginary_time, isf, isf_error, frequency, temperature,
             number_of_generations, number_of_timeslices, population_size, genome_size,
@@ -2209,7 +2173,14 @@ int main (int argc, char *argv[]) {
             self_adapting_differential_weight, stop_minimum_fitness,
             track_stats, seed_int, uuid_str, spectra_type, save_directory);
 
-    free(numpy_data);
-    free(frequency);
     return 0;
+}
+
+int main (int argc, char *argv[]) {
+    try {
+        return deac_main(argc, argv);
+    } catch (const std::exception& error) {
+        std::cerr << error.what() << std::endl;
+        return 1;
+    }
 }

--- a/src/deac/src/result_io.hpp
+++ b/src/deac/src/result_io.hpp
@@ -1,0 +1,248 @@
+#ifndef DEAC_RESULT_IO_HPP
+#define DEAC_RESULT_IO_HPP
+
+#include <algorithm>
+#include <cerrno>
+#include <cstddef>
+#include <fstream>
+#include <limits>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include <fs.h>
+
+namespace deac_io {
+
+inline std::string quoted_path(const fs::path& path) {
+    return "'" + path.string() + "'";
+}
+
+inline std::string errno_detail(int error_number) {
+    if (error_number == 0) {
+        return "";
+    }
+    return ": " + std::error_code(error_number, std::generic_category()).message();
+}
+
+inline void ensure_result_directory(const fs::path& directory) {
+    if (directory.empty()) {
+        throw std::runtime_error("result directory path is empty");
+    }
+
+    try {
+        if (fs::exists(directory)) {
+            if (!fs::is_directory(directory)) {
+                throw std::runtime_error(
+                        "result path " + quoted_path(directory) +
+                        " exists but is not a directory");
+            }
+            return;
+        }
+        if (!fs::create_directories(directory) && !fs::is_directory(directory)) {
+            throw std::runtime_error(
+                    "could not create result directory " + quoted_path(directory));
+        }
+    } catch (const fs::filesystem_error& error) {
+        throw std::runtime_error(
+                "could not create result directory " + quoted_path(directory) +
+                ": " + error.code().message());
+    }
+}
+
+inline std::vector<double> read_binary_doubles(const fs::path& path) {
+    errno = 0;
+    std::ifstream input(path.string(), std::ios::binary | std::ios::ate);
+    if (!input.is_open()) {
+        const int open_error = errno;
+        throw std::runtime_error(
+                "could not open binary input " + quoted_path(path) +
+                " for reading" + errno_detail(open_error));
+    }
+
+    const std::streamoff end_position = input.tellg();
+    if (end_position < 0) {
+        input.clear();
+        input.close();
+        throw std::runtime_error(
+                "could not determine byte length of binary input " +
+                quoted_path(path));
+    }
+
+    const auto byte_count = static_cast<unsigned long long>(end_position);
+    if (byte_count % sizeof(double) != 0) {
+        input.close();
+        if (input.fail()) {
+            throw std::runtime_error(
+                    "failed to close binary input " + quoted_path(path));
+        }
+        throw std::runtime_error(
+                "binary input " + quoted_path(path) +
+                " does not contain a whole number of doubles");
+    }
+    if (byte_count == 0) {
+        input.close();
+        if (input.fail()) {
+            throw std::runtime_error(
+                    "failed to close binary input " + quoted_path(path));
+        }
+        throw std::runtime_error("binary input " + quoted_path(path) + " is empty");
+    }
+    const auto element_count = byte_count / sizeof(double);
+    if (byte_count > static_cast<unsigned long long>(
+                             std::numeric_limits<std::size_t>::max())) {
+        input.close();
+        if (input.fail()) {
+            throw std::runtime_error(
+                    "failed to close binary input " + quoted_path(path));
+        }
+        throw std::runtime_error(
+                "binary input " + quoted_path(path) +
+                " is too large for this process");
+    }
+
+    std::vector<double> values;
+    if (element_count > values.max_size()) {
+        input.close();
+        if (input.fail()) {
+            throw std::runtime_error(
+                    "failed to close binary input " + quoted_path(path));
+        }
+        throw std::runtime_error(
+                "binary input " + quoted_path(path) +
+                " is too large for a double array");
+    }
+    values.resize(static_cast<std::size_t>(element_count));
+    input.seekg(0, std::ios::beg);
+    if (!input) {
+        input.clear();
+        input.close();
+        throw std::runtime_error(
+                "could not seek to the start of binary input " + quoted_path(path));
+    }
+
+    std::size_t offset = 0;
+    const std::size_t total_bytes = static_cast<std::size_t>(byte_count);
+    const auto maximum_chunk = static_cast<std::size_t>(
+            std::numeric_limits<std::streamsize>::max());
+    auto* destination = reinterpret_cast<char*>(values.data());
+    while (offset < total_bytes) {
+        const std::size_t chunk = std::min(total_bytes - offset, maximum_chunk);
+        input.read(destination + offset, static_cast<std::streamsize>(chunk));
+        if (input.gcount() != static_cast<std::streamsize>(chunk)) {
+            const std::streamsize bytes_read = input.gcount();
+            input.clear();
+            input.close();
+            throw std::runtime_error(
+                    "short read from binary input " + quoted_path(path) +
+                    ": expected " + std::to_string(chunk) + " bytes, got " +
+                    std::to_string(bytes_read));
+        }
+        offset += chunk;
+    }
+
+    input.close();
+    if (input.fail()) {
+        throw std::runtime_error(
+                "failed to close binary input " + quoted_path(path));
+    }
+    return values;
+}
+
+inline void write_binary_doubles(
+        const fs::path& path, std::span<const double> values) {
+    errno = 0;
+    std::ofstream output(path.string(), std::ios::binary | std::ios::trunc);
+    if (!output.is_open()) {
+        const int open_error = errno;
+        throw std::runtime_error(
+                "could not open binary output " + quoted_path(path) +
+                " for writing" + errno_detail(open_error));
+    }
+
+    const auto* source = reinterpret_cast<const char*>(values.data());
+    const std::size_t total_bytes = values.size_bytes();
+    const auto maximum_chunk = static_cast<std::size_t>(
+            std::numeric_limits<std::streamsize>::max());
+    std::size_t offset = 0;
+    while (offset < total_bytes) {
+        const std::size_t chunk = std::min(total_bytes - offset, maximum_chunk);
+        errno = 0;
+        output.write(source + offset, static_cast<std::streamsize>(chunk));
+        if (!output) {
+            const int write_error = errno;
+            output.clear();
+            output.close();
+            throw std::runtime_error(
+                    "failed to write binary output " + quoted_path(path) +
+                    errno_detail(write_error));
+        }
+        offset += chunk;
+    }
+
+    errno = 0;
+    output.flush();
+    if (!output) {
+        const int flush_error = errno;
+        output.clear();
+        output.close();
+        throw std::runtime_error(
+                "failed to flush binary output " + quoted_path(path) +
+                errno_detail(flush_error));
+    }
+    errno = 0;
+    output.close();
+    if (output.fail()) {
+        const int close_error = errno;
+        throw std::runtime_error(
+                "failed to close binary output " + quoted_path(path) +
+                errno_detail(close_error));
+    }
+}
+
+inline void append_text(const fs::path& path, std::string_view text) {
+    errno = 0;
+    std::ofstream output(path.string(), std::ios::out | std::ios::app);
+    if (!output.is_open()) {
+        const int open_error = errno;
+        throw std::runtime_error(
+                "could not open log file " + quoted_path(path) +
+                " for appending" + errno_detail(open_error));
+    }
+
+    errno = 0;
+    output.write(text.data(), static_cast<std::streamsize>(text.size()));
+    if (!output) {
+        const int write_error = errno;
+        output.clear();
+        output.close();
+        throw std::runtime_error(
+                "failed to append log file " + quoted_path(path) +
+                errno_detail(write_error));
+    }
+    errno = 0;
+    output.flush();
+    if (!output) {
+        const int flush_error = errno;
+        output.clear();
+        output.close();
+        throw std::runtime_error(
+                "failed to flush log file " + quoted_path(path) +
+                errno_detail(flush_error));
+    }
+    errno = 0;
+    output.close();
+    if (output.fail()) {
+        const int close_error = errno;
+        throw std::runtime_error(
+                "failed to close log file " + quoted_path(path) +
+                errno_detail(close_error));
+    }
+}
+
+} // namespace deac_io
+
+#endif

--- a/test/deac_smoke_test.py
+++ b/test/deac_smoke_test.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 import argparse
 import math
+import os
 import shutil
+import stat
 import struct
 import subprocess
 from pathlib import Path
@@ -19,6 +21,7 @@ SMOKE_CASES = [
     "first_moment",
     "negative_first_moment",
     "track_stats",
+    "nested_output",
 ]
 
 VALIDATION_CASES = [
@@ -27,6 +30,7 @@ VALIDATION_CASES = [
     "uneven_isf_arrays",
     "too_few_timeslices",
     "nonfinite_isf",
+    "missing_isf",
     "positive_isf_single_particle",
     "bad_third_moment_error",
     "bad_crossover_probability",
@@ -38,10 +42,15 @@ VALIDATION_CASES = [
     "too_small_population",
     "too_small_genome",
     "bad_omega_max",
+    "missing_frequency",
     "short_frequency_file",
     "nonfinite_frequency",
     "negative_frequency",
     "unsorted_frequency",
+    "save_directory_is_file",
+    "unwritable_save_directory",
+    "log_destination_is_directory",
+    "result_destination_is_directory",
     "unsupported_negative_first_moment",
 ]
 
@@ -103,7 +112,11 @@ def deac_command(
     omega_max="4.0",
     seed="7",
     extra_args=None,
+    save_directory=None,
+    uuid=None,
 ):
+    if save_directory is None:
+        save_directory = workdir / "results"
     command = [
         exe,
         "-T",
@@ -117,10 +130,12 @@ def deac_command(
         "--omega_max",
         omega_max,
         "--save_directory",
-        str(workdir / "results"),
+        str(save_directory),
         "--seed",
         seed,
     ]
+    if uuid is not None:
+        command.extend(["--uuid", uuid])
     if extra_args:
         command.extend(extra_args)
     command.append(str(fixture))
@@ -140,7 +155,11 @@ def assert_file_size(path, expected_size):
 def run_deac_case(exe, workdir, case_name, detailed_balance=False):
     fixture = workdir / "tiny-isf.bin"
     write_fixture(fixture)
-    save_dir = workdir / "results"
+    save_dir = (
+        workdir / "nested" / "result" / "directory"
+        if case_name == "nested_output"
+        else workdir / "results"
+    )
     seed = {
         "default": "1",
         "evolution_control_lower_boundaries": "8",
@@ -150,6 +169,7 @@ def run_deac_case(exe, workdir, case_name, detailed_balance=False):
         "first_moment": "3",
         "negative_first_moment": "5",
         "track_stats": "4",
+        "nested_output": "10",
     }[case_name]
 
     extra_args = []
@@ -200,6 +220,7 @@ def run_deac_case(exe, workdir, case_name, detailed_balance=False):
         population_size=population_size,
         seed=seed,
         extra_args=extra_args,
+        save_directory=save_dir,
     )
 
     run_command(command, workdir, expected_output="minimum_fitness:")
@@ -253,6 +274,9 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
     frequency_file = workdir / "frequency.bin"
     command_options = {}
     extra_args = None
+    save_directory = None
+    uuid = None
+    permission_restore = None
     expected_returncode = 1
 
     if case_name == "bad_isf_byte_length":
@@ -270,6 +294,8 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
     elif case_name == "nonfinite_isf":
         write_fixture(fixture, isf=[-1.0, float("nan"), -0.72, -0.61])
         expected_output = "ISF input file contains non-finite values"
+    elif case_name == "missing_isf":
+        expected_output = "could not open binary input"
     elif case_name == "positive_isf_single_particle":
         write_positive_fixture(fixture)
         if detailed_balance:
@@ -323,6 +349,10 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
         write_fixture(fixture)
         command_options["omega_max"] = "0.0"
         expected_output = "omega_max must be positive"
+    elif case_name == "missing_frequency":
+        write_fixture(fixture)
+        extra_args = ["--frequency_file", str(frequency_file)]
+        expected_output = "could not open binary input"
     elif case_name == "short_frequency_file":
         write_fixture(fixture)
         write_doubles(frequency_file, [0.0])
@@ -343,6 +373,42 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
         write_doubles(frequency_file, [0.0, 2.0, 1.0])
         extra_args = ["--frequency_file", str(frequency_file)]
         expected_output = "frequencies must be sorted in non-decreasing order"
+    elif case_name == "save_directory_is_file":
+        write_fixture(fixture)
+        save_directory = workdir / "result-path-is-a-file"
+        save_directory.write_text("not a directory")
+        expected_output = "exists but is not a directory"
+    elif case_name == "unwritable_save_directory":
+        write_fixture(fixture)
+        if hasattr(os, "geteuid") and os.geteuid() == 0 and Path("/proc").is_dir():
+            save_directory = Path("/proc") / "deac-cpp-result-io-test" / "nested"
+        elif os.name == "posix":
+            read_only_parent = workdir / "read-only"
+            read_only_parent.mkdir()
+            read_only_parent.chmod(stat.S_IRUSR | stat.S_IXUSR)
+            permission_restore = read_only_parent
+            save_directory = read_only_parent / "nested"
+        else:
+            blocked_parent = workdir / "blocked-parent"
+            blocked_parent.write_text("not a directory")
+            save_directory = blocked_parent / "nested"
+        expected_output = "could not create result directory"
+    elif case_name == "log_destination_is_directory":
+        write_fixture(fixture)
+        uuid = "log-destination"
+        save_directory = workdir / "results"
+        save_directory.mkdir()
+        prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
+        (save_directory / f"{prefix}_log_{uuid}.dat").mkdir()
+        expected_output = "could not open log file"
+    elif case_name == "result_destination_is_directory":
+        write_fixture(fixture)
+        uuid = "result-destination"
+        save_directory = workdir / "results"
+        save_directory.mkdir()
+        prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
+        (save_directory / f"{prefix}_dsf_{uuid}.bin").mkdir()
+        expected_output = "could not open binary output"
     elif case_name == "unsupported_negative_first_moment":
         write_fixture(fixture)
         extra_args = ["--use_negative_first_moment"]
@@ -358,19 +424,36 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
         workdir,
         fixture,
         extra_args=extra_args,
+        save_directory=save_directory,
+        uuid=uuid,
         **command_options,
     )
-    save_dir = workdir / "results"
+    save_dir = save_directory if save_directory is not None else workdir / "results"
     if case_name == "bad_stop_minimum_fitness":
         # Exercise the no-log guarantee independently of the no-directory
         # guarantee covered by the other invalid evolution controls.
         save_dir.mkdir()
-    run_command(
-        command,
-        workdir,
-        expected_returncode=expected_returncode,
-        expected_output=expected_output,
-    )
+    try:
+        result = run_command(
+            command,
+            workdir,
+            expected_returncode=expected_returncode,
+            expected_output=expected_output,
+        )
+    finally:
+        if permission_restore is not None:
+            permission_restore.chmod(stat.S_IRWXU)
+
+    if case_name == "log_destination_is_directory":
+        if "minimum_fitness:" in result.stdout:
+            raise AssertionError("evolution started despite an invalid initial log destination")
+        prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
+        if (save_dir / f"{prefix}_dsf_{uuid}.bin").exists():
+            raise AssertionError("invalid initial log destination produced a spectrum")
+    elif case_name == "result_destination_is_directory":
+        prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
+        if (save_dir / f"{prefix}_frequency_{uuid}.bin").exists():
+            raise AssertionError("solver continued writing after the first result I/O failure")
     if case_name.startswith("bad_") and case_name in {
         "bad_crossover_probability",
         "bad_self_adapting_crossover_probability",

--- a/test/result_io_test.cpp
+++ b/test/result_io_test.cpp
@@ -1,0 +1,144 @@
+#include "result_io.hpp"
+
+#include <chrono>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+class temporary_directory {
+public:
+    temporary_directory() {
+        const auto suffix = std::chrono::high_resolution_clock::now()
+                                    .time_since_epoch()
+                                    .count();
+        path_ = fs::temp_directory_path() /
+                ("deac-result-io-test-" + std::to_string(suffix));
+        fs::create_directories(path_);
+    }
+
+    ~temporary_directory() {
+        try {
+            fs::remove_all(path_);
+        } catch (...) {
+        }
+    }
+
+    const fs::path& path() const { return path_; }
+
+private:
+    fs::path path_;
+};
+
+template <typename Callable>
+void expect_error(Callable&& callable, const std::string& expected_text) {
+    try {
+        callable();
+    } catch (const std::runtime_error& error) {
+        if (std::string(error.what()).find(expected_text) == std::string::npos) {
+            throw std::runtime_error(
+                    "expected error containing '" + expected_text +
+                    "', got '" + error.what() + "'");
+        }
+        return;
+    }
+    throw std::runtime_error(
+            "expected runtime_error containing '" + expected_text + "'");
+}
+
+void write_bytes(const fs::path& path, const std::string& bytes) {
+    std::ofstream output(path.string(), std::ios::binary | std::ios::trunc);
+    output.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+    output.close();
+    if (!output) {
+        throw std::runtime_error("test fixture write failed");
+    }
+}
+
+} // namespace
+
+int main() {
+    try {
+        temporary_directory temporary;
+        const fs::path root = temporary.path();
+
+        const std::vector<double> expected{0.0, -1.25, 4.5};
+        const fs::path binary_path = root / "values.bin";
+        deac_io::write_binary_doubles(binary_path, expected);
+        const std::vector<double> actual = deac_io::read_binary_doubles(binary_path);
+        if (actual.size() != expected.size() ||
+            std::memcmp(actual.data(), expected.data(), expected.size() * sizeof(double)) != 0) {
+            throw std::runtime_error("binary-double round trip changed bytes");
+        }
+
+        expect_error(
+                [&] { deac_io::read_binary_doubles(root / "missing.bin"); },
+                "could not open binary input");
+
+        const fs::path empty_path = root / "empty.bin";
+        write_bytes(empty_path, "");
+        expect_error(
+                [&] { deac_io::read_binary_doubles(empty_path); }, "is empty");
+
+        const fs::path partial_path = root / "partial.bin";
+        write_bytes(partial_path, "partial");
+        expect_error(
+                [&] { deac_io::read_binary_doubles(partial_path); },
+                "does not contain a whole number of doubles");
+
+        const fs::path nested_directory = root / "nested" / "result" / "directory";
+        deac_io::ensure_result_directory(nested_directory);
+        if (!fs::is_directory(nested_directory)) {
+            throw std::runtime_error("nested result directory was not created");
+        }
+
+        const fs::path file_instead_of_directory = root / "ordinary-file";
+        write_bytes(file_instead_of_directory, "content");
+        expect_error(
+                [&] { deac_io::ensure_result_directory(file_instead_of_directory); },
+                "exists but is not a directory");
+
+        expect_error(
+                [&] {
+                    deac_io::write_binary_doubles(
+                            root / "missing-parent" / "output.bin", expected);
+                },
+                "could not open binary output");
+
+        const fs::path log_path = root / "run.log";
+        deac_io::append_text(log_path, "first\n");
+        deac_io::append_text(log_path, "second\n");
+        std::ifstream log_input(log_path.string());
+        const std::string log_text(
+                (std::istreambuf_iterator<char>(log_input)),
+                std::istreambuf_iterator<char>());
+        if (log_text != "first\nsecond\n") {
+            throw std::runtime_error("checked log append changed text");
+        }
+
+        const fs::path log_directory = root / "directory.log";
+        fs::create_directory(log_directory);
+        expect_error(
+                [&] { deac_io::append_text(log_directory, "text\n"); },
+                "could not open log file");
+
+        const fs::path full_device("/dev/full");
+        if (fs::exists(full_device)) {
+            expect_error(
+                    [&] { deac_io::write_binary_doubles(full_device, expected); },
+                    "binary output");
+            expect_error(
+                    [&] { deac_io::append_text(full_device, "text\n"); },
+                    "log file");
+        }
+    } catch (const std::exception& error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary

- centralize native-double binary reads/writes and log appends behind checked, path-specific helpers
- replace raw input/frequency ownership with `std::vector`
- recursively create result directories and validate the initial log destination before evolution starts
- preserve solver resource cleanup when a final result write or log append fails
- cover missing, empty, non-double-sized, nested, file-as-directory, unwritable, invalid-log, invalid-result, and `/dev/full` failure paths

Fixes #23.

## Compatibility

Baseline `95e8402c50bdd5c3cd2f7df42f3ff0ceb4045f81`; candidate `74d8703dd2c5ff0763c61474cf9536fff5d8364c`.

Seeded standard and detailed-balance A/B runs matched at zero tolerance. All 25 corresponding binary frequency, spectrum, and statistics artifacts passed `cmp`; their manifest SHA-256 was `98cde1055b87a1f2fb4e9df07d5e9dab808a6d64ad64e98e00337cbbb7dc9722`. A representative spectrum SHA-256 was `c09d4a91d091e12c9e7665c3591bd7c9701801c8bb2570f1d3999ae9e1806964`.

Serialization deliberately remains the existing native sequence of `double` values. Portable versioning and endianness are separate concerns.

## Validation

- GCC 14.3 CPU standard: 42/42
- GCC 14.3 CPU hyperbolic: 42/42
- GCC 14.3 CPU detailed balance: 42/42
- GCC 14.3 ASan + UBSan with leak detection: 42/42
- IntelLLVM 2026.1 SYCL standard on Intel Data Center GPU Max 1550: 43/43, including CPU parity
- IntelLLVM 2026.1 SYCL detailed balance on the same GPU: 43/43, including CPU parity
- independent review: no blocker
- `git diff --check`: clean

The SYCL configurations used Level Zero, `-fsycl`, block size 256, and subgroup size 16. A second independent gate run passed IntelLLVM CPU standard/hyperbolic/detailed 42/42, GCC ASan/UBSan 42/42, and both SYCL/parity configurations 43/43.

## Scope limits

- `/dev/full` deterministically exercises write/flush failure; successful close operations are checked, but the test suite does not synthesize a close-only fault.
- Each result file is individually checked, flushed, and closed. The set of output files is not transactional, so a later failure can leave earlier successfully written files alongside the reported error.
