### PR TITLE
fix: restore one-sided ZeroT semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,32 @@ As above, and with further details below, but you should consider using the foll
 Executables will be installed to `CMAKE_INSTALL_PREFIX` location or, if the install is skipped, they will be located in `build/deac`.
 Executables produced are `deac.e`, `deacd.e`, `deac-zT.e`, and `deac-zTd.e` for `CMAKE_BUILD_TYPE=Release|Debug|ZeroT|ZeroTDebug` respectively.
 
-A typical `cmake` line for building deac in zero temperature mode with GPU acceleration using CUDA on a Tesla V100 device with an undetected CUDA architecture is:
+### Zero-temperature mode
 
-`cmake -DGPU_BACKEND=cuda -DGPU_BLOCK_SIZE=1024 -DCMAKE_CUDA_ARCHITECTURES=70 -DCMAKE_BUILD_TYPE=ZeroT ../src`
+`ZeroT` and `ZeroTDebug` restore the original zero-temperature problem: one
+non-negative-frequency population represents `S(omega)` on the supplied
+frequency grid, and the forward model is the one-sided Laplace transform
+
+`F(tau) = integral_0^infinity exp(-tau*omega) S(omega) d omega`.
+
+There is no independently evolved negative-frequency population, no beta or
+finite-temperature periodicity factor, and the frequency and spectrum outputs
+each contain exactly `genome_size` doubles. The fixed `--spectra_type positive`
+value is the default, `--temperature` is ignored and recorded as zero, and
+result filenames retain the historical `deac-zT_*` prefix.
+
+The supported ZeroT configuration is currently the CPU backend:
+
+```bash
+cmake -S src -B build-zerot \
+  -DCMAKE_BUILD_TYPE=ZeroT -DGPU_BACKEND=none
+cmake --build build-zerot --parallel
+ctest --test-dir build-zerot --output-on-failure
+```
+
+The CUDA, HIP, and SYCL ZeroT combinations are not release-tested and are not
+claimed as supported by this documentation. Their finite-temperature support
+is independent of the CPU ZeroT mode.
 
 If you run into problems, failures with linking etc., common errors may include
 not properly setting your `LD_LIBRARY_PATH` or `LIBRARY_PATH` and not starting from a clean build

--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -302,6 +302,14 @@ add_test(
     NAME deac_unit_result_io
     COMMAND deac_result_io_test)
 
