### PR TITLE
fix: normalize evolved CPU candidates

### DIFF
--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -378,6 +378,15 @@ if(Python3_Interpreter_FOUND)
                 ${DEAC_SMOKE_VARIANT_ARGS}
         )
     endforeach()
+    add_test(
+        NAME deac_normalization_evolution
+        COMMAND
+            ${Python3_EXECUTABLE}
+            ${CMAKE_SOURCE_DIR}/../test/deac_normalization_evolution_test.py
+            --exe $<TARGET_FILE:${exe}>
+            --workdir ${CMAKE_CURRENT_BINARY_DIR}/normalization-evolution
+            ${DEAC_SMOKE_VARIANT_ARGS}
+    )
     set(DEAC_PARITY_REFERENCE_EXE "" CACHE FILEPATH "Reference deac executable for backend parity tests.")
     if(NOT "${DEAC_PARITY_REFERENCE_EXE}" STREQUAL "")
         add_test(

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -1238,24 +1238,21 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 for (size_t i=0; i<population_size; i++) {
                     normalization[i] = 0.0;
                 }
-                #ifndef SINGLE_PARTICLE_FERMIONIC_SPECTRAL_FUNCTION
-                #else
-                    matrix_multiply_MxN_by_Nx1(normalization, population_new_positive_frequency,
-                            normalization_term_positive_frequency, population_size, genome_size);
-                    #ifdef DEAC_TWO_SIDED_POPULATION
-                        matrix_multiply_MxN_by_Nx1(normalization, population_new_negative_frequency,
-                                normalization_term_negative_frequency, population_size, genome_size);
-                    #endif
-                    for (size_t i=0; i<population_size; i++) {
-                        double _norm = normalization[i];
-                        for (size_t j=0; j<genome_size; j++) {
-                            population_new_positive_frequency[i*genome_size + j] *= zeroth_moment/_norm;
-                            #ifdef DEAC_TWO_SIDED_POPULATION
-                                population_new_negative_frequency[i*genome_size + j] *= zeroth_moment/_norm;
-                            #endif
-                        }
-                    }
+                matrix_multiply_MxN_by_Nx1(normalization, population_new_positive_frequency,
+                        normalization_term_positive_frequency, population_size, genome_size);
+                #ifdef DEAC_TWO_SIDED_POPULATION
+                    matrix_multiply_MxN_by_Nx1(normalization, population_new_negative_frequency,
+                            normalization_term_negative_frequency, population_size, genome_size);
                 #endif
+                for (size_t i=0; i<population_size; i++) {
+                    double _norm = normalization[i];
+                    for (size_t j=0; j<genome_size; j++) {
+                        population_new_positive_frequency[i*genome_size + j] *= zeroth_moment/_norm;
+                        #ifdef DEAC_TWO_SIDED_POPULATION
+                            population_new_negative_frequency[i*genome_size + j] *= zeroth_moment/_norm;
+                        #endif
+                    }
+                }
             #endif
         }
 

