### PR TITLE
fix: remove CUDA and HIP GEMV barrier hazards

### DIFF
--- a/src/deac/include/deac_gpu.hip.hpp
+++ b/src/deac/include/deac_gpu.hip.hpp
@@ -326,7 +326,11 @@ __global__ void gpu_deac_gemv_simple(int m, int n, double alpha, double* __restr
         for (int j = 0; j < n; j++) {
             sum += A[row + j*lda] * x[j*incx];
         }
-        y[row*incy] = alpha * sum + beta * y[row*incy];
+        if (beta == 0.0) {
+            y[row*incy] = alpha * sum;
+        } else {
+            y[row*incy] = alpha * sum + beta * y[row*incy];
+        }
     }
 }
 
@@ -346,38 +350,6 @@ __global__ void gpu_deac_gemv_atomic(int m, int n, double alpha, double* __restr
         }
     }
 }
-
-__global__ void gpu_deac_gemv(int m, int n, double alpha, double* __restrict__ A, int lda, double* __restrict__ x, int incx, double beta, double* __restrict__ y, int incy) {
-    __shared__ double As[TILE_WIDTH][TILE_WIDTH];
-    int tx = hipThreadIdx_x;
-    int by = hipBlockIdx_y, ty = hipThreadIdx_y;
-    int row = by * hipBlockDim_y + ty;
-
-    double sum = 0.0;
-    if (row < m) {
-        for (int i = 0; i < (n + TILE_WIDTH - 1) / TILE_WIDTH; ++i) {
-            if (i*TILE_WIDTH + tx < n && row < m) {
-                As[ty][tx] = A[row + (i*TILE_WIDTH + tx) * lda];
-            } else {
-                As[ty][tx] = 0.0;
-            }
-            __syncthreads();
-
-            for (int k = 0; k < TILE_WIDTH; ++k) {
-                if (i*TILE_WIDTH + k < n) {
-                    sum += As[ty][k] * x[(i*TILE_WIDTH + k)*incx];
-                }
-            }
-            __syncthreads();
-        }
-        if (beta == 0.0) {
-            y[row * incy] = alpha * sum;
-        } else {
-            y[row * incy] = alpha * sum + beta * y[row * incy];
-        }
-    }
-}
-
 
 __global__
 void gpu_get_minimum(double* __restrict__ minimum, double* __restrict__ array, size_t N) {
@@ -660,9 +632,12 @@ void gpu_matmul(hipStream_t s, int m, int n, int k, double alpha, double* __rest
 }
 
 void gpu_deac_gemv(hipStream_t s, int m, int n, double alpha, double* __restrict__ A, double* __restrict__ x, double beta, double* __restrict__ y) {
-    //hipLaunchKernelGGL(gpu_deac_gemv_simple, dim3((m + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE), dim3(GPU_BLOCK_SIZE), 0, s, m, n, alpha, A, m, x, 1, beta, y, 1);
-    //hipLaunchKernelGGL(gpu_deac_gemv_atomic, dim3((n + TILE_WIDTH - 1) / TILE_WIDTH), dim3(TILE_WIDTH), 0, s, m, n, alpha, A, m, x, 1, beta, y, 1);
-    hipLaunchKernelGGL(gpu_deac_gemv, dim3((n + TILE_WIDTH - 1) / TILE_WIDTH, (n + TILE_WIDTH - 1) / TILE_WIDTH), dim3(TILE_WIDTH, TILE_WIDTH), 0, s, m, n, alpha, A, m, x, 1, beta, y, 1);
+    // One thread owns each output row.  The former tiled kernel placed block
+    // barriers inside `row < m`, so a partial final row tile could deadlock.
+    // Its unused x grid dimension also raced multiple blocks on each output.
+    hipLaunchKernelGGL(gpu_deac_gemv_simple,
+            dim3((m + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE), dim3(GPU_BLOCK_SIZE),
+            0, s, m, n, alpha, A, m, x, 1, beta, y, 1);
 }
 
 

--- a/src/deac/src/deac_gpu.cu
+++ b/src/deac/src/deac_gpu.cu
@@ -321,7 +321,11 @@ __global__ void gpu_deac_gemv_simple(int m, int n, double alpha, double* __restr
         for (int j = 0; j < n; j++) {
             sum += A[row + j*lda] * x[j*incx];
         }
-        y[row*incy] = alpha * sum + beta * y[row*incy];
+        if (beta == 0.0) {
+            y[row*incy] = alpha * sum;
+        } else {
+            y[row*incy] = alpha * sum + beta * y[row*incy];
+        }
     }
 }
 
@@ -338,37 +342,6 @@ __global__ void gpu_deac_gemv_atomic(int m, int n, double alpha, double* __restr
         for (int i = 0; i < m; i++) {
             double Aval = A[i + col * lda];
             atomicAdd(&y[i * incy], alpha * Aval * shared_x[threadIdx.x]);
-        }
-    }
-}
-
-__global__ void gpu_deac_gemv(int m, int n, double alpha, double* __restrict__ A, int lda, double* __restrict__ x, int incx, double beta, double* __restrict__ y, int incy) {
-    __shared__ double As[TILE_WIDTH][TILE_WIDTH];
-    int tx = threadIdx.x;
-    int by = blockIdx.y, ty = threadIdx.y;
-    int row = by * blockDim.y + ty;
-
-    double sum = 0.0;
-    if (row < m) {
-        for (int i = 0; i < (n + TILE_WIDTH - 1) / TILE_WIDTH; ++i) {
-            if (i*TILE_WIDTH + tx < n && row < m) {
-                As[ty][tx] = A[row + (i*TILE_WIDTH + tx) * lda];
-            } else {
-                As[ty][tx] = 0.0;
-            }
-            __syncthreads();
-
-            for (int k = 0; k < TILE_WIDTH; ++k) {
-                if (i*TILE_WIDTH + k < n) {
-                    sum += As[ty][k] * x[(i*TILE_WIDTH + k)*incx];
-                }
-            }
-            __syncthreads();
-        }
-        if (beta == 0.0) {
-            y[row * incy] = alpha * sum;
-        } else {
-            y[row * incy] = alpha * sum + beta * y[row * incy];
         }
     }
 }