+add_executable(deac_zero_temperature_kernel_test
+    ${CMAKE_SOURCE_DIR}/../test/zero_temperature_kernel_test.cpp)
+target_include_directories(deac_zero_temperature_kernel_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_test(
+    NAME deac_unit_zero_temperature_kernel
+    COMMAND deac_zero_temperature_kernel_test)
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     set(DEAC_SMOKE_TEST "${CMAKE_SOURCE_DIR}/../test/deac_smoke_test.py")
@@ -309,6 +317,9 @@ if(Python3_Interpreter_FOUND)
     set(DEAC_SMOKE_VARIANT_ARGS)
     if(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF)
         list(APPEND DEAC_SMOKE_VARIANT_ARGS --detailed-balance)
+    endif()
+    if(CMAKE_BUILD_TYPE MATCHES "^ZeroT")
+        list(APPEND DEAC_SMOKE_VARIANT_ARGS --zero-temperature)
     endif()
     set(DEAC_SMOKE_CASES
             help
@@ -320,6 +331,7 @@ if(Python3_Interpreter_FOUND)
             normalize
             normalize_large_population
             first_moment
+            third_moment
             track_stats
             bad_isf_byte_length
             empty_isf

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -15,6 +15,7 @@
 #include "evolution_controls.hpp"
 #include "population_projection.hpp"
 #include "result_io.hpp"
+#include "zero_temperature_kernel.hpp"
 #include "trapezoidal_weights.hpp"
 #include <memory> // string_format
 #include <string> // string_format
@@ -31,6 +32,13 @@
 #endif
 #ifdef USE_SYCL
     #include "deac_gpu.sycl.h"
+#endif
+
+// Finite-temperature spectra without detailed balance have independently
+// evolved positive- and negative-frequency populations.  ZeroT deliberately
+// retains the original one-sided, non-negative-frequency population.
+#if !defined(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF) && !defined(ZEROT)
+    #define DEAC_TWO_SIDED_POPULATION 1
 #endif
 
 [[noreturn]] void fail_with_error(const std::string& error_message) {
@@ -157,7 +165,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         use_negative_first_moment = false; //FIXME disabling inverse first moment for zero temperature (needs further investigation)
         temperature = 0.0;
     #else
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             //Use beta periodicity in imaginary time to reduce numerical instabilities
             double periodicity = 1.0; // Periodic for bosnonic systems
             if (
@@ -236,7 +244,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     size_t bytes_isf_term = sizeof(double)*genome_size*number_of_timeslices;
     double * isf_term_positive_frequency;
     isf_term_positive_frequency = (double*) malloc(bytes_isf_term);
-    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+    #ifdef DEAC_TWO_SIDED_POPULATION
         double * isf_term_negative_frequency;
         isf_term_negative_frequency = (double*) malloc(bytes_isf_term);
     #endif
@@ -264,10 +272,6 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 #else
                     double tmb = t - beta; // subtract beta from tau
                 #endif
-            #endif
-        #else
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-                double tmb = t - beta; // subtract beta from tau
             #endif
         #endif
         for (size_t j=0; j<genome_size; j++) {
@@ -308,12 +312,8 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                     #endif
                 #endif
             #else
-                #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-                    isf_term_positive_frequency[isf_term_idx] = df*exp(-t*f);
-                #else
-                    isf_term_positive_frequency[isf_term_idx] = df*exp(-t*f);
-                    isf_term_negative_frequency[isf_term_idx] = periodicity*df*exp(tmb*f); // exp(-t*f) with t - beta
-                #endif
+                isf_term_positive_frequency[isf_term_idx] =
+                        deac_numerics::zero_temperature_laplace_term(t, f, df);
             #endif
         }
     }
@@ -324,7 +324,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         GPU_ASSERT(deac_malloc_device(double, d_isf_term_positive_frequency, genome_size*number_of_timeslices, default_stream));
         GPU_ASSERT(deac_wait(default_stream));
         GPU_ASSERT(deac_memcpy_host_to_device(d_isf_term_positive_frequency, isf_term_positive_frequency, bytes_isf_term, default_stream));
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             double* d_isf_term_negative_frequency;
             GPU_ASSERT(deac_malloc_device(double, d_isf_term_negative_frequency, genome_size*number_of_timeslices, default_stream));
             GPU_ASSERT(deac_wait(default_stream));
@@ -339,7 +339,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     double * population_new_positive_frequency;
     population_new_positive_frequency = (double*) malloc(bytes_population);
     population_old_positive_frequency = (double*) malloc(bytes_population);
-    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+    #ifdef DEAC_TWO_SIDED_POPULATION
         double * population_old_negative_frequency;
         double * population_new_negative_frequency;
         population_old_negative_frequency = (double*) malloc(bytes_population);
@@ -356,7 +356,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             #ifdef ALLOW_NEGATIVE_SPECTRAL_WEIGHT
                 population_old_positive_frequency[population_idx] -= 0.5;
             #endif
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 population_old_negative_frequency[population_idx] = (xoshiro256p(rng) >> 11) * 0x1.0p-53; // to_double2
                 #ifdef ALLOW_NEGATIVE_SPECTRAL_WEIGHT
                     population_old_negative_frequency[population_idx] -= 0.5;
@@ -364,7 +364,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             #endif
         }
     }
-    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+    #ifdef DEAC_TWO_SIDED_POPULATION
         for (size_t i=0; i<population_size; i++) {
             #ifdef USE_GPU
                 size_t zero_frequency_idx = i;
@@ -382,7 +382,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         GPU_ASSERT(deac_malloc_device(double, d_population_new_positive_frequency, genome_size*population_size, default_stream));
         GPU_ASSERT(deac_wait(default_stream));
         GPU_ASSERT(deac_memcpy_host_to_device(d_population_old_positive_frequency, population_old_positive_frequency, bytes_population, default_stream));
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             double* d_population_old_negative_frequency;
             double* d_population_new_negative_frequency;
             GPU_ASSERT(deac_malloc_device(double, d_population_old_negative_frequency, genome_size*population_size, default_stream));
@@ -398,20 +398,20 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     size_t bytes_normalization_term = sizeof(double)*genome_size;
     double * normalization = nullptr;
     double * normalization_term_positive_frequency = nullptr;
-    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+    #ifdef DEAC_TWO_SIDED_POPULATION
         double * normalization_term_negative_frequency = nullptr;
     #endif
     #ifdef USE_GPU
         double* d_normalization;
         double* d_normalization_term_positive_frequency;
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             double* d_normalization_term_negative_frequency;
         #endif
     #endif
     if (normalize) {
         normalization = (double*) malloc(bytes_normalization);
         normalization_term_positive_frequency = (double*) malloc(bytes_normalization_term);
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             normalization_term_negative_frequency = (double*) malloc(bytes_normalization_term);
         #endif
         for (size_t j=0; j<genome_size; j++) {
@@ -446,7 +446,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 #endif
             #else
                 normalization_term_positive_frequency[j] = df;
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     normalization_term_negative_frequency[j] = df;
                 #endif
             #endif
@@ -458,7 +458,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             GPU_ASSERT(deac_malloc_device(double, d_normalization_term_positive_frequency, genome_size,     default_stream));
             GPU_ASSERT(deac_wait(default_stream));
             GPU_ASSERT(deac_memcpy_host_to_device(d_normalization_term_positive_frequency, normalization_term_positive_frequency, bytes_normalization_term, default_stream));
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 GPU_ASSERT(deac_malloc_device(double, d_normalization_term_negative_frequency, genome_size,     default_stream));
                 GPU_ASSERT(deac_wait(default_stream));
                 GPU_ASSERT(deac_memcpy_host_to_device(d_normalization_term_negative_frequency, normalization_term_negative_frequency, bytes_normalization_term, default_stream));
@@ -474,21 +474,21 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             #ifdef USE_BLAS
                 gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0/zeroth_moment, d_population_old_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
                 GPU_ASSERT(deac_wait(default_stream));
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0/zeroth_moment, d_population_old_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
             #else
                 gpu_deac_gemv(default_stream, population_size, genome_size, 1.0/zeroth_moment, d_population_old_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
                 GPU_ASSERT(deac_wait(default_stream));
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     gpu_deac_gemv(default_stream, population_size, genome_size, 1.0/zeroth_moment, d_population_old_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
             #endif
 
             gpu_deac_dgmmDiv1D(stream_array[0], d_population_old_positive_frequency, d_normalization, population_size, genome_size); 
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 gpu_deac_dgmmDiv1D(stream_array[1 % MAX_GPU_STREAMS], d_population_old_negative_frequency, d_normalization, population_size, genome_size); 
                 #if MAX_GPU_STREAMS > 1
                     GPU_ASSERT(deac_wait(stream_array[1]));
@@ -501,7 +501,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             }
             matrix_multiply_MxN_by_Nx1(normalization, population_old_positive_frequency,
                     normalization_term_positive_frequency, population_size, genome_size);
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 matrix_multiply_MxN_by_Nx1(normalization, population_old_negative_frequency,
                         normalization_term_negative_frequency, population_size, genome_size);
             #endif
@@ -509,7 +509,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 double _norm = normalization[i];
                 for (size_t j=0; j<genome_size; j++) {
                     population_old_positive_frequency[i*genome_size + j] *= zeroth_moment/_norm;
-                    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    #ifdef DEAC_TWO_SIDED_POPULATION
                         population_old_negative_frequency[i*genome_size + j] *= zeroth_moment/_norm;
                     #endif
                 }
@@ -523,13 +523,13 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
 
     double * first_moments = nullptr;
     double * first_moments_term_positive_frequency = nullptr;
-    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+    #ifdef DEAC_TWO_SIDED_POPULATION
         double * first_moments_term_negative_frequency = nullptr;
     #endif
     #ifdef USE_GPU
         double* d_first_moments;
         double* d_first_moments_term_positive_frequency;
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             double* d_first_moments_term_negative_frequency;
         #endif
     #endif
@@ -542,7 +542,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     if (use_first_moment) {
         std::cout << "WARNING: setting first_moment_error to 1.0." << std::endl;
         first_moments_term_positive_frequency = (double*) malloc(bytes_first_moments_term);
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             first_moments_term_negative_frequency = (double*) malloc(bytes_first_moments_term);
         #endif
         for (size_t j=0; j<genome_size; j++) {
@@ -576,7 +576,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 #endif
             #else
                 first_moments_term_positive_frequency[j] = df*f;
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     first_moments_term_negative_frequency[j] = -df*f;
                 #endif
             #endif
@@ -588,7 +588,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             GPU_ASSERT(deac_malloc_device(double, d_first_moments_term_positive_frequency, genome_size,     default_stream));
             GPU_ASSERT(deac_wait(default_stream));
             GPU_ASSERT(deac_memcpy_host_to_device(d_first_moments_term_positive_frequency, first_moments_term_positive_frequency, bytes_first_moments_term, default_stream));
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 GPU_ASSERT(deac_malloc_device(double, d_first_moments_term_negative_frequency, genome_size,     default_stream));
                 GPU_ASSERT(deac_wait(default_stream));
                 GPU_ASSERT(deac_memcpy_host_to_device(d_first_moments_term_negative_frequency, first_moments_term_negative_frequency, bytes_first_moments_term, default_stream));
@@ -600,14 +600,14 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             #ifdef USE_BLAS
                 gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_old_positive_frequency, d_first_moments_term_positive_frequency, 0.0, d_first_moments);
                 GPU_ASSERT(deac_wait(default_stream));
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_old_negative_frequency, d_first_moments_term_negative_frequency, 1.0, d_first_moments);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
             #else
                 gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_old_positive_frequency, d_first_moments_term_positive_frequency, 0.0, d_first_moments);
                 GPU_ASSERT(deac_wait(default_stream));
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_old_negative_frequency, d_first_moments_term_negative_frequency, 1.0, d_first_moments);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
@@ -618,7 +618,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             }
             matrix_multiply_MxN_by_Nx1(first_moments, population_old_positive_frequency,
                     first_moments_term_positive_frequency, population_size, genome_size);
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 matrix_multiply_MxN_by_Nx1(first_moments, population_old_negative_frequency,
                         first_moments_term_negative_frequency, population_size, genome_size);
             #endif
@@ -631,20 +631,20 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
 
     double * third_moments = nullptr;
     double * third_moments_term_positive_frequency = nullptr;
-    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+    #ifdef DEAC_TWO_SIDED_POPULATION
         double * third_moments_term_negative_frequency = nullptr;
     #endif
     #ifdef USE_GPU
         double* d_third_moments;
         double* d_third_moments_term_positive_frequency;
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             double* d_third_moments_term_negative_frequency;
         #endif
     #endif
 
     if (use_third_moment) {
         third_moments_term_positive_frequency = (double*) malloc(bytes_third_moments_term);
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             third_moments_term_negative_frequency = (double*) malloc(bytes_third_moments_term);
         #endif
         for (size_t j=0; j<genome_size; j++) {
@@ -677,10 +677,8 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                     #endif
                 #endif
             #else
-                third_moments_term_positive_frequency[j] = df*pow(f,3)*f;
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-                    third_moments_term_negative_frequency[j] = -df*pow(f,3)*f;
-                #endif
+                third_moments_term_positive_frequency[j] =
+                        deac_numerics::zero_temperature_third_moment_term(f, df);
             #endif
         }
 
@@ -690,7 +688,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             GPU_ASSERT(deac_malloc_device(double, d_third_moments_term_positive_frequency, genome_size,     default_stream));
             GPU_ASSERT(deac_wait(default_stream));
             GPU_ASSERT(deac_memcpy_host_to_device(d_third_moments_term_positive_frequency, third_moments_term_positive_frequency, bytes_third_moments_term, default_stream));
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 GPU_ASSERT(deac_malloc_device(double, d_third_moments_term_negative_frequency, genome_size,     default_stream));
                 GPU_ASSERT(deac_wait(default_stream));
                 GPU_ASSERT(deac_memcpy_host_to_device(d_third_moments_term_negative_frequency, third_moments_term_negative_frequency, bytes_third_moments_term, default_stream));
@@ -702,14 +700,14 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             #ifdef USE_BLAS
                 gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_old_positive_frequency, d_third_moments_term_positive_frequency, 0.0, d_third_moments);
                 GPU_ASSERT(deac_wait(default_stream));
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_old_negative_frequency, d_third_moments_term_negative_frequency, 1.0, d_third_moments);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
             #else
                 gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_old_positive_frequency, d_third_moments_term_positive_frequency, 0.0, d_third_moments);
                 GPU_ASSERT(deac_wait(default_stream));
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_old_negative_frequency, d_third_moments_term_negative_frequency, 1.0, d_third_moments);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
@@ -720,7 +718,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             }
             matrix_multiply_MxN_by_Nx1(third_moments, population_old_positive_frequency,
                     third_moments_term_positive_frequency, population_size, genome_size);
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 matrix_multiply_MxN_by_Nx1(third_moments, population_old_negative_frequency,
                         third_moments_term_negative_frequency, population_size, genome_size);
             #endif