--- a/test/deac_normalization_evolution_test.py
+++ b/test/deac_normalization_evolution_test.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+import argparse
+import math
+import shutil
+import struct
+import subprocess
+from pathlib import Path
+
+
+def write_doubles(path, values):
+    path.write_bytes(struct.pack("<" + "d" * len(values), *values))
+
+
+def read_doubles(path):
+    data = path.read_bytes()
+    if len(data) % 8 != 0:
+        raise AssertionError(f"{path} does not contain a whole number of doubles")
+    return struct.unpack("<" + "d" * (len(data) // 8), data)
+
+
+def trapezoidal_weights(coordinates):
+    weights = [0.0] * len(coordinates)
+    weights[0] = 0.5 * (coordinates[1] - coordinates[0])
+    for index in range(1, len(coordinates) - 1):
+        weights[index] = 0.5 * (coordinates[index + 1] - coordinates[index - 1])
+    weights[-1] = 0.5 * (coordinates[-1] - coordinates[-2])
+    return weights
+
+
+def run_normalized_evolution(
+    exe,
+    workdir,
+    fixture,
+    frequency_file,
+    frequency,
+    observed_at_zero,
+    seed,
+    detailed_balance,
+    zero_temperature,
+):
+    save_dir = workdir / f"results-{seed}"
+    command = [
+        exe,
+        "--temperature",
+        "0.0" if zero_temperature else "1.0",
+        "--number_of_generations",
+        "2",
+        "--population_size",
+        "4",
+        "--frequency_file",
+        str(frequency_file),
+        "--normalize",
+        "--crossover_probability",
+        "1",
+        "--self_adapting_crossover_probability",
+        "0",
+        "--differential_weight",
+        "2",
+        "--self_adapting_differential_weight_probability",
+        "0",
+        "--stop_minimum_fitness",
+        "-1",
+        "--track_stats",
+        "--save_directory",
+        str(save_dir),
+        "--seed",
+        seed,
+        "--uuid",
+        seed,
+    ]
+    if not detailed_balance and not zero_temperature:
+        command.extend(["--spectra_type", "bfull"])
+    command.append(str(fixture))
+
+    result = subprocess.run(
+        command,
+        cwd=workdir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"normalization evolution run failed with {result.returncode}\n"
+            f"command: {' '.join(map(str, command))}\noutput:\n{result.stdout}"
+        )
+    if "generation: 1" not in result.stdout:
+        raise AssertionError(
+            f"seed {seed} did not complete the requested evolution step:\n"
+            f"{result.stdout}"
+        )
+
+    if zero_temperature:
+        prefix = "deac-zT"
+    elif detailed_balance:
+        prefix = "deac-bdsf"
+    else:
+        prefix = "deac-bfull"
+    output_frequency = read_doubles(save_dir / f"{prefix}_frequency_{seed}.bin")
+    output_spectrum = read_doubles(save_dir / f"{prefix}_dsf_{seed}.bin")
+    fitness_minimum = read_doubles(
+        save_dir / f"{prefix}_stats_fitness-minimum_{seed}.bin"
+    )
+    if len(output_frequency) != len(output_spectrum):
+        raise AssertionError(
+            f"frequency/spectrum size mismatch for seed {seed}: "
+            f"{len(output_frequency)} != {len(output_spectrum)}"
+        )
+    expected_frequency = (
+        tuple(frequency)
+        if detailed_balance or zero_temperature
+        else (-frequency[-1], -frequency[0], frequency[-1])
+    )
+    if output_frequency != expected_frequency:
+        raise AssertionError(
+            f"seed {seed} output frequency mismatch: "
+            f"expected {expected_frequency}, got {output_frequency}"
+        )
+    if any(not math.isfinite(value) for value in output_spectrum):
+        raise AssertionError(f"seed {seed} produced an invalid spectrum")
+    if len(fitness_minimum) != 2 or any(
+        not math.isfinite(value) for value in fitness_minimum
+    ):
+        raise AssertionError(
+            f"seed {seed} produced invalid fitness minima: {fitness_minimum}"
+        )
+
+    weights = trapezoidal_weights(frequency)
+    if zero_temperature:
+        normalization = sum(
+            weight * spectrum
+            for weight, spectrum in zip(weights, output_spectrum)
+        )
+    elif detailed_balance:
+        beta = 1.0
+        normalization = sum(
+            weight * spectrum * (1.0 + math.exp(-beta * omega))
+            for weight, omega, spectrum in zip(
+                weights, output_frequency, output_spectrum
+            )
+        )
+    else:
+        genome_size = len(frequency)
+        normalization = 0.0
+        for index, weight in enumerate(weights):
+            positive_index = genome_size + index - 1
+            negative_index = genome_size - index - 1
+            normalization += weight * (
+                output_spectrum[positive_index]
+                + output_spectrum[negative_index]
+            )
+
+    if not math.isclose(
+        normalization, observed_at_zero, rel_tol=1e-12, abs_tol=1e-12
+    ):
+        raise AssertionError(
+            f"seed {seed} evolved spectrum violated --normalize: "
+            f"expected {observed_at_zero}, got {normalization}"
+        )
+    return fitness_minimum[1] < fitness_minimum[0]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exe", required=True)
+    parser.add_argument("--workdir", required=True)
+    parser.add_argument("--detailed-balance", action="store_true")
+    parser.add_argument("--zero-temperature", action="store_true")
+    parser.add_argument("--seeds", nargs="+", default=("2", "3", "4", "34"))
+    args = parser.parse_args()
+
+    exe = str(Path(args.exe))
+    if not Path(exe).is_file():
+        raise AssertionError(f"expected executable {exe} to exist")
+
+    workdir = Path(args.workdir)
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+
+    tau = [0.0, 0.2, 0.4, 0.6]
+    observed = [1.0, 0.85, 0.72, 0.61]
+    errors = [0.05, 0.05, 0.05, 0.05]
+    frequency = [0.0, 3.0]
+    fixture = workdir / "positive-isf.bin"
+    frequency_file = workdir / "frequency.bin"
+    write_doubles(fixture, tau + observed + errors)
+    write_doubles(frequency_file, frequency)
+
+    # Different model/backend RNG streams accept different trials. Across this
+    # fixed seed set at least one final best member comes from the evolution step.
+    accepted_improved_trial = False
+    for seed in args.seeds:
+        accepted_improved_trial |= run_normalized_evolution(
+            exe,
+            workdir,
+            fixture,
+            frequency_file,
+            frequency,
+            observed[0],
+            seed,
+            args.detailed_balance,
+            args.zero_temperature,
+        )
+    if not accepted_improved_trial:
+        raise AssertionError(
+            "normalization regression did not accept an improved evolved trial"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- normalize every evolved CPU candidate whenever `--normalize` is enabled, removing the stale inverted `SINGLE_PARTICLE_FERMIONIC_SPECTRAL_FUNCTION` guard
- apply the joint quadrature normalization to both positive- and, when compiled, negative-frequency populations, matching initial-population and GPU behavior
- add a deterministic CTest regression that runs a real evolution step, requires an accepted fitness improvement, and validates the model-specific output normalization

## Numerical regression

The new test fails on the `d0c13ba` baseline with GCC 14.3 after an accepted seed-34 evolution:

| CPU variant | requested moment | baseline evolved moment | fixed |
| --- | ---: | ---: | ---: |
| standard, two-sided `bfull` | 1.0 | 1.0908223411299347 | 1.0 within 1e-12 |
| bosonic detailed balance, `bdsf` | 1.0 | 1.1623216471859419 | 1.0 within 1e-12 |

Seeded CPU spectra can therefore change once evolution accepts a trial. That is the intended correctness change; this PR does not claim byte-identical normalized CPU output.

## Validation

- GCC 14.3 CPU: standard, detailed-balance, hyperbolic, normalization-model, ZeroT, and ZeroTDebug variants each pass 46/46 tests
- GCC 14.3 Debug standard build with ASan+UBSan: 46/46
- IntelLLVM 2026.1 SYCL on Intel Data Center GPU Max 1550: standard 47/47 and detailed-balance 47/47, including CPU-reference parity
- `git diff --check`
- the unchanged CUDA/HIP paths were audited but toolchains were unavailable here; no accelerator ZeroT support claim is made

First-moment objective handling remains separate in #30.

Fixes #29