@@ -653,9 +626,10 @@ void gpu_matmul(cudaStream_t s, int m, int n, int k, double alpha, double* __res
 }
 
 void gpu_deac_gemv(cudaStream_t s, int m, int n, double alpha, double* __restrict__ A, double* __restrict__ x, double beta, double* __restrict__ y) {
-    //gpu_deac_gemv_simple<<<dim3((m + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE), dim3(GPU_BLOCK_SIZE), 0, s>>>(m, n, alpha, A, m, x, 1, beta, y, 1);
-    //gpu_deac_gemv_atomic<<<dim3((n + TILE_WIDTH - 1) / TILE_WIDTH), dim3(TILE_WIDTH), 0, s>>>(m, n, alpha, A, m, x, 1, beta, y, 1);
-    gpu_deac_gemv<<<dim3((n + TILE_WIDTH - 1) / TILE_WIDTH, (m + TILE_WIDTH - 1) / TILE_WIDTH), dim3(TILE_WIDTH, TILE_WIDTH), 0, s>>>(m, n, alpha, A, m, x, 1, beta, y, 1);
+    // One thread owns each output row.  The former tiled kernel placed block
+    // barriers inside `row < m`, so a partial final row tile could deadlock.
+    // Its unused x grid dimension also raced multiple blocks on each output.
+    gpu_deac_gemv_simple<<<dim3((m + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE), dim3(GPU_BLOCK_SIZE), 0, s>>>(m, n, alpha, A, m, x, 1, beta, y, 1);
 }
 
 void gpu_get_minimum(cudaStream_t s, double* __restrict__ minimum, double* __restrict__ array, size_t N) {


### PR DESCRIPTION
## Summary

- remove the active tiled custom GEMV kernels whose row predicate made block-barrier participation divergent;
- route the unchanged CUDA and HIP host APIs to the existing one-thread-per-output-row kernels with a row count derived from `m`;
- preserve the sequential `j = 0..n-1` accumulation order and apply `beta` exactly once per output row;
- keep the `beta == 0` path from reading an output buffer whose prior contents are not part of the operation.

## Defect and arithmetic behavior

Both tiled kernels put two `__syncthreads()` calls inside `row < m`. A partial final row tile therefore let only some threads reach each barrier. Every x-dimension work item also computed and wrote the same output row, and multiple x blocks raced when `n > TILE_WIDTH`. The HIP launcher additionally derived its row-grid extent from `n` instead of `m`, leaving rows uncovered or launching redundant rows whenever those dimensions differed.

The selected simple kernels retain the public `gpu_deac_gemv` wrappers and stream behavior. Each output still accumulates matrix/vector products in increasing column order (`j = 0..n-1`), which is the same floating-point order used by each worker in the removed tiled implementation. The difference is that one worker owns each row, so the `beta` update is deterministic and occurs once.

## Existing boundary coverage

The registered smoke/parity suite already includes:

- normalized populations at `P=8`, below `TILE_WIDTH=32`;
- normalized populations at `P=1028`, crossing tile boundaries and creating a partial second work group with the default `GPU_BLOCK_SIZE=1024`;
- the first-moment path at `P=8`;
- the detailed-balance inverse-first-moment path at `P=8`.

Those cases are automatically registered for CUDA and HIP builds, but they have not been executed for either backend in this environment.

## Validation available on this node

Base: `752f31ffef68acdd3c89724c2cacf9a67f6076a3`

- GNU 14.3.0 CPU, standard: 43/43 CTest tests passed.
- GNU 14.3.0 CPU, detailed balance: 43/43 passed.
- Intel oneAPI DPC++/C++ 2026.1.0, SYCL on Intel Data Center GPU Max 1550, standard: 44/44 passed, including CPU-reference parity.
- Same SYCL configuration, detailed balance: 44/44 passed, including CPU-reference parity.
- `git diff --check` passed.

The CPU and SYCL runs validate the surrounding suite and analogous row-wise path; they are not CUDA/HIP compile or runtime evidence.

## Required before ready to merge

- CUDA configure currently stops because this node has no `nvcc` or CUDA toolkit, and it exposes no NVIDIA device.
- HIP configure currently stops because this node has no HIP headers or `hipcc`, and it exposes no AMD device.
- Run both backend builds, the bounded normalization/moment smoke cases, and CPU-reference parity on documented CUDA and HIP hardware.

This PR intentionally remains a draft and does not close the tracking issue.

Refs #14