@@ -742,14 +740,14 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         #ifdef USE_BLAS
             gpu_blas_gemm(default_blas_handle, population_size, number_of_timeslices, genome_size, 1.0, d_population_old_positive_frequency, d_isf_term_positive_frequency, 0.0, d_isf_model);
             GPU_ASSERT(deac_wait(default_stream));
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 gpu_blas_gemm(default_blas_handle, population_size, number_of_timeslices, genome_size, 1.0, d_population_old_negative_frequency, d_isf_term_negative_frequency, 1.0, d_isf_model);
                 GPU_ASSERT(deac_wait(default_stream));
             #endif
         #else
             gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_old_positive_frequency, d_isf_term_positive_frequency, 0.0, d_isf_model);
             GPU_ASSERT(deac_wait(default_stream));
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_old_negative_frequency, d_isf_term_negative_frequency, 1.0, d_isf_model);
                 GPU_ASSERT(deac_wait(default_stream));
             #endif
@@ -761,7 +759,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         deac_numerics::accumulate_population_projection(
                 isf_model, isf_term_positive_frequency, population_old_positive_frequency,
                 number_of_timeslices, genome_size, population_size);
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             deac_numerics::accumulate_population_projection(
                     isf_model, isf_term_negative_frequency, population_old_negative_frequency,
                     number_of_timeslices, genome_size, population_size);
@@ -877,7 +875,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     double * crossover_probabilities_new_positive_frequency;
     crossover_probabilities_old_positive_frequency = (double*) malloc(bytes_crossover_probabilities);
     crossover_probabilities_new_positive_frequency = (double*) malloc(bytes_crossover_probabilities);
-    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+    #ifdef DEAC_TWO_SIDED_POPULATION
         double * crossover_probabilities_old_negative_frequency;
         double * crossover_probabilities_new_negative_frequency;
         crossover_probabilities_old_negative_frequency = (double*) malloc(bytes_crossover_probabilities);
@@ -886,7 +884,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
 
     for (size_t i=0; i<population_size; i++) {
         crossover_probabilities_old_positive_frequency[i] = crossover_probability;
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             crossover_probabilities_old_negative_frequency[i] = crossover_probability;
         #endif
     }
@@ -898,7 +896,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         GPU_ASSERT(deac_malloc_device(double, d_crossover_probabilities_new_positive_frequency, population_size, default_stream));
         GPU_ASSERT(deac_wait(default_stream));
         GPU_ASSERT(deac_memcpy_host_to_device(d_crossover_probabilities_old_positive_frequency, crossover_probabilities_old_positive_frequency, bytes_crossover_probabilities, default_stream));
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             double* d_crossover_probabilities_old_negative_frequency;
             double* d_crossover_probabilities_new_negative_frequency;
             GPU_ASSERT(deac_malloc_device(double, d_crossover_probabilities_old_negative_frequency, population_size, default_stream));
@@ -914,7 +912,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     double * differential_weights_new_positive_frequency;
     differential_weights_old_positive_frequency = (double*) malloc(bytes_differential_weights);
     differential_weights_new_positive_frequency = (double*) malloc(bytes_differential_weights);
-    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+    #ifdef DEAC_TWO_SIDED_POPULATION
         double * differential_weights_old_negative_frequency;
         double * differential_weights_new_negative_frequency;
         differential_weights_old_negative_frequency = (double*) malloc(bytes_differential_weights);
@@ -923,7 +921,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
 
     for (size_t i=0; i<population_size; i++) {
         differential_weights_old_positive_frequency[i] = differential_weight;
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             differential_weights_old_negative_frequency[i] = differential_weight;
         #endif
     }
@@ -935,7 +933,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         GPU_ASSERT(deac_malloc_device(double, d_differential_weights_new_positive_frequency, population_size, default_stream));
         GPU_ASSERT(deac_wait(default_stream));
         GPU_ASSERT(deac_memcpy_host_to_device(d_differential_weights_old_positive_frequency, differential_weights_old_positive_frequency, bytes_differential_weights, default_stream));
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             double* d_differential_weights_old_negative_frequency;
             double* d_differential_weights_new_negative_frequency;
             GPU_ASSERT(deac_malloc_device(double, d_differential_weights_old_negative_frequency, population_size, default_stream));
@@ -973,14 +971,14 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     size_t bytes_mutate_indices = sizeof(bool)*genome_size*population_size;
     bool* mutate_indices_positive_frequency;
     mutate_indices_positive_frequency = (bool*) malloc(bytes_mutate_indices);
-    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+    #ifdef DEAC_TWO_SIDED_POPULATION
         bool* mutate_indices_negative_frequency;
         mutate_indices_negative_frequency = (bool*) malloc(bytes_mutate_indices);
     #endif
     #ifdef USE_GPU
         bool* d_mutate_indices_positive_frequency;
         GPU_ASSERT(deac_malloc_device(bool, d_mutate_indices_positive_frequency, population_size*genome_size, default_stream));
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             bool* d_mutate_indices_negative_frequency;
             GPU_ASSERT(deac_malloc_device(bool, d_mutate_indices_negative_frequency, population_size*genome_size, default_stream));
         #endif
@@ -1009,10 +1007,10 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     #endif
 
     #ifdef USE_GPU
-        #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-            size_t size_rng_state  = 4*population_size*(genome_size + 1);
-        #else
+        #ifdef DEAC_TWO_SIDED_POPULATION
             size_t size_rng_state = 8*population_size*(genome_size + 1);
+        #else
+            size_t size_rng_state  = 4*population_size*(genome_size + 1);
         #endif
         size_t bytes_rng_state = sizeof(uint64_t)*size_rng_state;
 
