### PR TITLE
Remove inactive controls and dead helpers

### DIFF
--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -334,6 +334,7 @@ if(Python3_Interpreter_FOUND)
             bad_differential_weight
             bad_self_adapting_differential_weight_probability
             bad_stop_minimum_fitness
+            inactive_options_rejected
             too_few_generations
             too_small_population
             too_small_genome

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -74,18 +74,6 @@ double minimum(double * A, size_t length) {
     return _minimum;
 }
 
-size_t argmin(double * A, size_t length) {
-    size_t _argmin=0;
-    double _minimum = A[0];
-    for (size_t i=0; i<length; i++) {
-        if (A[i] < _minimum) {
-            _minimum = A[i];
-            _argmin = i;
-        }
-    }
-    return _argmin;
-}
-
 std::tuple <size_t, double> argmin_and_min(double * A, size_t length) {
     size_t _argmin=0;
     double _minimum = A[0];
@@ -113,27 +101,6 @@ double squared_mean(double * A, size_t length) {
         _squared_mean += A[i]*A[i];
     }
     return _squared_mean/length;
-}
-
-std::tuple <size_t, size_t, size_t> get_mutant_indices(struct xoshiro256p_state * rng, size_t mutant_index0, size_t length) {
-    size_t mutant_index1 = mutant_index0;
-    size_t mutant_index2 = mutant_index0;
-    size_t mutant_index3 = mutant_index0;
-    while (mutant_index1 == mutant_index0) {
-        mutant_index1 = xoshiro256p(rng) % length;
-    }
-
-    while ((mutant_index2 == mutant_index0) || (mutant_index2 == mutant_index1)) {
-        mutant_index2 = xoshiro256p(rng) % length;
-    }
-
-    while ((mutant_index3 == mutant_index0) || (mutant_index3 == mutant_index1)
-            || (mutant_index3 == mutant_index2)) {
-        mutant_index3 = xoshiro256p(rng) % length;
-    }
-
-    std::tuple <size_t, size_t, size_t> _mutant_indices(mutant_index1, mutant_index2, mutant_index3);
-    return _mutant_indices;
 }
 
 void set_mutant_indices(struct xoshiro256p_state* rng, size_t* mutant_indices, size_t mutant_index0, size_t length) {
@@ -179,8 +146,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         double self_adapting_crossover_probability,
         double differential_weight, 
         double self_adapting_differential_weight_probability,
-        double self_adapting_differential_weight_shift,
-        double self_adapting_differential_weight, double stop_minimum_fitness,
+        double stop_minimum_fitness,
         bool track_stats, size_t seed, std::string uuid_str, std::string spectra_type, fs::path save_directory) {
 
     #ifdef ZEROT
@@ -1117,9 +1083,6 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 }
 
                 if ((xoshiro256p(rng) >> 11) * 0x1.0p-53 < self_adapting_differential_weight_probability) {
-                    //differential_weights_new[i] = 
-                    //    self_adapting_differential_weight_shift + 
-                    //    self_adapting_differential_weight*((xoshiro256p(rng) >> 11) * 0x1.0p-53);
                     differential_weights_new_positive_frequency[i] = 2.0*((xoshiro256p(rng) >> 11) * 0x1.0p-53);
                 } else {
                     differential_weights_new_positive_frequency[i] = differential_weights_old_positive_frequency[i];
@@ -1133,9 +1096,6 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                     }
 
                     if ((xoshiro256p(rng) >> 11) * 0x1.0p-53 < self_adapting_differential_weight_probability) {
-                        //differential_weights_new[i] = 
-                        //    self_adapting_differential_weight_shift + 
-                        //    self_adapting_differential_weight*((xoshiro256p(rng) >> 11) * 0x1.0p-53);
                         differential_weights_new_negative_frequency[i] = 2.0*((xoshiro256p(rng) >> 11) * 0x1.0p-53);
                     } else {
                         differential_weights_new_negative_frequency[i] = differential_weights_old_negative_frequency[i];
@@ -1666,7 +1626,6 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                     fitness_squared_mean_filename,
                     std::span<const double>(fitness_squared_mean, generation + 1));
         }
-
         // Append the final run record only after all binary artifacts are
         // successfully flushed and closed.
         std::string log_filename_str = string_format("%s_log_%s.dat",deac_prefix.c_str(),uuid_str.c_str());
@@ -1706,8 +1665,6 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         log << "self_adapting_crossover_probability: " << self_adapting_crossover_probability << std::endl;
         log << "differential_weight: " << differential_weight << std::endl;
         log << "self_adapting_differential_weight_probability: " << self_adapting_differential_weight_probability << std::endl;
-        log << "self_adapting_differential_weight_shift: " << self_adapting_differential_weight_shift << std::endl;
-        log << "self_adapting_differential_weight: " << self_adapting_differential_weight << std::endl;
         log << "stop_minimum_fitness: " << stop_minimum_fitness << std::endl;
         log << "track_stats: " << track_stats << std::endl;
         log << "seed: " << seed << std::endl;
@@ -1948,14 +1905,6 @@ int deac_main (int argc, char *argv[]) {
         .help("Probability for `differential_weight` to mutate. Must be finite and in [0, 1].")
         .default_value(0.1)
         .action([](const std::string& value) { return std::stod(value); });
-    program.add_argument("-l","--self_adapting_differential_weight_shift")
-        .help("If `self_adapting_differential_weight_probability` mutate, new value is `l + m*rand()`.")
-        .default_value(0.1)
-        .action([](const std::string& value) { return std::stod(value); });
-    program.add_argument("-m","--self_adapting_differential_weight")
-        .help("If `self_adapting_differential_weight_probability` mutate, new value is `l + m*rand()`.")
-        .default_value(0.9)
-        .action([](const std::string& value) { return std::stod(value); });
     program.add_argument("--stop_minimum_fitness")
         .help("Stop evolving when minimum fitness is at or below this finite value. Negative values are allowed.")
         .default_value(1.0)
@@ -1967,10 +1916,6 @@ int deac_main (int argc, char *argv[]) {
     program.add_argument("--uuid")
         .help("UUID for run. If empty will be set to `seed`.")
         .default_value("");
-    program.add_argument("--save_state")
-        .help("Save state of DEAC algorithm. Saves the random number generator, population, and population fitness.")
-        .default_value(false)
-        .implicit_value(true);
     program.add_argument("--save_directory")
         .help("Directory to save results in.")
         .default_value("./deacresults");
@@ -2142,9 +2087,6 @@ int deac_main (int argc, char *argv[]) {
         fail_with_error("third_moment_error must be positive when third_moment is used");
     }
 
-    double self_adapting_differential_weight_shift = program.get<double>("--self_adapting_differential_weight_shift");
-    double self_adapting_differential_weight = program.get<double>("--self_adapting_differential_weight");
-
     bool track_stats = program.get<bool>("--track_stats");
     std::string save_directory_str = program.get<std::string>("--save_directory");
     fs::path save_directory(save_directory_str);
@@ -2169,8 +2111,7 @@ int deac_main (int argc, char *argv[]) {
             third_moment_error, crossover_probability,
             self_adapting_crossover_probability, differential_weight,
             self_adapting_differential_weight_probability,
-            self_adapting_differential_weight_shift,
-            self_adapting_differential_weight, stop_minimum_fitness,
+            stop_minimum_fitness,
             track_stats, seed_int, uuid_str, spectra_type, save_directory);
 
     return 0;

--- a/test/deac_smoke_test.py
+++ b/test/deac_smoke_test.py
@@ -38,6 +38,7 @@ VALIDATION_CASES = [
     "bad_differential_weight",
     "bad_self_adapting_differential_weight_probability",
     "bad_stop_minimum_fitness",
+    "inactive_options_rejected",
     "too_few_generations",
     "too_small_population",
     "too_small_genome",
@@ -333,6 +334,33 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
         write_fixture(fixture)
         extra_args = ["--stop_minimum_fitness", "inf"]
         expected_output = "stop_minimum_fitness must be finite"
+    elif case_name == "inactive_options_rejected":
+        write_fixture(fixture)
+        save_dir = workdir / "results"
+        for inactive_option in (
+            ["--save_state"],
+            ["-l", "0.1"],
+            ["--self_adapting_differential_weight_shift", "0.1"],
+            ["-m", "0.9"],
+            ["--self_adapting_differential_weight", "0.9"],
+        ):
+            command = deac_command(
+                exe,
+                workdir,
+                fixture,
+                extra_args=inactive_option,
+            )
+            run_command(
+                command,
+                workdir,
+                expected_returncode=1,
+                expected_output=inactive_option[0],
+            )
+            if save_dir.exists():
+                raise AssertionError(
+                    f"inactive option {inactive_option[0]} created {save_dir}"
+                )
+        return
     elif case_name == "too_few_generations":
         write_fixture(fixture)
         command_options["number_of_generations"] = "1"
@@ -504,6 +532,23 @@ def main():
                     f"expected --help to contain {expected_output!r}\n"
                     f"output:\n{result.stdout}"
                 )
+        for inactive_option in (
+            "--save_state",
+            "--self_adapting_differential_weight_shift",
+        ):
+            if inactive_option in result.stdout:
+                raise AssertionError(
+                    f"expected --help to omit inactive option {inactive_option!r}\n"
+                    f"output:\n{result.stdout}"
+                )
+        help_without_probability = result.stdout.replace(
+            "--self_adapting_differential_weight_probability", ""
+        )
+        if "--self_adapting_differential_weight" in help_without_probability:
+            raise AssertionError(
+                "expected --help to omit inactive differential-weight range option\n"
+                f"output:\n{result.stdout}"
+            )
     elif args.case == "version":
         result = run_command([exe, "-v"], workdir)
         if result.stdout.strip() != "2.0.0-rc1":


### PR DESCRIPTION
## Summary

- remove `--save_state`, which was parsed but had no consumer or restart implementation
- remove `-l`/`--self_adapting_differential_weight_shift` and `-m`/`--self_adapting_differential_weight`, which were only logged while evolution continued to use the hard-coded `2 * rand()` distribution
- remove the corresponding unused internal parameters, log claims, and commented formula without changing the active distribution
- delete `argmin` and `get_mutant_indices`, both superseded and proven to have no callers
- test all five retired option spellings and verify they fail during parsing before creating an output directory

Fixes #20.

## Compatibility decision

Silently activating the commented `l + m * rand()` formula would change seeded evolution and invent semantics for existing runs. Implementing `--save_state` would require a separately designed/versioned restart format. This PR instead makes unsupported settings impossible to claim.

This is an intentional CLI compatibility break for options that never affected execution. The active self-adapting differential-weight probability and the existing `2 * rand()` behavior remain unchanged. Logs no longer record the two inert range values.

Baseline `f9e4ded555b78b064f59548cba14aa81feedea27`; candidate `7cb49f0a82b5717346f34cf8ac36f7d0e1335260`.

Seeded standard, statistics-enabled, and detailed-balance runs produced byte-identical frequency, spectrum, and statistics binaries before and after the cleanup. Representative spectrum SHA-256 values were `9a4abb144c9f6dd3496a5a625e5129f44ebe52e79f24c8ddbfdb5954bd754422` (standard) and `ac787c1da1e0be1cdec951fcc9d18eb7eabe55d012619eed2162ea5b4a2d446d` (detailed balance).

## Validation

- IntelLLVM 2026.1 CPU standard: 43/43
- IntelLLVM 2026.1 CPU hyperbolic: 43/43
- IntelLLVM 2026.1 CPU detailed balance: 43/43
- GCC 14.3 ASan + UBSan with leak detection: 43/43
- IntelLLVM 2026.1 SYCL standard on Intel Data Center GPU Max 1550: 44/44, including CPU parity
- IntelLLVM 2026.1 SYCL detailed balance on the same GPU: 44/44, including CPU parity
- `git diff --check`: clean

The SYCL configurations used Level Zero, `-fsycl`, block size 256, and subgroup size 16.