@@ -1066,7 +1064,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             size_t grid_size_self_adapting_parameters = (population_size + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE;
             gpu_set_crossover_probabilities_new(stream_array[0], grid_size_self_adapting_parameters, d_rng_state, d_crossover_probabilities_new_positive_frequency, d_crossover_probabilities_old_positive_frequency, self_adapting_crossover_probability, population_size);
             gpu_set_differential_weights_new(stream_array[1 % MAX_GPU_STREAMS], grid_size_self_adapting_parameters, d_rng_state + 4*population_size, d_differential_weights_new_positive_frequency, d_differential_weights_old_positive_frequency, self_adapting_differential_weight_probability, population_size);
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 gpu_set_crossover_probabilities_new(stream_array[2 % MAX_GPU_STREAMS], grid_size_self_adapting_parameters, d_rng_state + 8*population_size, d_crossover_probabilities_new_negative_frequency, d_crossover_probabilities_old_negative_frequency, self_adapting_crossover_probability, population_size);
                 gpu_set_differential_weights_new(stream_array[3 % MAX_GPU_STREAMS], grid_size_self_adapting_parameters, d_rng_state + 12*population_size, d_differential_weights_new_negative_frequency, d_differential_weights_old_negative_frequency, self_adapting_differential_weight_probability, population_size);
             #endif
@@ -1088,7 +1086,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                     differential_weights_new_positive_frequency[i] = differential_weights_old_positive_frequency[i];
                 }
 
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     if ((xoshiro256p(rng) >> 11) * 0x1.0p-53 < self_adapting_crossover_probability) {
                         crossover_probabilities_new_negative_frequency[i] = (xoshiro256p(rng) >> 11) * 0x1.0p-53;
                     } else {
@@ -1109,7 +1107,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             size_t grid_size_set_mutate_indices = (population_size*genome_size + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE;
             gpu_set_mutant_indices(stream_array[0], grid_size_set_mutant_indices, d_rng_state, d_mutant_indices, population_size);
             gpu_set_mutate_indices(stream_array[1 % MAX_GPU_STREAMS], grid_size_set_mutate_indices, d_rng_state + 4*population_size, d_mutate_indices_positive_frequency, d_crossover_probabilities_new_positive_frequency, population_size, genome_size);
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 gpu_set_mutate_indices(stream_array[2 % MAX_GPU_STREAMS], grid_size_set_mutate_indices, d_rng_state + 4*population_size + 4*population_size*genome_size, d_mutate_indices_negative_frequency, d_crossover_probabilities_new_negative_frequency, population_size, genome_size);
             #endif
             for (auto& s : stream_array) {
@@ -1126,7 +1124,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                     mutate_indices_positive_frequency[i*genome_size + j] =
                             (xoshiro256p(rng) >> 11) < crossover_threshold_positive_frequency;
                 }
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     double crossover_rate_negative_frequency = crossover_probabilities_new_negative_frequency[i];
                     const uint64_t crossover_threshold_negative_frequency =
                             probability_threshold(crossover_rate_negative_frequency);
@@ -1141,7 +1139,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         #ifdef USE_GPU
             size_t grid_size_set_population_new = (population_size*genome_size + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE;
             gpu_set_population_new(stream_array[0], grid_size_set_population_new, d_population_new_positive_frequency, d_population_old_positive_frequency, d_mutant_indices, d_differential_weights_new_positive_frequency, d_mutate_indices_positive_frequency, population_size, genome_size);
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 gpu_set_population_new(stream_array[1 % MAX_GPU_STREAMS], grid_size_set_population_new, d_population_new_negative_frequency, d_population_old_negative_frequency, d_mutant_indices, d_differential_weights_new_negative_frequency, d_mutate_indices_negative_frequency, population_size, genome_size);
                 #if MAX_GPU_STREAMS > 1
                     GPU_ASSERT(deac_wait(stream_array[1]));
@@ -1149,7 +1147,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             #endif
             GPU_ASSERT(deac_wait(stream_array[0]));
 
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 size_t grid_size_match_population_zero = (population_size + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE;
                 gpu_match_population_zero(default_stream, grid_size_match_population_zero, d_population_new_negative_frequency, d_population_new_positive_frequency, population_size, genome_size);
                 GPU_ASSERT(deac_wait(default_stream));
@@ -1157,7 +1155,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         #else
             for (size_t i=0; i<population_size; i++) {
                 double F_positive_frequency = differential_weights_new_positive_frequency[i];
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     double F_negative_frequency = differential_weights_new_negative_frequency[i];
                 #endif
                 size_t mutant_index1 = mutant_indices[3*i];
@@ -1165,7 +1163,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 size_t mutant_index3 = mutant_indices[3*i + 2];
                 for (size_t j=0; j<genome_size; j++) {
                     bool mutate_positive_frequency = mutate_indices_positive_frequency[i*genome_size + j];
-                    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    #ifdef DEAC_TWO_SIDED_POPULATION
                         bool mutate_negative_frequency = mutate_indices_negative_frequency[i*genome_size + j];
                     #endif
                     if (mutate_positive_frequency) {
@@ -1183,7 +1181,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                     } else {
                         population_new_positive_frequency[i*genome_size + j] = population_old_positive_frequency[i*genome_size + j];
                     }
-                    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    #ifdef DEAC_TWO_SIDED_POPULATION
                         if (mutate_negative_frequency) {
                             #ifdef ALLOW_NEGATIVE_SPECTRAL_WEIGHT
                                 population_new_negative_frequency[i*genome_size + j] =
@@ -1214,21 +1212,21 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 #ifdef USE_BLAS
                     gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0/zeroth_moment, d_population_new_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
                     GPU_ASSERT(deac_wait(default_stream));
-                    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    #ifdef DEAC_TWO_SIDED_POPULATION
                         gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0/zeroth_moment, d_population_new_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
                         GPU_ASSERT(deac_wait(default_stream));
                     #endif
                 #else
                     gpu_deac_gemv(default_stream, population_size, genome_size, 1.0/zeroth_moment, d_population_new_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
                     GPU_ASSERT(deac_wait(default_stream));
-                    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    #ifdef DEAC_TWO_SIDED_POPULATION
                         gpu_deac_gemv(default_stream, population_size, genome_size, 1.0/zeroth_moment, d_population_new_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
                         GPU_ASSERT(deac_wait(default_stream));
                     #endif
                 #endif
 
                 gpu_deac_dgmmDiv1D(stream_array[0], d_population_new_positive_frequency, d_normalization, population_size, genome_size); 
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     gpu_deac_dgmmDiv1D(stream_array[1 % MAX_GPU_STREAMS], d_population_new_negative_frequency, d_normalization, population_size, genome_size); 
                     GPU_ASSERT(deac_wait(stream_array[1 % MAX_GPU_STREAMS]));
                     #if MAX_GPU_STREAMS > 1
@@ -1244,7 +1242,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 #else
                     matrix_multiply_MxN_by_Nx1(normalization, population_new_positive_frequency,
                             normalization_term_positive_frequency, population_size, genome_size);
-                    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    #ifdef DEAC_TWO_SIDED_POPULATION
                         matrix_multiply_MxN_by_Nx1(normalization, population_new_negative_frequency,
                                 normalization_term_negative_frequency, population_size, genome_size);
                     #endif
@@ -1252,7 +1250,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                         double _norm = normalization[i];
                         for (size_t j=0; j<genome_size; j++) {
                             population_new_positive_frequency[i*genome_size + j] *= zeroth_moment/_norm;
-                            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                            #ifdef DEAC_TWO_SIDED_POPULATION
                                 population_new_negative_frequency[i*genome_size + j] *= zeroth_moment/_norm;
                             #endif
                         }
@@ -1267,14 +1265,14 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             #ifdef USE_BLAS
                 gpu_blas_gemm(default_blas_handle, population_size, number_of_timeslices, genome_size, 1.0, d_population_new_positive_frequency, d_isf_term_positive_frequency, 0.0, d_isf_model);
                 GPU_ASSERT(deac_wait(default_stream));
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     gpu_blas_gemm(default_blas_handle, population_size, number_of_timeslices, genome_size, 1.0, d_population_new_negative_frequency, d_isf_term_negative_frequency, 1.0, d_isf_model);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
             #else
                 gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_new_positive_frequency, d_isf_term_positive_frequency, 0.0, d_isf_model);
                 GPU_ASSERT(deac_wait(default_stream));
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_new_negative_frequency, d_isf_term_negative_frequency, 1.0, d_isf_model);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
@@ -1286,7 +1284,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             deac_numerics::accumulate_population_projection(
                     isf_model, isf_term_positive_frequency, population_new_positive_frequency,
                     number_of_timeslices, genome_size, population_size);
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 deac_numerics::accumulate_population_projection(
                         isf_model, isf_term_negative_frequency, population_new_negative_frequency,
                         number_of_timeslices, genome_size, population_size);
@@ -1320,14 +1318,14 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 #ifdef USE_BLAS
                     gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_new_positive_frequency, d_first_moments_term_positive_frequency, 0.0, d_first_moments);
                     GPU_ASSERT(deac_wait(default_stream));
-                    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    #ifdef DEAC_TWO_SIDED_POPULATION
                         gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_new_negative_frequency, d_first_moments_term_negative_frequency, 1.0, d_first_moments);
                         GPU_ASSERT(deac_wait(default_stream));
                     #endif
                 #else
                     gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_new_positive_frequency, d_first_moments_term_positive_frequency, 0.0, d_first_moments);
                     GPU_ASSERT(deac_wait(default_stream));
-                    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    #ifdef DEAC_TWO_SIDED_POPULATION
                         gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_new_negative_frequency, d_first_moments_term_negative_frequency, 1.0, d_first_moments);
                         GPU_ASSERT(deac_wait(default_stream));
                     #endif
@@ -1338,7 +1336,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 }
                 matrix_multiply_MxN_by_Nx1(first_moments, population_new_positive_frequency,
                         first_moments_term_positive_frequency, population_size, genome_size);
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     matrix_multiply_MxN_by_Nx1(first_moments, population_new_negative_frequency,
                             first_moments_term_negative_frequency, population_size, genome_size);
                 #endif
@@ -1349,14 +1347,14 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 #ifdef USE_BLAS
                     gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_new_positive_frequency, d_third_moments_term_positive_frequency, 0.0, d_third_moments);
                     GPU_ASSERT(deac_wait(default_stream));
-                    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    #ifdef DEAC_TWO_SIDED_POPULATION
                         gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_new_negative_frequency, d_third_moments_term_negative_frequency, 1.0, d_third_moments);
                         GPU_ASSERT(deac_wait(default_stream));
                     #endif
                 #else
                     gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_new_positive_frequency, d_third_moments_term_positive_frequency, 0.0, d_third_moments);
                     GPU_ASSERT(deac_wait(default_stream));
-                    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    #ifdef DEAC_TWO_SIDED_POPULATION
                         gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_new_negative_frequency, d_third_moments_term_negative_frequency, 1.0, d_third_moments);
                         GPU_ASSERT(deac_wait(default_stream));
                     #endif
@@ -1367,7 +1365,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 }
                 matrix_multiply_MxN_by_Nx1(third_moments, population_new_positive_frequency,
                         third_moments_term_positive_frequency, population_size, genome_size);
-                #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                #ifdef DEAC_TWO_SIDED_POPULATION
                     matrix_multiply_MxN_by_Nx1(third_moments, population_new_negative_frequency,
                             third_moments_term_negative_frequency, population_size, genome_size);
                 #endif
@@ -1412,7 +1410,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             gpu_swap_control_parameters(stream_array[1 % MAX_GPU_STREAMS], grid_size_swap_control_parameters, d_differential_weights_old_positive_frequency, d_differential_weights_new_positive_frequency, d_rejection_indices, population_size);
             gpu_swap_populations(stream_array[2 % MAX_GPU_STREAMS], grid_size_swap_populations, d_population_old_positive_frequency, d_population_new_positive_frequency, d_rejection_indices, population_size, genome_size);
 
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 gpu_swap_control_parameters(stream_array[3 % MAX_GPU_STREAMS], grid_size_swap_control_parameters, d_crossover_probabilities_old_negative_frequency, d_crossover_probabilities_new_negative_frequency, d_rejection_indices, population_size);
                 gpu_swap_control_parameters(stream_array[4 % MAX_GPU_STREAMS], grid_size_swap_control_parameters, d_differential_weights_old_negative_frequency, d_differential_weights_new_negative_frequency, d_rejection_indices, population_size);
                 gpu_swap_populations(stream_array[5 % MAX_GPU_STREAMS], grid_size_swap_populations, d_population_old_negative_frequency, d_population_new_negative_frequency, d_rejection_indices, population_size, genome_size);
@@ -1456,13 +1454,13 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                     fitness_old[i] = _fitness;
                     crossover_probabilities_old_positive_frequency[i] = crossover_probabilities_new_positive_frequency[i];
                     differential_weights_old_positive_frequency[i] = differential_weights_new_positive_frequency[i];
-                    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    #ifdef DEAC_TWO_SIDED_POPULATION
                         crossover_probabilities_old_negative_frequency[i] = crossover_probabilities_new_negative_frequency[i];
                         differential_weights_old_negative_frequency[i] = differential_weights_new_negative_frequency[i];
                     #endif
                     for (size_t j=0; j<genome_size; j++) {
                         population_old_positive_frequency[i*genome_size + j] = population_new_positive_frequency[i*genome_size + j];
-                        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                        #ifdef DEAC_TWO_SIDED_POPULATION
                             population_old_negative_frequency[i*genome_size + j] = population_new_negative_frequency[i*genome_size + j];
                         #endif
                     }
@@ -1475,7 +1473,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     #ifdef USE_GPU
         GPU_ASSERT(deac_memcpy_device_to_host(fitness_old, d_fitness_old, bytes_fitness, stream_array[0]));
         GPU_ASSERT(deac_memcpy_device_to_host(population_old_positive_frequency, d_population_old_positive_frequency, bytes_population, stream_array[1 % MAX_GPU_STREAMS]));
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             GPU_ASSERT(deac_memcpy_device_to_host(population_old_negative_frequency, d_population_old_negative_frequency, bytes_population, stream_array[1 % MAX_GPU_STREAMS]));
         #endif
         if (track_stats) {
@@ -1491,23 +1489,23 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
 
     double * best_dsf;
     double * best_frequency;
-    #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-        best_dsf = (double*) malloc(sizeof(double)*genome_size);
-        best_frequency = (double*) malloc(sizeof(double)*genome_size);
-    #else
+    #ifdef DEAC_TWO_SIDED_POPULATION
         best_dsf = (double*) malloc(sizeof(double)*(2*genome_size - 1));
         best_frequency = (double*) malloc(sizeof(double)*(2*genome_size - 1));
+    #else
+        best_dsf = (double*) malloc(sizeof(double)*genome_size);
+        best_frequency = (double*) malloc(sizeof(double)*genome_size);
     #endif
     for (size_t i=0; i<genome_size; i++) {
         double f = frequency[i];
-        #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-            size_t idx_p = i;
-        #else
+        #ifdef DEAC_TWO_SIDED_POPULATION
             size_t idx_p = genome_size + i - 1;
             size_t idx_n = genome_size - i - 1;
+        #else
+            size_t idx_p = i;
         #endif
         best_frequency[idx_p] = f;
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             best_frequency[idx_n] = -f;
         #endif
         #ifdef USE_GPU
@@ -1566,7 +1564,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             #endif
         #else
             best_dsf[idx_p] = population_old_positive_frequency[idx_dsf];
-            #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            #ifdef DEAC_TWO_SIDED_POPULATION
                 best_dsf[idx_n] = population_old_negative_frequency[idx_dsf];
             #endif
         #endif
@@ -1588,23 +1586,23 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         #ifndef ZEROT
             std::string deac_prefix = "deac-" + spectra_type;
         #else
-            std::string deac_prefix = "deac-zT" + spectra_type;
+            std::string deac_prefix = "deac-zT";
         #endif
         std::string best_dsf_filename_str = string_format("%s_dsf_%s.bin",deac_prefix.c_str(),uuid_str.c_str());
         fs::path best_dsf_filename = save_directory / best_dsf_filename_str;
         std::string frequency_filename_str = string_format("%s_frequency_%s.bin",deac_prefix.c_str(),uuid_str.c_str());
         fs::path frequency_filename = save_directory / frequency_filename_str;
-        #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-            deac_io::write_binary_doubles(
-                    best_dsf_filename, std::span<const double>(best_dsf, genome_size));
-            deac_io::write_binary_doubles(
-                    frequency_filename, std::span<const double>(best_frequency, genome_size));
-        #else
+        #ifdef DEAC_TWO_SIDED_POPULATION
             const size_t output_size = 2*genome_size - 1;
             deac_io::write_binary_doubles(
                     best_dsf_filename, std::span<const double>(best_dsf, output_size));
             deac_io::write_binary_doubles(
                     frequency_filename, std::span<const double>(best_frequency, output_size));
+        #else
+            deac_io::write_binary_doubles(
+                    best_dsf_filename, std::span<const double>(best_dsf, genome_size));
+            deac_io::write_binary_doubles(
+                    frequency_filename, std::span<const double>(best_frequency, genome_size));
         #endif
         fs::path fitness_mean_filename;
         fs::path fitness_minimum_filename;
@@ -1642,7 +1640,11 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         #ifdef USE_NORMALIZATION_MODEL
             log << "build: USE_NORMALIZATION_MODEL" << std::endl;
         #endif
-        log << "kernel: " << spectra_type << std::endl;
+        #ifndef ZEROT
+            log << "kernel: " << spectra_type << std::endl;
+        #else
+            log << "kernel: zero-temperature-positive-laplace" << std::endl;
+        #endif
 
         // Input parameters
         log << "temperature: " << temperature << std::endl;
@@ -1728,7 +1730,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     free(differential_weights_new_positive_frequency);
     free(mutate_indices_positive_frequency);
 
-    #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+    #ifdef DEAC_TWO_SIDED_POPULATION
         free(isf_term_negative_frequency);
         free(population_old_negative_frequency);
         free(population_new_negative_frequency);
@@ -1799,7 +1801,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         GPU_ASSERT(deac_free(d_differential_weights_new_positive_frequency,    stream_array[25 % MAX_GPU_STREAMS]));
         GPU_ASSERT(deac_free(d_mutate_indices_positive_frequency,              stream_array[26 % MAX_GPU_STREAMS]));
 
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             GPU_ASSERT(deac_free(d_isf_term_negative_frequency,       stream_array[27 % MAX_GPU_STREAMS]));
             GPU_ASSERT(deac_free(d_population_old_negative_frequency, stream_array[28 % MAX_GPU_STREAMS]));
             GPU_ASSERT(deac_free(d_population_new_negative_frequency, stream_array[29 % MAX_GPU_STREAMS]));
@@ -1848,7 +1850,11 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
 int deac_main (int argc, char *argv[]) {
     argparse::ArgumentParser program("deac-cpp", "2.0.0-rc1");
     program.add_argument("-T", "--temperature")
-        .help("Temperature of system.")
+        #ifndef ZEROT
+            .help("Temperature of system. Must be positive.")
+        #else
+            .help("Ignored by ZeroT builds; the temperature is fixed to zero.")
+        #endif
         .default_value(0.0)
         .action([](const std::string& value) { return std::stod(value); });
     program.add_argument("-N", "--number_of_generations")
@@ -1924,7 +1930,10 @@ int deac_main (int argc, char *argv[]) {
         .default_value(false)
         .implicit_value(true);
     program.add_argument("--spectra_type")
-        #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef ZEROT
+            .help("ZeroT uses the fixed one-sided positive-frequency Laplace kernel [positive].")
+            .default_value("positive");
+        #elif defined(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF)
             .help("Choose spectral type for kernel factors [bdsf].")
             .default_value("bdsf");
         #else
@@ -1965,13 +1974,17 @@ int deac_main (int argc, char *argv[]) {
     std::cout << "uuid: " << uuid_str << std::endl;
 
     std::string spectra_type = program.get<std::string>("--spectra_type");
-    #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+    #ifdef ZEROT
+        std::string valid_spectra_type = "positive";
+    #elif defined(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF)
         std::string valid_spectra_type = "bdsf";
     #else
         std::string valid_spectra_type = "spbsf, spfsf, bfull, ffull";
     #endif
     if (!(
-         #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+         #ifdef ZEROT
+             (spectra_type == "positive")
+         #elif defined(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF)
              (spectra_type == "bdsf")
          #else
              (spectra_type == "spbsf") ||
@@ -2002,7 +2015,7 @@ int deac_main (int argc, char *argv[]) {
         if (!std::isfinite(imaginary_time[i]) || !std::isfinite(isf[i]) || !std::isfinite(isf_error[i])) {
             fail_with_error("ISF input file contains non-finite values");
         }
-        #ifndef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+        #ifdef DEAC_TWO_SIDED_POPULATION
             if (((spectra_type == "spbsf") || (spectra_type == "spfsf")) && (isf[i] > 0.0)) {
                 fail_with_error("positive ISF values are not supported for single-particle spectra");
             }
@@ -2096,7 +2109,7 @@ int deac_main (int argc, char *argv[]) {
     #ifndef ZEROT
         std::string deac_prefix = "deac-" + spectra_type;
     #else
-        std::string deac_prefix = "deac-zT" + spectra_type;
+        std::string deac_prefix = "deac-zT";
     #endif
     std::string log_filename_str = string_format("%s_log_%s.dat",deac_prefix.c_str(),uuid_str.c_str());
     fs::path log_filename = save_directory / log_filename_str;

--- a/src/deac/src/zero_temperature_kernel.hpp
+++ b/src/deac/src/zero_temperature_kernel.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cmath>
+
+namespace deac_numerics {
+
+// Zero-temperature DSF forward kernel on the non-negative frequency grid:
+//     F(tau) = integral_0^infinity exp(-tau*omega) S(omega) d omega.
+// The caller supplies the frequency quadrature weight.
+inline double zero_temperature_laplace_term(
+        double tau, double frequency, double quadrature_weight) noexcept {
+    return quadrature_weight*std::exp(-tau*frequency);
+}
+
+inline double zero_temperature_third_moment_term(
+        double frequency, double quadrature_weight) noexcept {
+    return quadrature_weight*frequency*frequency*frequency;
+}
+
+}  // namespace deac_numerics

--- a/test/deac_parity_test.py
+++ b/test/deac_parity_test.py
@@ -52,13 +52,14 @@ def run_deac(
     normalize=False,
     negative_first_moment=False,
     population_size="8",
+    zero_temperature=False,
 ):
     workdir.mkdir(parents=True)
     save_dir = workdir / "results"
     command = [
         exe,
         "-T",
-        "1.0",
+        "0.0" if zero_temperature else "1.0",
         "-N",
         "2",
         "-P",
@@ -128,8 +129,12 @@ def assert_outputs_match(
     absolute_tolerance,
     relative_tolerance,
     detailed_balance=False,
+    zero_temperature=False,
 ):
-    prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
+    if zero_temperature:
+        prefix = "deac-zT"
+    else:
+        prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
     for suffix in [
         "frequency",
         "dsf",
@@ -176,6 +181,7 @@ def main():
     parser.add_argument("--absolute-tolerance", type=float, default=1e-9)
     parser.add_argument("--relative-tolerance", type=float, default=1e-9)
     parser.add_argument("--detailed-balance", action="store_true")
+    parser.add_argument("--zero-temperature", action="store_true")
     args = parser.parse_args()
 
     reference_exe = str(Path(args.reference_exe))
@@ -190,11 +196,13 @@ def main():
     workdir.mkdir(parents=True)
 
     fixture = workdir / "tiny-isf.bin"
+    if args.zero_temperature:
+        isf = [1.0, 0.85, 0.72, 0.61]
+    else:
+        isf = [-1.0, -0.85, -0.72, -0.61]
     write_doubles(
         fixture,
-        [0.0, 0.2, 0.4, 0.6]
-        + [-1.0, -0.85, -0.72, -0.61]
-        + [0.05, 0.05, 0.05, 0.05],
+        [0.0, 0.2, 0.4, 0.6] + isf + [0.05, 0.05, 0.05, 0.05],
     )
     frequency_file = workdir / "frequency.bin"
     write_doubles(frequency_file, [0.0, 0.7, 1.8, 3.0])
@@ -205,7 +213,7 @@ def main():
         # with the default GPU_BLOCK_SIZE=1024.
         ("normalize_large_population", "19", True, False, "1028"),
     ]
-    if args.detailed_balance:
+    if args.detailed_balance and not args.zero_temperature:
         cases.append(("negative_first_moment", "23", False, True, "8"))
     for case_name, seed, normalize, negative_first_moment, population_size in cases:
         reference_dir = run_deac(
@@ -217,6 +225,7 @@ def main():
             normalize=normalize,
             negative_first_moment=negative_first_moment,
             population_size=population_size,
+            zero_temperature=args.zero_temperature,
         )
         candidate_dir = run_deac(
             candidate_exe,
@@ -227,6 +236,7 @@ def main():
             normalize=normalize,
             negative_first_moment=negative_first_moment,
             population_size=population_size,
+            zero_temperature=args.zero_temperature,
         )
         assert_outputs_match(
             reference_dir,
@@ -235,6 +245,7 @@ def main():
             args.absolute_tolerance,
             args.relative_tolerance,
             args.detailed_balance,
+            args.zero_temperature,
         )
 
 

--- a/test/deac_smoke_test.py
+++ b/test/deac_smoke_test.py
@@ -19,6 +19,7 @@ SMOKE_CASES = [
     "normalize",
     "normalize_large_population",
     "first_moment",
+    "third_moment",
     "negative_first_moment",
     "track_stats",
     "nested_output",
@@ -58,6 +59,13 @@ VALIDATION_CASES = [
 
 def write_doubles(path, values):
     path.write_bytes(struct.pack("<" + "d" * len(values), *values))
+
+
+def read_doubles(path):
+    data = path.read_bytes()
+    if len(data) % 8 != 0:
+        raise AssertionError(f"{path} does not contain a whole number of doubles")
+    return struct.unpack("<" + "d" * (len(data) // 8), data)
 
 
 def write_fixture(path, tau=None, isf=None, error=None):
@@ -115,13 +123,14 @@ def deac_command(
     extra_args=None,
     save_directory=None,
     uuid=None,
+    zero_temperature=False,
 ):
     if save_directory is None:
         save_directory = workdir / "results"
     command = [
         exe,
         "-T",
-        "1.0",
+        "0.0" if zero_temperature else "1.0",
         "-N",
         number_of_generations,
         "-P",
@@ -153,9 +162,14 @@ def assert_file_size(path, expected_size):
         )
 
 
-def run_deac_case(exe, workdir, case_name, detailed_balance=False):
+def run_deac_case(
+    exe, workdir, case_name, detailed_balance=False, zero_temperature=False
+):
     fixture = workdir / "tiny-isf.bin"
-    write_fixture(fixture)
+    if zero_temperature:
+        write_positive_fixture(fixture)
+    else:
+        write_fixture(fixture)
     save_dir = (
         workdir / "nested" / "result" / "directory"
         if case_name == "nested_output"
@@ -168,6 +182,7 @@ def run_deac_case(exe, workdir, case_name, detailed_balance=False):
         "normalize": "2",
         "normalize_large_population": "6",
         "first_moment": "3",
+        "third_moment": "11",
         "negative_first_moment": "5",
         "track_stats": "4",
         "nested_output": "10",
@@ -182,6 +197,10 @@ def run_deac_case(exe, workdir, case_name, detailed_balance=False):
             population_size = "1028"
     elif case_name == "first_moment":
         extra_args.extend(["--first_moment", "0.5"])
+    elif case_name == "third_moment":
+        extra_args.extend(
+            ["--third_moment", "0.5", "--third_moment_error", "0.1"]
+        )
     elif case_name == "negative_first_moment":
         extra_args.append("--use_negative_first_moment")
     elif case_name == "track_stats":
@@ -222,14 +241,28 @@ def run_deac_case(exe, workdir, case_name, detailed_balance=False):
         seed=seed,
         extra_args=extra_args,
         save_directory=save_dir,
+        zero_temperature=zero_temperature,
     )
 
     run_command(command, workdir, expected_output="minimum_fitness:")
 
-    expected_spectrum_bytes = (8 if detailed_balance else 2 * 8 - 1) * 8
-    prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
+    expected_spectrum_bytes = (
+        8 if detailed_balance or zero_temperature else 2 * 8 - 1
+    ) * 8
+    if zero_temperature:
+        prefix = "deac-zT"
+    else:
+        prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
     assert_file_size(save_dir / f"{prefix}_dsf_{seed}.bin", expected_spectrum_bytes)
     assert_file_size(save_dir / f"{prefix}_frequency_{seed}.bin", expected_spectrum_bytes)
+
+    if zero_temperature:
+        frequencies = read_doubles(save_dir / f"{prefix}_frequency_{seed}.bin")
+        if len(frequencies) != 8 or any(frequency < 0.0 for frequency in frequencies):
+            raise AssertionError(
+                "expected ZeroT output to contain only the eight non-negative "
+                f"input-grid frequencies, got {frequencies}"
+            )
 
     log_path = save_dir / f"{prefix}_log_{seed}.dat"
     if not log_path.exists():
@@ -237,6 +270,13 @@ def run_deac_case(exe, workdir, case_name, detailed_balance=False):
     log_text = log_path.read_text()
     if "minimum_fitness:" not in log_text:
         raise AssertionError(f"expected {log_path} to contain minimum_fitness")
+    if zero_temperature:
+        if "kernel: zero-temperature-positive-laplace" not in log_text:
+            raise AssertionError(
+                f"expected {log_path} to identify the ZeroT Laplace kernel"
+            )
+        if "temperature: 0" not in log_text:
+            raise AssertionError(f"expected {log_path} to record zero temperature")
 
     if detailed_balance and case_name == "negative_first_moment":
         error_line = next(
@@ -270,7 +310,9 @@ def run_deac_case(exe, workdir, case_name, detailed_balance=False):
             raise AssertionError("tracked-stat filenames were not written to the log")
 
 
-def run_validation_case(exe, workdir, case_name, detailed_balance=False):
+def run_validation_case(
+    exe, workdir, case_name, detailed_balance=False, zero_temperature=False
+):
     fixture = workdir / "invalid-isf.bin"
     frequency_file = workdir / "frequency.bin"
     command_options = {}
@@ -299,7 +341,7 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
         expected_output = "could not open binary input"
     elif case_name == "positive_isf_single_particle":
         write_positive_fixture(fixture)
-        if detailed_balance:
+        if detailed_balance or zero_temperature:
             expected_returncode = 0
             expected_output = "minimum_fitness:"
         else:
@@ -349,6 +391,7 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
                 workdir,
                 fixture,
                 extra_args=inactive_option,
+                zero_temperature=zero_temperature,
             )
             run_command(
                 command,
@@ -426,7 +469,10 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
         uuid = "log-destination"
         save_directory = workdir / "results"
         save_directory.mkdir()
-        prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
+        if zero_temperature:
+            prefix = "deac-zT"
+        else:
+            prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
         (save_directory / f"{prefix}_log_{uuid}.dat").mkdir()
         expected_output = "could not open log file"
     elif case_name == "result_destination_is_directory":
@@ -434,7 +480,10 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
         uuid = "result-destination"
         save_directory = workdir / "results"
         save_directory.mkdir()
-        prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
+        if zero_temperature:
+            prefix = "deac-zT"
+        else:
+            prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
         (save_directory / f"{prefix}_dsf_{uuid}.bin").mkdir()
         expected_output = "could not open binary output"
     elif case_name == "unsupported_negative_first_moment":
@@ -454,6 +503,7 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
         extra_args=extra_args,
         save_directory=save_directory,
         uuid=uuid,
+        zero_temperature=zero_temperature,
         **command_options,
     )
     save_dir = save_directory if save_directory is not None else workdir / "results"
@@ -475,11 +525,17 @@ def run_validation_case(exe, workdir, case_name, detailed_balance=False):
     if case_name == "log_destination_is_directory":
         if "minimum_fitness:" in result.stdout:
             raise AssertionError("evolution started despite an invalid initial log destination")
-        prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
+        if zero_temperature:
+            prefix = "deac-zT"
+        else:
+            prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
         if (save_dir / f"{prefix}_dsf_{uuid}.bin").exists():
             raise AssertionError("invalid initial log destination produced a spectrum")
     elif case_name == "result_destination_is_directory":
-        prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
+        if zero_temperature:
+            prefix = "deac-zT"
+        else:
+            prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
         if (save_dir / f"{prefix}_frequency_{uuid}.bin").exists():
             raise AssertionError("solver continued writing after the first result I/O failure")
     if case_name.startswith("bad_") and case_name in {
@@ -505,6 +561,7 @@ def main():
     parser.add_argument("--exe", required=True)
     parser.add_argument("--workdir", required=True)
     parser.add_argument("--detailed-balance", action="store_true")
+    parser.add_argument("--zero-temperature", action="store_true")
     parser.add_argument(
         "--case",
         required=True,
@@ -549,6 +606,16 @@ def main():
                 "expected --help to omit inactive differential-weight range option\n"
                 f"output:\n{result.stdout}"
             )
+        if args.zero_temperature:
+            for expected_output in (
+                "temperature is fixed to zero",
+                "one-sided positive-frequency Laplace kernel",
+            ):
+                if expected_output not in result.stdout:
+                    raise AssertionError(
+                        f"expected ZeroT --help to contain {expected_output!r}\n"
+                        f"output:\n{result.stdout}"
+                    )
     elif args.case == "version":
         result = run_command([exe, "-v"], workdir)
         if result.stdout.strip() != "2.0.0-rc1":
@@ -572,9 +639,21 @@ def main():
             expected_output="Please choose spectra_type",
         )
     elif args.case in VALIDATION_CASES:
-        run_validation_case(exe, workdir, args.case, args.detailed_balance)
+        run_validation_case(
+            exe,
+            workdir,
+            args.case,
+            args.detailed_balance,
+            args.zero_temperature,
+        )
     else:
-        run_deac_case(exe, workdir, args.case, args.detailed_balance)
+        run_deac_case(
+            exe,
+            workdir,
+            args.case,
+            args.detailed_balance,
+            args.zero_temperature,
+        )
 
 
 if __name__ == "__main__":

--- a/test/zero_temperature_kernel_test.cpp
+++ b/test/zero_temperature_kernel_test.cpp
@@ -1,0 +1,41 @@
+#include "zero_temperature_kernel.hpp"
+
+#include <cmath>
+
+namespace {
+
+bool check_close(double actual, double expected) {
+    return std::abs(actual - expected) <= 1e-14;
+}
+
+}  // namespace
+
+int main() {
+    using deac_numerics::zero_temperature_laplace_term;
+    using deac_numerics::zero_temperature_third_moment_term;
+
+    if (!check_close(zero_temperature_laplace_term(0.0, 3.0, 0.25), 0.25)
+            || !check_close(zero_temperature_laplace_term(2.0, 0.0, 0.75), 0.75)
+            || !check_close(
+                    zero_temperature_laplace_term(0.5, 2.0, 1.5),
+                    1.5*std::exp(-1.0))
+            || !check_close(
+                    zero_temperature_third_moment_term(2.0, 1.5), 12.0)) {
+        return 1;
+    }
+
+    // A small nonuniform-grid forward projection protects both the one-sided
+    // Laplace factors and the caller-owned quadrature weights.
+    const double spectrum[] = {2.0, 3.0, 5.0};
+    const double frequency[] = {0.0, 1.0, 3.0};
+    const double weights[] = {0.25, 1.5, 0.75};
+    constexpr double tau = 0.4;
+    double projection = 0.0;
+    for (int index = 0; index < 3; ++index) {
+        projection += spectrum[index]*zero_temperature_laplace_term(
+                tau, frequency[index], weights[index]);
+    }
+    const double expected =
+            2.0*0.25 + 3.0*1.5*std::exp(-0.4) + 5.0*0.75*std::exp(-1.2);
+    return check_close(projection, expected) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- restore the original ZeroT problem as one non-negative-frequency population with the weighted Laplace kernel `w * exp(-tau * omega)`
- exclude every finite-temperature negative-frequency allocation, evolution path, projection, output slot, and device RNG segment from ZeroT builds
- restore the historical ZeroT normalization (`w`), first-moment (`w * omega`), third-moment (`w * omega^3`), raw-spectrum output, `genome_size` output length, and `deac-zT_*` filenames
- factor and unit-test the ZeroT kernel and third-moment terms; extend CLI smoke and CPU/backend parity tests for the explicit ZeroT mode
- document the physics boundary and limit the supported ZeroT claim to CPU

## Historical basis

Commit `98f7e8369e83feaa791aaf99e6419ee215aa6c6b` introduced ZeroT with one population, `omega >= 0`, `w * exp(-tau * omega)`, and genome-sized output. Commit `ba1301d3454b483b321a5db6e3f99e0d640b1bb3` later introduced separate positive/negative-frequency populations; the ZeroT preprocessor branch was carried into that split and began referencing finite-temperature `beta` and `periodicity`. This change restores the earlier, internally consistent semantics instead of inventing a negative-frequency zero-temperature kernel.

Independent review also found that the inherited ZeroT third-moment branch had drifted from `w * omega^3` to `w * omega^4`; this PR restores and directly tests the historical cubic weight.

## Validation

Baseline: `752f31ffef68acdd3c89724c2cacf9a67f6076a3`.

CPU and sanitizer gates:

- IntelLLVM 2026.1.0, CPU `ZeroT`: 45/45 CTest passed
- IntelLLVM 2026.1.0, CPU `ZeroTDebug`: 45/45 CTest passed
- GCC 14.3.0, CPU `ZeroT`: 45/45 CTest passed
- IntelLLVM 2026.1.0, ASan+UBSan `ZeroTDebug`: 45/45 CTest passed with leak detection and halt-on-error enabled
- IntelLLVM 2026.1.0 finite standard, hyperbolic, and bosonic detailed-balance builds: 45/45 CTest passed in each configuration

Finite-temperature byte parity against executables built from the baseline SHA:

- standard: 21/21 generated binary artifacts identical; manifest SHA-256 `15ab49340a8aeb1117cd056a15a6fd32a416f7763ea7f11049f8516c63be59d0`
- hyperbolic: 21/21 identical; manifest SHA-256 `9a0046d3a65de7be779e18ddb1054da6abcf40110164140f94c8545500ebf8d5`
- detailed balance: 25/25 identical; manifest SHA-256 `4a0c4c2405e7f20b41ed6771867e84a7adecabbb72584950cd10aae0e99412e6`

Each manifest digest is over sorted `sha256  relative-path` lines. The separate parity harness also passed at zero tolerance for all three finite configurations.

Backend audit:

- Intel Data Center GPU Max 1550, IntelLLVM 2026.1.0, Level Zero, block 256/subgroup 16: 46/46 passed, including the registered ZeroT CPU-reference/SYCL parity test
- a focused ZeroT third-moment early-stop comparison had byte-identical frequency, spectrum, and minimum fitness; max absolute differences were `3.64e-12` for fitness mean and `2.98e-8` for squared fitness mean
- CUDA and HIP toolchains are not installed on this node, so those combinations were only statically audited and are not claimed
- despite the local SYCL evidence, README support language remains CPU-only until accelerator ZeroT is covered by the release test matrix

Fixes #8