### PR TITLE
fix: reject invalid normalization targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,26 @@ directory (issue `make clean` or `rm -rf ./*` inside the build directory).
 
 A single reconstruction of the dynamic structure factor can be generated using the input data from step 1. For example:
 ```bash
-deac.e --number_of_generations 1600000 --temperature 1.35 --population_size 8 --genome_size 4096 --normalize --omega_max 512.0 --save_directory deac_results --seed 1 --stop_minimum_fitness 1.0 isf.bin
+deac.e --number_of_generations 1600000 --temperature 1.35 --population_size 8 --genome_size 4096 --normalize --spectra_type bfull --omega_max 512.0 --save_directory deac_results --seed 1 --stop_minimum_fitness 1.0 isf.bin
 ```
 This command will save the generated spectrum in the `deac_results` directory after `1600000` steps or if the desired fitness cutoff of `1.0` is reached. Please see `deac.e --help` for more command line arguments and further description.
+
+For every model and backend, `--normalize` uses the first ISF value as the
+target zeroth moment. The target must be finite, positive, and at least the
+smallest normal binary64 value. It must also produce a normal initial scale for
+the selected model and frequency grid; this additional lower bound is checked
+before output creation because it depends on the grid's quadrature weights.
+Zero, negative, non-finite, subnormal, and unrepresentably small targets are
+therefore rejected before the solver creates its result directory or starts
+evolution. Builds that allow negative spectral weights reject `--normalize`
+because a signed population does not guarantee a positive denominator. Choose
+a kernel convention with a positive equal-time correlation, such as `bfull`,
+`bdsf`, or the ZeroT positive-frequency kernel; the solver does not silently
+flip the sign of a single-particle correlation. An invalid initial population
+normalization is fatal because there is no valid incumbent. During evolution,
+a candidate with a zero, non-finite, or otherwise unrepresentable denominator
+or scale is assigned noncompetitive fitness and rejected; it cannot contaminate
+the incumbent population or its statistics.
 	
 The general recommendation is to generate several spectra using different seeds (`--seed`) and average the final results. A sample bash script to generate a command file with multiple seeds can be found in the tools directory `tools/generate_commands.sh`.
 	

--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -285,6 +285,48 @@ add_test(
     NAME deac_unit_evolution_controls
     COMMAND deac_evolution_controls_test)
 
+add_executable(deac_normalization_test
+    ${CMAKE_SOURCE_DIR}/../test/normalization_test.cpp)
+target_include_directories(deac_normalization_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_test(
+    NAME deac_unit_normalization
+    COMMAND deac_normalization_test)
+
+if(NOT "${GPU_BACKEND}" STREQUAL "none")
+    set(DEAC_GPU_NORMALIZATION_TEST_SOURCES
+        ${CMAKE_SOURCE_DIR}/../test/gpu_normalization_test.cpp)
+    if("${GPU_BACKEND}" STREQUAL "cuda")
+        list(APPEND DEAC_GPU_NORMALIZATION_TEST_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/deac_gpu.cu)
+    endif()
+    add_executable(deac_gpu_normalization_test
+        ${DEAC_GPU_NORMALIZATION_TEST_SOURCES})
+    target_include_directories(deac_gpu_normalization_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    if("${GPU_BACKEND}" STREQUAL "cuda")
+        set_target_properties(deac_gpu_normalization_test PROPERTIES
+            CUDA_SEPARABLE_COMPILATION ON)
+    endif()
+    if(USE_BLAS AND "${GPU_BACKEND}" STREQUAL "cuda")
+        target_link_libraries(deac_gpu_normalization_test CUDA::cublas)
+    endif()
+    if(USE_BLAS AND "${GPU_BACKEND}" STREQUAL "sycl")
+        target_link_libraries(deac_gpu_normalization_test
+            ${MKL_SYCL_BLAS_LIBRARY}
+            ${MKL_SYCL_LIBRARY}
+            ${MKL_INTEL_ILP64_LIBRARY}
+            ${MKL_SEQUENTIAL_LIBRARY}
+            ${MKL_CORE_LIBRARY}
+            pthread
+            m
+            dl)
+    endif()
+    add_test(
+        NAME deac_unit_gpu_normalization
+        COMMAND deac_gpu_normalization_test)
+endif()
+
 add_executable(deac_population_projection_test
     ${CMAKE_SOURCE_DIR}/../test/population_projection_test.cpp)
 target_include_directories(deac_population_projection_test PRIVATE
@@ -339,6 +381,11 @@ if(Python3_Interpreter_FOUND)
             uneven_isf_arrays
             too_few_timeslices
             nonfinite_isf
+            normalize_zero_target
+            normalize_negative_target
+            normalize_subnormal_target
+            normalize_nonfinite_target
+            normalize_unrepresentable_scale
             missing_isf
             positive_isf_single_particle
             bad_third_moment_error

--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -352,6 +352,53 @@ add_test(
     NAME deac_unit_zero_temperature_kernel
     COMMAND deac_zero_temperature_kernel_test)
 
+# A separate test-only solver binary forces every evolved normalization
+# denominator to zero.  Keeping the hook out of the installed solver makes the
+# complete-loop rejection regression deterministic without adding a public
+# option or runtime branch.
+if(NOT USE_ALLOW_NEGATIVE_SPECTRAL_WEIGHT)
+    if("${GPU_BACKEND}" STREQUAL "cuda")
+        add_executable(deac_invalid_normalization_evolution_test_exe
+            ${DEAC_SRC} ${DEAC_CUDA})
+        set_target_properties(
+            deac_invalid_normalization_evolution_test_exe PROPERTIES
+            CUDA_SEPARABLE_COMPILATION ON)
+    else()
+        add_executable(deac_invalid_normalization_evolution_test_exe
+            ${DEAC_SRC})
+    endif()
+    target_compile_definitions(
+        deac_invalid_normalization_evolution_test_exe PRIVATE
+        DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS=1)
+    target_include_directories(
+        deac_invalid_normalization_evolution_test_exe PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        PRIVATE src)
+    if(USE_BLAS AND "${GPU_BACKEND}" STREQUAL "cuda")
+        target_link_libraries(
+            deac_invalid_normalization_evolution_test_exe CUDA::cublas)
+    endif()
+    if(USE_BLAS AND "${GPU_BACKEND}" STREQUAL "sycl")
+        target_include_directories(
+            deac_invalid_normalization_evolution_test_exe PRIVATE
+            "${MKLROOT}/include")
+        target_link_libraries(
+            deac_invalid_normalization_evolution_test_exe
+            ${MKL_SYCL_BLAS_LIBRARY}
+            ${MKL_SYCL_LIBRARY}
+            ${MKL_INTEL_ILP64_LIBRARY}
+            ${MKL_SEQUENTIAL_LIBRARY}
+            ${MKL_CORE_LIBRARY}
+            pthread
+            m
+            dl)
+    endif()
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+        target_link_libraries(
+            deac_invalid_normalization_evolution_test_exe stdc++fs)
+    endif()
+endif()
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     set(DEAC_SMOKE_TEST "${CMAKE_SOURCE_DIR}/../test/deac_smoke_test.py")
@@ -370,8 +417,6 @@ if(Python3_Interpreter_FOUND)
             default
             evolution_control_lower_boundaries
             evolution_control_upper_boundaries
-            normalize
-            normalize_large_population
             first_moment
             third_moment
             track_stats
@@ -385,7 +430,6 @@ if(Python3_Interpreter_FOUND)
             normalize_negative_target
             normalize_subnormal_target
             normalize_nonfinite_target
-            normalize_unrepresentable_scale
             missing_isf
             positive_isf_single_particle
             bad_third_moment_error
@@ -411,6 +455,16 @@ if(Python3_Interpreter_FOUND)
             unwritable_save_directory
             log_destination_is_directory
             result_destination_is_directory)
+    if(USE_ALLOW_NEGATIVE_SPECTRAL_WEIGHT)
+        # Basic malformed-target validation still takes precedence above.  A
+        # valid target reaches this build-mode incompatibility check.
+        list(APPEND DEAC_SMOKE_CASES normalize_signed_weights)
+    else()
+        list(APPEND DEAC_SMOKE_CASES
+            normalize
+            normalize_large_population
+            normalize_unrepresentable_scale)
+    endif()
     if(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF)
         list(APPEND DEAC_SMOKE_CASES negative_first_moment)
     else()
@@ -428,15 +482,27 @@ if(Python3_Interpreter_FOUND)
                 ${DEAC_SMOKE_VARIANT_ARGS}
         )
     endforeach()
-    add_test(
-        NAME deac_normalization_evolution
-        COMMAND
-            ${Python3_EXECUTABLE}
-            ${CMAKE_SOURCE_DIR}/../test/deac_normalization_evolution_test.py
-            --exe $<TARGET_FILE:${exe}>
-            --workdir ${CMAKE_CURRENT_BINARY_DIR}/normalization-evolution
-            ${DEAC_SMOKE_VARIANT_ARGS}
-    )
+    if(NOT USE_ALLOW_NEGATIVE_SPECTRAL_WEIGHT)
+        add_test(
+            NAME deac_normalization_evolution
+            COMMAND
+                ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/../test/deac_normalization_evolution_test.py
+                --exe $<TARGET_FILE:${exe}>
+                --workdir ${CMAKE_CURRENT_BINARY_DIR}/normalization-evolution
+                ${DEAC_SMOKE_VARIANT_ARGS}
+        )
+        add_test(
+            NAME deac_invalid_normalization_evolution
+            COMMAND
+                ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/../test/deac_invalid_normalization_evolution_test.py
+                --reference-exe $<TARGET_FILE:${exe}>
+                --forced-exe $<TARGET_FILE:deac_invalid_normalization_evolution_test_exe>
+                --workdir ${CMAKE_CURRENT_BINARY_DIR}/invalid-normalization-evolution
+                ${DEAC_SMOKE_VARIANT_ARGS}
+        )
+    endif()
     set(DEAC_PARITY_REFERENCE_EXE "" CACHE FILEPATH "Reference deac executable for backend parity tests.")
     if(NOT "${DEAC_PARITY_REFERENCE_EXE}" STREQUAL "")
         add_test(

--- a/src/deac/include/deac_gpu.cuh
+++ b/src/deac/include/deac_gpu.cuh
@@ -8,17 +8,22 @@ void gpu_dot(cudaStream_t s, double* __restrict__ C, double* __restrict__ B, dou
 void gpu_matmul(cudaStream_t s, int m, int n, int k, double alpha, double* __restrict__ A, double* __restrict__ B, double beta, double* __restrict__ C);
 void gpu_deac_gemv(cudaStream_t s, int m, int n, double alpha, double* __restrict__ A, double* __restrict__ x, double beta, double* __restrict__ y);
 void gpu_get_minimum(cudaStream_t s, double* __restrict__ minimum, double* __restrict__ array, size_t N);
-void gpu_deac_dgmmDiv1D(cudaStream_t s, double* __restrict__ positive_matrix,
-        double* __restrict__ negative_matrix,
-        const double* __restrict__ vector, bool* __restrict__ valid_rows,
+void gpu_deac_dgmmDiv1D(cudaStream_t s, double* __restrict__ matrix,
+        double* __restrict__ vector, size_t rows, size_t cols);
+void gpu_validate_normalization_rows(cudaStream_t s,
+        const double* __restrict__ matrix,
+        const double* __restrict__ vector, int* __restrict__ valid_rows,
         double target, size_t rows, size_t cols);
+void gpu_cleanup_invalid_normalization_rows(cudaStream_t s,
+        double* __restrict__ matrix, const int* __restrict__ valid_rows,
+        size_t rows, size_t cols);
 void gpu_deac_reduced_chi_squared(cudaStream_t s, const double* __restrict__ calculated_data, const double* __restrict__ observed_data, const double* __restrict__ standard_deviations, double* __restrict__ reduced_chi_squared, size_t m, size_t n, size_t ddof, double beta);
 void gpu_deac_add_scalar_reduced_chi_squared(cudaStream_t s, const double* __restrict__ calculated_data, double observed_data, double standard_deviation, double* __restrict__ reduced_chi_squared, size_t m);
 void gpu_set_fitness_mean(cudaStream_t s, double* __restrict__ fitness_mean, double* __restrict__ fitness, size_t population_size);
 void gpu_set_fitness_squared_mean(cudaStream_t s, double* __restrict__ fitness_squared_mean, double* __restrict__ fitness, size_t population_size);
 void gpu_set_population_new(cudaStream_t s, size_t grid_size, double* __restrict__ population_new, double* __restrict__ population_old, size_t* __restrict__ mutant_indices, double* __restrict__ differential_weights_new, bool* __restrict__ mutate_indices, size_t population_size, size_t genome_size);
 void gpu_match_population_zero(cudaStream_t s, size_t grid_size, double* __restrict__ population_negative_frequency, double* __restrict__ population_positive_frequency, size_t population_size, size_t genome_size);
-void gpu_set_rejection_indices(cudaStream_t s, size_t grid_size, bool* __restrict__ rejection_indices, double* __restrict__ fitness_new, double* __restrict__ fitness_old, const bool* __restrict__ normalization_valid, bool normalize, size_t population_size);
+void gpu_set_rejection_indices(cudaStream_t s, size_t grid_size, bool* __restrict__ rejection_indices, double* __restrict__ fitness_new, double* __restrict__ fitness_old, const int* __restrict__ normalization_valid, bool normalize, size_t population_size);
 void gpu_swap_control_parameters(cudaStream_t s, size_t grid_size, double* __restrict__ control_parameter_old, double* __restrict__ control_parameter_new, bool* __restrict__ rejection_indices, size_t population_size);
 void gpu_swap_populations(cudaStream_t s, size_t grid_size, double* __restrict__ population_old, double* __restrict__ population_new, bool* __restrict__ rejection_indices, size_t population_size, size_t genome_size);
 void gpu_set_crossover_probabilities_new(cudaStream_t s, size_t grid_size, uint64_t* __restrict__ rng_state, double* __restrict__ crossover_probabilities_new, double* __restrict__ crossover_probabilities_old, double self_adapting_crossover_probability, size_t population_size);

--- a/src/deac/include/deac_gpu.cuh
+++ b/src/deac/include/deac_gpu.cuh
@@ -1,20 +1,24 @@
 #pragma once
 #include "common_gpu.hpp"
 #include "device_launch_parameters.h"
+#include <cfloat>
 #include <stdint.h>
 
 void gpu_dot(cudaStream_t s, double* __restrict__ C, double* __restrict__ B, double* __restrict__ A, size_t N);
 void gpu_matmul(cudaStream_t s, int m, int n, int k, double alpha, double* __restrict__ A, double* __restrict__ B, double beta, double* __restrict__ C);
 void gpu_deac_gemv(cudaStream_t s, int m, int n, double alpha, double* __restrict__ A, double* __restrict__ x, double beta, double* __restrict__ y);
 void gpu_get_minimum(cudaStream_t s, double* __restrict__ minimum, double* __restrict__ array, size_t N);
-void gpu_deac_dgmmDiv1D(cudaStream_t s, double* __restrict__ matrix, double* __restrict__ vector, size_t rows, size_t cols);
+void gpu_deac_dgmmDiv1D(cudaStream_t s, double* __restrict__ positive_matrix,
+        double* __restrict__ negative_matrix,
+        const double* __restrict__ vector, bool* __restrict__ valid_rows,
+        double target, size_t rows, size_t cols);
 void gpu_deac_reduced_chi_squared(cudaStream_t s, const double* __restrict__ calculated_data, const double* __restrict__ observed_data, const double* __restrict__ standard_deviations, double* __restrict__ reduced_chi_squared, size_t m, size_t n, size_t ddof, double beta);
 void gpu_deac_add_scalar_reduced_chi_squared(cudaStream_t s, const double* __restrict__ calculated_data, double observed_data, double standard_deviation, double* __restrict__ reduced_chi_squared, size_t m);
 void gpu_set_fitness_mean(cudaStream_t s, double* __restrict__ fitness_mean, double* __restrict__ fitness, size_t population_size);
 void gpu_set_fitness_squared_mean(cudaStream_t s, double* __restrict__ fitness_squared_mean, double* __restrict__ fitness, size_t population_size);
 void gpu_set_population_new(cudaStream_t s, size_t grid_size, double* __restrict__ population_new, double* __restrict__ population_old, size_t* __restrict__ mutant_indices, double* __restrict__ differential_weights_new, bool* __restrict__ mutate_indices, size_t population_size, size_t genome_size);
 void gpu_match_population_zero(cudaStream_t s, size_t grid_size, double* __restrict__ population_negative_frequency, double* __restrict__ population_positive_frequency, size_t population_size, size_t genome_size);
-void gpu_set_rejection_indices(cudaStream_t s, size_t grid_size, bool* __restrict__ rejection_indices, double* __restrict__ fitness_new, double* __restrict__ fitness_old, size_t population_size);
+void gpu_set_rejection_indices(cudaStream_t s, size_t grid_size, bool* __restrict__ rejection_indices, double* __restrict__ fitness_new, double* __restrict__ fitness_old, const bool* __restrict__ normalization_valid, bool normalize, size_t population_size);
 void gpu_swap_control_parameters(cudaStream_t s, size_t grid_size, double* __restrict__ control_parameter_old, double* __restrict__ control_parameter_new, bool* __restrict__ rejection_indices, size_t population_size);
 void gpu_swap_populations(cudaStream_t s, size_t grid_size, double* __restrict__ population_old, double* __restrict__ population_new, bool* __restrict__ rejection_indices, size_t population_size, size_t genome_size);
 void gpu_set_crossover_probabilities_new(cudaStream_t s, size_t grid_size, uint64_t* __restrict__ rng_state, double* __restrict__ crossover_probabilities_new, double* __restrict__ crossover_probabilities_old, double self_adapting_crossover_probability, size_t population_size);

--- a/src/deac/include/deac_gpu.hip.hpp
+++ b/src/deac/include/deac_gpu.hip.hpp
@@ -410,38 +410,30 @@ void gpu_get_minimum(double* __restrict__ minimum, double* __restrict__ array, s
     }
 }
 
-__global__ void gpu_deac_dgmmDiv1D(double* __restrict__ positive_matrix,
-        double* __restrict__ negative_matrix,
-        const double* __restrict__ vector, bool* __restrict__ valid_rows,
+__global__ void gpu_deac_dgmmDiv1D(double* __restrict__ matrix,
+        double* __restrict__ vector, size_t rows, size_t cols) {
+    size_t idx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    if (idx < rows * cols) {
+        size_t row = idx % rows;
+        double reciprocal = 1.0/vector[row];
+        matrix[idx] *= reciprocal;
+    }
+}
+
+__global__ void gpu_validate_normalization_rows_kernel(
+        const double* __restrict__ matrix,
+        const double* __restrict__ vector, int* __restrict__ valid_rows,
         double target, size_t rows, size_t cols) {
-    const size_t row = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    if (row < rows) {
-        const double scale = target/vector[row];
-        bool valid = vector[row] >= DBL_MIN && vector[row] <= DBL_MAX
-                && scale >= DBL_MIN && scale <= DBL_MAX;
-        if (valid) {
-            for (size_t col=0; col<cols; ++col) {
-                const size_t idx = row + col*rows;
-                positive_matrix[idx] *= scale;
-                valid = valid && isfinite(positive_matrix[idx]);
-            }
-            if (negative_matrix != nullptr) {
-                for (size_t col=0; col<cols; ++col) {
-                    const size_t idx = row + col*rows;
-                    negative_matrix[idx] *= scale;
-                    valid = valid && isfinite(negative_matrix[idx]);
-                }
-            }
+    const size_t idx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    if (idx < rows*cols) {
+        const size_t row = idx % rows;
+        const double denominator = vector[row]*target;
+        const double reciprocal = 1.0/vector[row];
+        if (!(denominator >= DBL_MIN && denominator <= DBL_MAX
+                    && reciprocal >= DBL_MIN && reciprocal <= DBL_MAX
+                    && isfinite(matrix[idx]))) {
+            atomicExch(valid_rows + row, 0);
         }
-        if (!valid) {
-            for (size_t col=0; col<cols; ++col) {
-                positive_matrix[row + col*rows] = 0.0;
-                if (negative_matrix != nullptr) {
-                    negative_matrix[row + col*rows] = 0.0;
-                }
-            }
-        }
-        valid_rows[row] = valid;
     }
 }
 
@@ -582,14 +574,14 @@ void gpu_match_population_zero(double* __restrict__ population_negative_frequenc
 __global__
 void gpu_set_rejection_indices(bool* __restrict__ rejection_indices,
         double* __restrict__ fitness_new, double* __restrict__ fitness_old,
-        const bool* __restrict__ normalization_valid, bool normalize,
+        const int* __restrict__ normalization_valid, bool normalize,
         size_t population_size) {
     size_t global_idx = hipBlockDim_x*hipBlockIdx_x + hipThreadIdx_x;
     if (global_idx < population_size) {
-        if (normalize && !normalization_valid[global_idx]) {
+        if (normalize && normalization_valid[global_idx] == 0) {
             fitness_new[global_idx] = DBL_MAX;
         }
-        bool accept = (!normalize || normalization_valid[global_idx])
+        bool accept = (!normalize || normalization_valid[global_idx] != 0)
                 && fitness_new[global_idx] <= fitness_old[global_idx];
         rejection_indices[global_idx] = accept;
         if (accept) {
@@ -704,15 +696,44 @@ void gpu_get_minimum(hipStream_t s, double* __restrict__ minimum, double* __rest
             minimum, array, N);
 }
 
-void gpu_deac_dgmmDiv1D(hipStream_t s, double* __restrict__ positive_matrix,
-        double* __restrict__ negative_matrix,
-        const double* __restrict__ vector, bool* __restrict__ valid_rows,
-        double target, size_t rows, size_t cols) {
+void gpu_deac_dgmmDiv1D(hipStream_t s, double* __restrict__ matrix,
+        double* __restrict__ vector, size_t rows, size_t cols) {
     hipLaunchKernelGGL(gpu_deac_dgmmDiv1D,
-            dim3((rows + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE),
+            dim3((rows*cols + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE),
             dim3(GPU_BLOCK_SIZE), 0, s,
-            positive_matrix, negative_matrix, vector, valid_rows,
-            target, rows, cols);
+            matrix, vector, rows, cols);
+}
+
+void gpu_validate_normalization_rows(hipStream_t s,
+        const double* __restrict__ matrix,
+        const double* __restrict__ vector, int* __restrict__ valid_rows,
+        double target, size_t rows, size_t cols) {
+    hipLaunchKernelGGL(
+            gpu_validate_normalization_rows_kernel,
+            dim3((rows*cols + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE),
+            dim3(GPU_BLOCK_SIZE), 0, s,
+            matrix, vector, valid_rows, target, rows, cols);
+}
+
+__global__ void gpu_cleanup_invalid_normalization_rows_kernel(
+        double* __restrict__ matrix, const int* __restrict__ valid_rows,
+        size_t rows, size_t cols) {
+    const size_t row = hipBlockDim_x*hipBlockIdx_x + hipThreadIdx_x;
+    if (row < rows && valid_rows[row] == 0) {
+        for (size_t col=0; col<cols; ++col) {
+            matrix[row + rows*col] = 0.0;
+        }
+    }
+}
+
+void gpu_cleanup_invalid_normalization_rows(hipStream_t s,
+        double* __restrict__ matrix, const int* __restrict__ valid_rows,
+        size_t rows, size_t cols) {
+    const size_t grid_size = (rows + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE;
+    hipLaunchKernelGGL(
+            gpu_cleanup_invalid_normalization_rows_kernel,
+            dim3(grid_size), dim3(GPU_BLOCK_SIZE), 0, s,
+            matrix, valid_rows, rows, cols);
 }
 
 void gpu_deac_reduced_chi_squared(hipStream_t s, const double* __restrict__ calculated_data, const double* __restrict__ observed_data, const double* __restrict__ standard_deviations, double* __restrict__ reduced_chi_squared, size_t m, size_t n, size_t ddof, double beta) {
@@ -750,7 +771,7 @@ void gpu_match_population_zero(hipStream_t s, size_t grid_size, double* __restri
 void gpu_set_rejection_indices(hipStream_t s, size_t grid_size,
         bool* __restrict__ rejection_indices, double* __restrict__ fitness_new,
         double* __restrict__ fitness_old,
-        const bool* __restrict__ normalization_valid, bool normalize,
+        const int* __restrict__ normalization_valid, bool normalize,
         size_t population_size) {
     hipLaunchKernelGGL(gpu_set_rejection_indices,
             dim3(grid_size), dim3(GPU_BLOCK_SIZE), 0, s,

--- a/src/deac/include/deac_gpu.hip.hpp
+++ b/src/deac/include/deac_gpu.hip.hpp
@@ -10,6 +10,7 @@
 #define DEAC_GPU_HIP_H
 
 #include "common_gpu.hpp"
+#include <cfloat>
 #include <stdint.h>
 
 
@@ -409,14 +410,38 @@ void gpu_get_minimum(double* __restrict__ minimum, double* __restrict__ array, s
     }
 }
 
-__global__ void gpu_deac_dgmmDiv1D(double* __restrict__ matrix, double* __restrict__ vector, size_t rows, size_t cols) {
-    size_t idx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x; // 1D index for the entire matrix
-    if (idx < rows * cols) { // Ensure we do not go out of bounds
-        size_t row = idx % rows; // Calculate the row index
-        //size_t col = idx / rows; // Calculate the column index, assuming column-major order
-        double reciprocal = 1.0/vector[row];
-        // Perform the division operation
-        matrix[idx] *= reciprocal;
+__global__ void gpu_deac_dgmmDiv1D(double* __restrict__ positive_matrix,
+        double* __restrict__ negative_matrix,
+        const double* __restrict__ vector, bool* __restrict__ valid_rows,
+        double target, size_t rows, size_t cols) {
+    const size_t row = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    if (row < rows) {
+        const double scale = target/vector[row];
+        bool valid = vector[row] >= DBL_MIN && vector[row] <= DBL_MAX
+                && scale >= DBL_MIN && scale <= DBL_MAX;
+        if (valid) {
+            for (size_t col=0; col<cols; ++col) {
+                const size_t idx = row + col*rows;
+                positive_matrix[idx] *= scale;
+                valid = valid && isfinite(positive_matrix[idx]);
+            }
+            if (negative_matrix != nullptr) {
+                for (size_t col=0; col<cols; ++col) {
+                    const size_t idx = row + col*rows;
+                    negative_matrix[idx] *= scale;
+                    valid = valid && isfinite(negative_matrix[idx]);
+                }
+            }
+        }
+        if (!valid) {
+            for (size_t col=0; col<cols; ++col) {
+                positive_matrix[row + col*rows] = 0.0;
+                if (negative_matrix != nullptr) {
+                    negative_matrix[row + col*rows] = 0.0;
+                }
+            }
+        }
+        valid_rows[row] = valid;
     }
 }
 
@@ -555,10 +580,17 @@ void gpu_match_population_zero(double* __restrict__ population_negative_frequenc
 }
 
 __global__
-void gpu_set_rejection_indices(bool* __restrict__ rejection_indices, double* __restrict__ fitness_new, double* __restrict__ fitness_old, size_t population_size) {
+void gpu_set_rejection_indices(bool* __restrict__ rejection_indices,
+        double* __restrict__ fitness_new, double* __restrict__ fitness_old,
+        const bool* __restrict__ normalization_valid, bool normalize,
+        size_t population_size) {
     size_t global_idx = hipBlockDim_x*hipBlockIdx_x + hipThreadIdx_x;
     if (global_idx < population_size) {
-        bool accept = fitness_new[global_idx] <= fitness_old[global_idx];
+        if (normalize && !normalization_valid[global_idx]) {
+            fitness_new[global_idx] = DBL_MAX;
+        }
+        bool accept = (!normalize || normalization_valid[global_idx])
+                && fitness_new[global_idx] <= fitness_old[global_idx];
         rejection_indices[global_idx] = accept;
         if (accept) {
             fitness_old[global_idx] = fitness_new[global_idx];
@@ -672,8 +704,15 @@ void gpu_get_minimum(hipStream_t s, double* __restrict__ minimum, double* __rest
             minimum, array, N);
 }
 
-void gpu_deac_dgmmDiv1D(hipStream_t s, double* __restrict__ matrix, double* __restrict__ vector, size_t rows, size_t cols) {
-    hipLaunchKernelGGL(gpu_deac_dgmmDiv1D, dim3((rows*cols + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE), dim3(GPU_BLOCK_SIZE), 0, s, matrix, vector, rows, cols);
+void gpu_deac_dgmmDiv1D(hipStream_t s, double* __restrict__ positive_matrix,
+        double* __restrict__ negative_matrix,
+        const double* __restrict__ vector, bool* __restrict__ valid_rows,
+        double target, size_t rows, size_t cols) {
+    hipLaunchKernelGGL(gpu_deac_dgmmDiv1D,
+            dim3((rows + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE),
+            dim3(GPU_BLOCK_SIZE), 0, s,
+            positive_matrix, negative_matrix, vector, valid_rows,
+            target, rows, cols);
 }
 
 void gpu_deac_reduced_chi_squared(hipStream_t s, const double* __restrict__ calculated_data, const double* __restrict__ observed_data, const double* __restrict__ standard_deviations, double* __restrict__ reduced_chi_squared, size_t m, size_t n, size_t ddof, double beta) {
@@ -708,10 +747,15 @@ void gpu_match_population_zero(hipStream_t s, size_t grid_size, double* __restri
             population_negative_frequency, population_positive_frequency, population_size, genome_size);
 }
 
-void gpu_set_rejection_indices(hipStream_t s, size_t grid_size, bool* __restrict__ rejection_indices, double* __restrict__ fitness_new, double* __restrict__ fitness_old, size_t population_size) {
+void gpu_set_rejection_indices(hipStream_t s, size_t grid_size,
+        bool* __restrict__ rejection_indices, double* __restrict__ fitness_new,
+        double* __restrict__ fitness_old,
+        const bool* __restrict__ normalization_valid, bool normalize,
+        size_t population_size) {
     hipLaunchKernelGGL(gpu_set_rejection_indices,
             dim3(grid_size), dim3(GPU_BLOCK_SIZE), 0, s,
-            rejection_indices, fitness_new, fitness_old, population_size);
+            rejection_indices, fitness_new, fitness_old,
+            normalization_valid, normalize, population_size);
 }
 
 void gpu_swap_control_parameters(hipStream_t s, size_t grid_size, double* __restrict__ control_parameter_old, double* __restrict__ control_parameter_new, bool* __restrict__ rejection_indices, size_t population_size) {

--- a/src/deac/include/deac_gpu.sycl.h
+++ b/src/deac/include/deac_gpu.sycl.h
@@ -9,6 +9,7 @@
 #ifndef DEAC_GPU_SYCL_H 
 #define DEAC_GPU_SYCL_H
 #include "common_gpu.hpp"
+#include <cfloat>
 
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
@@ -446,18 +447,42 @@ void gpu_get_minimum(sycl::queue q, double* __restrict__ minimum, double* __rest
     });
 }
 
-void gpu_deac_dgmmDiv1D(sycl::queue q, double* __restrict__ matrix, double* __restrict__ vector, size_t rows, size_t cols) {
+void gpu_deac_dgmmDiv1D(sycl::queue q, double* __restrict__ positive_matrix,
+        double* __restrict__ negative_matrix,
+        const double* __restrict__ vector, bool* __restrict__ valid_rows,
+        double target, size_t rows, size_t cols) {
     q.submit([&](sycl::handler& cgh) {
-        size_t grid_size = (rows*cols + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE;
+        size_t grid_size = (rows + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE;
         cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(grid_size*GPU_BLOCK_SIZE), sycl::range<1>(GPU_BLOCK_SIZE)),
                 [=](sycl::nd_item<1> item) [[sycl::reqd_sub_group_size(SUB_GROUP_SIZE)]] {
-            size_t idx = item.get_global_id(0); // 1D index for the entire matrix
-            if (idx < rows * cols) { // Ensure we do not go out of bounds
-                size_t row = idx % rows; // Calculate the row index
-                //size_t col = idx / rows; // Calculate the column index, assuming column-major order
-                // Perform the division operation
-                double reciprocal = 1.0/vector[row];
-                matrix[idx] *= reciprocal;
+            const size_t row = item.get_global_id(0);
+            if (row < rows) {
+                const double scale = target/vector[row];
+                bool valid = vector[row] >= DBL_MIN && vector[row] <= DBL_MAX
+                        && scale >= DBL_MIN && scale <= DBL_MAX;
+                if (valid) {
+                    for (size_t col=0; col<cols; ++col) {
+                        const size_t idx = row + col*rows;
+                        positive_matrix[idx] *= scale;
+                        valid = valid && sycl::isfinite(positive_matrix[idx]);
+                    }
+                    if (negative_matrix != nullptr) {
+                        for (size_t col=0; col<cols; ++col) {
+                            const size_t idx = row + col*rows;
+                            negative_matrix[idx] *= scale;
+                            valid = valid && sycl::isfinite(negative_matrix[idx]);
+                        }
+                    }
+                }
+                if (!valid) {
+                    for (size_t col=0; col<cols; ++col) {
+                        positive_matrix[row + col*rows] = 0.0;
+                        if (negative_matrix != nullptr) {
+                            negative_matrix[row + col*rows] = 0.0;
+                        }
+                    }
+                }
+                valid_rows[row] = valid;
             }
         });
     });
@@ -623,13 +648,21 @@ void gpu_match_population_zero(sycl::queue q, size_t grid_size, double* __restri
     });
 }
 
-void gpu_set_rejection_indices(sycl::queue q, size_t grid_size, bool* __restrict__ rejection_indices, double* __restrict__ fitness_new, double* __restrict__ fitness_old, size_t population_size) {
+void gpu_set_rejection_indices(sycl::queue q, size_t grid_size,
+        bool* __restrict__ rejection_indices, double* __restrict__ fitness_new,
+        double* __restrict__ fitness_old,
+        const bool* __restrict__ normalization_valid, bool normalize,
+        size_t population_size) {
     q.submit([&](sycl::handler& cgh) {
         cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(grid_size*GPU_BLOCK_SIZE), sycl::range<1>(GPU_BLOCK_SIZE)),
                 [=](sycl::nd_item<1> item) [[sycl::reqd_sub_group_size(SUB_GROUP_SIZE)]] {
             size_t global_idx = item.get_global_id(0);
             if (global_idx < population_size) {
-                bool accept = fitness_new[global_idx] <= fitness_old[global_idx];
+                if (normalize && !normalization_valid[global_idx]) {
+                    fitness_new[global_idx] = DBL_MAX;
+                }
+                bool accept = (!normalize || normalization_valid[global_idx])
+                        && fitness_new[global_idx] <= fitness_old[global_idx];
                 rejection_indices[global_idx] = accept;
                 if (accept) {
                     fitness_old[global_idx] = fitness_new[global_idx];

--- a/src/deac/include/deac_gpu.sycl.h
+++ b/src/deac/include/deac_gpu.sycl.h
@@ -447,42 +447,71 @@ void gpu_get_minimum(sycl::queue q, double* __restrict__ minimum, double* __rest
     });
 }
 
-void gpu_deac_dgmmDiv1D(sycl::queue q, double* __restrict__ positive_matrix,
-        double* __restrict__ negative_matrix,
-        const double* __restrict__ vector, bool* __restrict__ valid_rows,
-        double target, size_t rows, size_t cols) {
+void gpu_deac_dgmmDiv1D(sycl::queue q, double* __restrict__ matrix, double* __restrict__ vector, size_t rows, size_t cols) {
     q.submit([&](sycl::handler& cgh) {
-        size_t grid_size = (rows + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE;
+        size_t grid_size = (rows*cols + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE;
         cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(grid_size*GPU_BLOCK_SIZE), sycl::range<1>(GPU_BLOCK_SIZE)),
                 [=](sycl::nd_item<1> item) [[sycl::reqd_sub_group_size(SUB_GROUP_SIZE)]] {
+            size_t idx = item.get_global_id(0); // 1D index for the entire matrix
+            if (idx < rows * cols) { // Ensure we do not go out of bounds
+                size_t row = idx % rows; // Calculate the row index
+                //size_t col = idx / rows; // Calculate the column index, assuming column-major order
+                // Perform the division operation
+                double reciprocal = 1.0/vector[row];
+                matrix[idx] *= reciprocal;
+            }
+        });
+    });
+}
+
+void gpu_validate_normalization_rows(
+        sycl::queue q, const double* __restrict__ matrix,
+        const double* __restrict__ vector, int* __restrict__ valid_rows,
+        double target, size_t rows, size_t cols) {
+    q.submit([&](sycl::handler& cgh) {
+        const size_t grid_size = (rows*cols + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE;
+        cgh.parallel_for(
+                sycl::nd_range<1>(
+                        sycl::range<1>(grid_size*GPU_BLOCK_SIZE),
+                        sycl::range<1>(GPU_BLOCK_SIZE)),
+                [=](sycl::nd_item<1> item)
+                        [[sycl::reqd_sub_group_size(SUB_GROUP_SIZE)]] {
+            const size_t idx = item.get_global_id(0);
+            if (idx < rows*cols) {
+                const size_t row = idx % rows;
+                const double denominator = vector[row]*target;
+                const double reciprocal = 1.0/vector[row];
+                if (!(denominator >= DBL_MIN && denominator <= DBL_MAX
+                            && reciprocal >= DBL_MIN && reciprocal <= DBL_MAX
+                            && sycl::isfinite(matrix[idx]))) {
+                    sycl::atomic_ref<
+                            int,
+                            sycl::memory_order::relaxed,
+                            sycl::memory_scope::device,
+                            sycl::access::address_space::global_space>(
+                                    valid_rows[row]).store(0);
+                }
+            }
+        });
+    });
+}
+
+void gpu_cleanup_invalid_normalization_rows(
+        sycl::queue q, double* __restrict__ matrix,
+        const int* __restrict__ valid_rows, size_t rows, size_t cols) {
+    q.submit([&](sycl::handler& cgh) {
+        const size_t grid_size = (rows + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE;
+        cgh.parallel_for(
+                sycl::nd_range<1>(
+                        sycl::range<1>(grid_size*GPU_BLOCK_SIZE),
+                        sycl::range<1>(GPU_BLOCK_SIZE)),
+                [=](sycl::nd_item<1> item)
+                        [[sycl::reqd_sub_group_size(SUB_GROUP_SIZE)]] {
             const size_t row = item.get_global_id(0);
-            if (row < rows) {
-                const double scale = target/vector[row];
-                bool valid = vector[row] >= DBL_MIN && vector[row] <= DBL_MAX
-                        && scale >= DBL_MIN && scale <= DBL_MAX;
-                if (valid) {
-                    for (size_t col=0; col<cols; ++col) {
-                        const size_t idx = row + col*rows;
-                        positive_matrix[idx] *= scale;
-                        valid = valid && sycl::isfinite(positive_matrix[idx]);
-                    }
-                    if (negative_matrix != nullptr) {
-                        for (size_t col=0; col<cols; ++col) {
-                            const size_t idx = row + col*rows;
-                            negative_matrix[idx] *= scale;
-                            valid = valid && sycl::isfinite(negative_matrix[idx]);
-                        }
-                    }
+            if (row < rows && valid_rows[row] == 0) {
+                for (size_t col=0; col<cols; ++col) {
+                    matrix[row + rows*col] = 0.0;
                 }
-                if (!valid) {
-                    for (size_t col=0; col<cols; ++col) {
-                        positive_matrix[row + col*rows] = 0.0;
-                        if (negative_matrix != nullptr) {
-                            negative_matrix[row + col*rows] = 0.0;
-                        }
-                    }
-                }
-                valid_rows[row] = valid;
             }
         });
     });
@@ -651,17 +680,17 @@ void gpu_match_population_zero(sycl::queue q, size_t grid_size, double* __restri
 void gpu_set_rejection_indices(sycl::queue q, size_t grid_size,
         bool* __restrict__ rejection_indices, double* __restrict__ fitness_new,
         double* __restrict__ fitness_old,
-        const bool* __restrict__ normalization_valid, bool normalize,
+        const int* __restrict__ normalization_valid, bool normalize,
         size_t population_size) {
     q.submit([&](sycl::handler& cgh) {
         cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(grid_size*GPU_BLOCK_SIZE), sycl::range<1>(GPU_BLOCK_SIZE)),
                 [=](sycl::nd_item<1> item) [[sycl::reqd_sub_group_size(SUB_GROUP_SIZE)]] {
             size_t global_idx = item.get_global_id(0);
             if (global_idx < population_size) {
-                if (normalize && !normalization_valid[global_idx]) {
+                if (normalize && normalization_valid[global_idx] == 0) {
                     fitness_new[global_idx] = DBL_MAX;
                 }
-                bool accept = (!normalize || normalization_valid[global_idx])
+                bool accept = (!normalize || normalization_valid[global_idx] != 0)
                         && fitness_new[global_idx] <= fitness_old[global_idx];
                 rejection_indices[global_idx] = accept;
                 if (accept) {

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -397,17 +397,17 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
 
     // Normalize population
     size_t bytes_normalization = sizeof(double)*population_size;
-    size_t bytes_normalization_valid = sizeof(bool)*population_size;
+    size_t bytes_normalization_valid = sizeof(int)*population_size;
     size_t bytes_normalization_term = sizeof(double)*genome_size;
     double * normalization = nullptr;
-    bool * normalization_valid = nullptr;
+    int * normalization_valid = nullptr;
     double * normalization_term_positive_frequency = nullptr;
     #ifdef DEAC_TWO_SIDED_POPULATION
         double * normalization_term_negative_frequency = nullptr;
     #endif
     #ifdef USE_GPU
         double* d_normalization = nullptr;
-        bool* d_normalization_valid = nullptr;
+        int* d_normalization_valid = nullptr;
         double* d_normalization_term_positive_frequency = nullptr;
         #ifdef DEAC_TWO_SIDED_POPULATION
             double* d_normalization_term_negative_frequency;
@@ -415,7 +415,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     #endif
     if (normalize) {
         normalization = (double*) malloc(bytes_normalization);
-        normalization_valid = (bool*) malloc(bytes_normalization_valid);
+        normalization_valid = (int*) malloc(bytes_normalization_valid);
         normalization_term_positive_frequency = (double*) malloc(bytes_normalization_term);
         #ifdef DEAC_TWO_SIDED_POPULATION
             normalization_term_negative_frequency = (double*) malloc(bytes_normalization_term);
@@ -438,7 +438,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         #ifdef USE_GPU
             //Load normalization terms onto GPU
             GPU_ASSERT(deac_malloc_device(double, d_normalization,                         population_size, default_stream));
-            GPU_ASSERT(deac_malloc_device(bool,   d_normalization_valid,                   population_size, default_stream));
+            GPU_ASSERT(deac_malloc_device(int,    d_normalization_valid,                   population_size, default_stream));
             GPU_ASSERT(deac_malloc_device(double, d_normalization_term_positive_frequency, genome_size,     default_stream));
             GPU_ASSERT(deac_wait(default_stream));
             GPU_ASSERT(deac_memcpy_host_to_device(d_normalization_term_positive_frequency, normalization_term_positive_frequency, bytes_normalization_term, default_stream));
@@ -456,37 +456,67 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             GPU_ASSERT(deac_wait(default_stream));
 
             #ifdef USE_BLAS
-                gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_old_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
+                gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0/zeroth_moment, d_population_old_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
                 GPU_ASSERT(deac_wait(default_stream));
                 #ifdef DEAC_TWO_SIDED_POPULATION
-                    gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_old_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
+                    gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0/zeroth_moment, d_population_old_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
             #else
-                gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_old_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
+                gpu_deac_gemv(default_stream, population_size, genome_size, 1.0/zeroth_moment, d_population_old_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
                 GPU_ASSERT(deac_wait(default_stream));
                 #ifdef DEAC_TWO_SIDED_POPULATION
-                    gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_old_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
+                    gpu_deac_gemv(default_stream, population_size, genome_size, 1.0/zeroth_moment, d_population_old_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
             #endif
 
-            gpu_deac_dgmmDiv1D(default_stream, d_population_old_positive_frequency,
+            GPU_ASSERT(deac_memset(
+                    d_normalization_valid, 1,
+                    bytes_normalization_valid, default_stream));
+            GPU_ASSERT(deac_wait(default_stream));
+            gpu_deac_dgmmDiv1D(stream_array[0],
+                    d_population_old_positive_frequency,
+                    d_normalization, population_size, genome_size);
             #ifdef DEAC_TWO_SIDED_POPULATION
-                    d_population_old_negative_frequency,
-            #else
-                    nullptr,
+                gpu_deac_dgmmDiv1D(stream_array[1 % MAX_GPU_STREAMS],
+                        d_population_old_negative_frequency,
+                        d_normalization, population_size, genome_size);
+                #if MAX_GPU_STREAMS > 1
+                    GPU_ASSERT(deac_wait(stream_array[1]));
+                #endif
             #endif
+            GPU_ASSERT(deac_wait(stream_array[0]));
+            gpu_validate_normalization_rows(stream_array[0],
+                    d_population_old_positive_frequency,
                     d_normalization, d_normalization_valid, zeroth_moment,
                     population_size, genome_size);
-            GPU_ASSERT(deac_wait(default_stream));
+            #ifdef DEAC_TWO_SIDED_POPULATION
+                gpu_validate_normalization_rows(stream_array[1 % MAX_GPU_STREAMS],
+                        d_population_old_negative_frequency,
+                        d_normalization, d_normalization_valid, zeroth_moment,
+                        population_size, genome_size);
+                #if MAX_GPU_STREAMS > 1
+                    GPU_ASSERT(deac_wait(stream_array[1]));
+                #endif
+            #endif
+            GPU_ASSERT(deac_wait(stream_array[0]));
+            gpu_cleanup_invalid_normalization_rows(stream_array[0],
+                    d_population_old_positive_frequency,
+                    d_normalization_valid, population_size, genome_size);
+            #ifdef DEAC_TWO_SIDED_POPULATION
+                gpu_cleanup_invalid_normalization_rows(stream_array[0],
+                        d_population_old_negative_frequency,
+                        d_normalization_valid, population_size, genome_size);
+            #endif
+            GPU_ASSERT(deac_wait(stream_array[0]));
             GPU_ASSERT(deac_memcpy_device_to_host(
                     normalization_valid, d_normalization_valid,
                     bytes_normalization_valid, default_stream));
             GPU_ASSERT(deac_wait(default_stream));
             if (!std::all_of(
                     normalization_valid, normalization_valid + population_size,
-                    [](bool valid) { return valid; })) {
+                    [](int valid) { return valid != 0; })) {
                 fail_with_error(
                         "initial population contains an unrepresentable "
                         "normalization row");
@@ -1215,31 +1245,69 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         if (normalize) {
             #ifdef USE_GPU
                 #ifdef USE_BLAS
-                    gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_new_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
+                    gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0/zeroth_moment, d_population_new_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
                     GPU_ASSERT(deac_wait(default_stream));
                     #ifdef DEAC_TWO_SIDED_POPULATION
-                        gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_new_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
+                        gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0/zeroth_moment, d_population_new_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
                         GPU_ASSERT(deac_wait(default_stream));
                     #endif
                 #else
-                    gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_new_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
+                    gpu_deac_gemv(default_stream, population_size, genome_size, 1.0/zeroth_moment, d_population_new_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
                     GPU_ASSERT(deac_wait(default_stream));
                     #ifdef DEAC_TWO_SIDED_POPULATION
-                        gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_new_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
+                        gpu_deac_gemv(default_stream, population_size, genome_size, 1.0/zeroth_moment, d_population_new_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
                         GPU_ASSERT(deac_wait(default_stream));
                     #endif
                 #endif
 
-                gpu_deac_dgmmDiv1D(default_stream,
-                        d_population_new_positive_frequency,
-                #ifdef DEAC_TWO_SIDED_POPULATION
-                        d_population_new_negative_frequency,
-                #else
-                        nullptr,
+                #ifdef DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS
+                    // Test-only executable: deterministically exercise the
+                    // complete rejection path for degenerate evolved rows.
+                    GPU_ASSERT(deac_memset(
+                            d_normalization, 0,
+                            bytes_normalization, default_stream));
+                    GPU_ASSERT(deac_wait(default_stream));
                 #endif
+
+                GPU_ASSERT(deac_memset(
+                        d_normalization_valid, 1,
+                        bytes_normalization_valid, default_stream));
+                GPU_ASSERT(deac_wait(default_stream));
+                gpu_deac_dgmmDiv1D(stream_array[0],
+                        d_population_new_positive_frequency,
+                        d_normalization, population_size, genome_size);
+                #ifdef DEAC_TWO_SIDED_POPULATION
+                    gpu_deac_dgmmDiv1D(stream_array[1 % MAX_GPU_STREAMS],
+                            d_population_new_negative_frequency,
+                            d_normalization, population_size, genome_size);
+                    #if MAX_GPU_STREAMS > 1
+                        GPU_ASSERT(deac_wait(stream_array[1]));
+                    #endif
+                #endif
+                GPU_ASSERT(deac_wait(stream_array[0]));
+                gpu_validate_normalization_rows(stream_array[0],
+                        d_population_new_positive_frequency,
                         d_normalization, d_normalization_valid, zeroth_moment,
                         population_size, genome_size);
-                GPU_ASSERT(deac_wait(default_stream));
+                #ifdef DEAC_TWO_SIDED_POPULATION
+                    gpu_validate_normalization_rows(stream_array[1 % MAX_GPU_STREAMS],
+                            d_population_new_negative_frequency,
+                            d_normalization, d_normalization_valid, zeroth_moment,
+                            population_size, genome_size);
+                    #if MAX_GPU_STREAMS > 1
+                        GPU_ASSERT(deac_wait(stream_array[1]));
+                    #endif
+                #endif
+                GPU_ASSERT(deac_wait(stream_array[0]));
+                gpu_cleanup_invalid_normalization_rows(stream_array[0],
+                        d_population_new_positive_frequency,
+                        d_normalization_valid, population_size, genome_size);
+                #ifdef DEAC_TWO_SIDED_POPULATION
+                    gpu_cleanup_invalid_normalization_rows(stream_array[0],
+                            d_population_new_negative_frequency,
+                            d_normalization_valid, population_size, genome_size);
+                #endif
+                GPU_ASSERT(deac_wait(stream_array[0]));
             #else
                 for (size_t i=0; i<population_size; i++) {
                     normalization[i] = 0.0;
@@ -1249,6 +1317,11 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 #ifdef DEAC_TWO_SIDED_POPULATION
                     matrix_multiply_MxN_by_Nx1(normalization, population_new_negative_frequency,
                             normalization_term_negative_frequency, population_size, genome_size);
+                #endif
+                #ifdef DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS
+                    std::fill(
+                            normalization,
+                            normalization + population_size, 0.0);
                 #endif
                 for (size_t i=0; i<population_size; i++) {
                     normalization_valid[i] = deac_numerics::try_apply_normalization(
@@ -1265,6 +1338,13 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 }
             #endif
         }
+
+        #ifdef DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS
+            if (normalize) {
+                std::cout << "test_forced_invalid_normalization_trials: "
+                          << population_size << '\n';
+            }
+        #endif
 
         //Rejection
         //Set model isf for new population
@@ -1415,6 +1495,21 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                     d_fitness_new, d_fitness_old, d_normalization_valid,
                     normalize, population_size);
             GPU_ASSERT(deac_wait(default_stream));
+            #ifdef DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS
+                GPU_ASSERT(deac_memcpy_device_to_host(
+                        fitness_old, d_fitness_new,
+                        bytes_fitness, default_stream));
+                GPU_ASSERT(deac_wait(default_stream));
+                if (!std::all_of(
+                        fitness_old, fitness_old + population_size,
+                        [](double value) {
+                            return value == std::numeric_limits<double>::max();
+                        })) {
+                    fail_with_error(
+                            "forced invalid normalization trial did not "
+                            "receive DBL_MAX fitness");
+                }
+            #endif
 
             gpu_swap_control_parameters(stream_array[0], grid_size_swap_control_parameters, d_crossover_probabilities_old_positive_frequency, d_crossover_probabilities_new_positive_frequency, d_rejection_indices, population_size);
             gpu_swap_control_parameters(stream_array[1 % MAX_GPU_STREAMS], grid_size_swap_control_parameters, d_differential_weights_old_positive_frequency, d_differential_weights_new_positive_frequency, d_rejection_indices, population_size);
@@ -1463,6 +1558,13 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 if (normalize && !normalization_valid[i]) {
                     _fitness = std::numeric_limits<double>::max();
                 }
+                #ifdef DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS
+                    if (_fitness != std::numeric_limits<double>::max()) {
+                        fail_with_error(
+                                "forced invalid normalization trial did not "
+                                "receive DBL_MAX fitness");
+                    }
+                #endif
                 if ((!normalize || normalization_valid[i])
                         && _fitness <= fitness_old[i]) {
                     fitness_old[i] = _fitness;
@@ -1480,6 +1582,9 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                     }
                 }
             }
+        #endif
+        #ifdef DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS
+            std::cout << "test_invalid_normalization_fitness: DBL_MAX\n";
         #endif
     }
 

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -9,10 +9,12 @@
 #include <cmath>
 #include <cstdint>
 #include <exception>
+#include <limits>
 #include <span>
 #include <vector>
 #include <rng.hpp>
 #include "evolution_controls.hpp"
+#include "normalization.hpp"
 #include "population_projection.hpp"
 #include "result_io.hpp"
 #include "zero_temperature_kernel.hpp"
@@ -395,66 +397,48 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
 
     // Normalize population
     size_t bytes_normalization = sizeof(double)*population_size;
+    size_t bytes_normalization_valid = sizeof(bool)*population_size;
     size_t bytes_normalization_term = sizeof(double)*genome_size;
     double * normalization = nullptr;
+    bool * normalization_valid = nullptr;
     double * normalization_term_positive_frequency = nullptr;
     #ifdef DEAC_TWO_SIDED_POPULATION
         double * normalization_term_negative_frequency = nullptr;
     #endif
     #ifdef USE_GPU
-        double* d_normalization;
-        double* d_normalization_term_positive_frequency;
+        double* d_normalization = nullptr;
+        bool* d_normalization_valid = nullptr;
+        double* d_normalization_term_positive_frequency = nullptr;
         #ifdef DEAC_TWO_SIDED_POPULATION
             double* d_normalization_term_negative_frequency;
         #endif
     #endif
     if (normalize) {
         normalization = (double*) malloc(bytes_normalization);
+        normalization_valid = (bool*) malloc(bytes_normalization_valid);
         normalization_term_positive_frequency = (double*) malloc(bytes_normalization_term);
         #ifdef DEAC_TWO_SIDED_POPULATION
             normalization_term_negative_frequency = (double*) malloc(bytes_normalization_term);
         #endif
-        for (size_t j=0; j<genome_size; j++) {
-            double f = frequency[j];
-            (void) f;
-            const double df = frequency_weights[j];
-            #ifndef ZEROT
-                #ifdef USE_HYPERBOLIC_MODEL
-                    #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-                        normalization_term_positive_frequency[j] = df*cosh(0.5*beta*f);
-                    #else
-                        normalization_term_positive_frequency[j] = 0.5*df/exp(-0.5*beta*f);
-                        normalization_term_negative_frequency[j] = 0.5*df*exp(-0.5*beta*f);
-                    #endif
-                #endif
-                #ifdef USE_STANDARD_MODEL
-                    #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-                        normalization_term_positive_frequency[j] = df*(1.0 + exp(-beta*f));
-                    #else
-                        normalization_term_positive_frequency[j] = df;
-                        normalization_term_negative_frequency[j] = df;
-                    #endif
-                #endif
-                #ifdef USE_NORMALIZATION_MODEL
-                    #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-                        normalization_term_positive_frequency[j] = df;
-                    #else
-                        normalization_term_positive_frequency[j] = df*(1.0/(1.0 + exp(-beta*f)));
-                        double e_to_bf = exp(-beta*f); // exp(beta*f) for negative f
-                        normalization_term_negative_frequency[j] = df*(e_to_bf/(1.0 + e_to_bf));
-                    #endif
-                #endif
-            #else
-                normalization_term_positive_frequency[j] = df;
-                #ifdef DEAC_TWO_SIDED_POPULATION
-                    normalization_term_negative_frequency[j] = df;
-                #endif
-            #endif
-        }
+        const deac_numerics::NormalizationTerms normalization_terms =
+                deac_numerics::make_normalization_terms(
+                        std::span<const double>(frequency, genome_size),
+                        frequency_weights, temperature);
+        std::copy(
+                normalization_terms.positive_frequency.begin(),
+                normalization_terms.positive_frequency.end(),
+                normalization_term_positive_frequency);
+        #ifdef DEAC_TWO_SIDED_POPULATION
+            std::copy(
+                    normalization_terms.negative_frequency.begin(),
+                    normalization_terms.negative_frequency.end(),
+                    normalization_term_negative_frequency);
+        #endif
 
         #ifdef USE_GPU
             //Load normalization terms onto GPU
             GPU_ASSERT(deac_malloc_device(double, d_normalization,                         population_size, default_stream));
+            GPU_ASSERT(deac_malloc_device(bool,   d_normalization_valid,                   population_size, default_stream));
             GPU_ASSERT(deac_malloc_device(double, d_normalization_term_positive_frequency, genome_size,     default_stream));
             GPU_ASSERT(deac_wait(default_stream));
             GPU_ASSERT(deac_memcpy_host_to_device(d_normalization_term_positive_frequency, normalization_term_positive_frequency, bytes_normalization_term, default_stream));
@@ -472,29 +456,41 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             GPU_ASSERT(deac_wait(default_stream));
 
             #ifdef USE_BLAS
-                gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0/zeroth_moment, d_population_old_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
+                gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_old_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
                 GPU_ASSERT(deac_wait(default_stream));
                 #ifdef DEAC_TWO_SIDED_POPULATION
-                    gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0/zeroth_moment, d_population_old_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
+                    gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_old_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
             #else
-                gpu_deac_gemv(default_stream, population_size, genome_size, 1.0/zeroth_moment, d_population_old_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
+                gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_old_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
                 GPU_ASSERT(deac_wait(default_stream));
                 #ifdef DEAC_TWO_SIDED_POPULATION
-                    gpu_deac_gemv(default_stream, population_size, genome_size, 1.0/zeroth_moment, d_population_old_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
+                    gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_old_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
                     GPU_ASSERT(deac_wait(default_stream));
                 #endif
             #endif
 
-            gpu_deac_dgmmDiv1D(stream_array[0], d_population_old_positive_frequency, d_normalization, population_size, genome_size); 
+            gpu_deac_dgmmDiv1D(default_stream, d_population_old_positive_frequency,
             #ifdef DEAC_TWO_SIDED_POPULATION
-                gpu_deac_dgmmDiv1D(stream_array[1 % MAX_GPU_STREAMS], d_population_old_negative_frequency, d_normalization, population_size, genome_size); 
-                #if MAX_GPU_STREAMS > 1
-                    GPU_ASSERT(deac_wait(stream_array[1]));
-                #endif
+                    d_population_old_negative_frequency,
+            #else
+                    nullptr,
             #endif
-            GPU_ASSERT(deac_wait(stream_array[0]));
+                    d_normalization, d_normalization_valid, zeroth_moment,
+                    population_size, genome_size);
+            GPU_ASSERT(deac_wait(default_stream));
+            GPU_ASSERT(deac_memcpy_device_to_host(
+                    normalization_valid, d_normalization_valid,
+                    bytes_normalization_valid, default_stream));
+            GPU_ASSERT(deac_wait(default_stream));
+            if (!std::all_of(
+                    normalization_valid, normalization_valid + population_size,
+                    [](bool valid) { return valid; })) {
+                fail_with_error(
+                        "initial population contains an unrepresentable "
+                        "normalization row");
+            }
         #else
             for (size_t i=0; i<population_size; i++) {
                 normalization[i] = 0.0;
@@ -506,12 +502,21 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                         normalization_term_negative_frequency, population_size, genome_size);
             #endif
             for (size_t i=0; i<population_size; i++) {
-                double _norm = normalization[i];
-                for (size_t j=0; j<genome_size; j++) {
-                    population_old_positive_frequency[i*genome_size + j] *= zeroth_moment/_norm;
-                    #ifdef DEAC_TWO_SIDED_POPULATION
-                        population_old_negative_frequency[i*genome_size + j] *= zeroth_moment/_norm;
-                    #endif
+                const bool valid = deac_numerics::try_apply_normalization(
+                        zeroth_moment, normalization[i],
+                        std::span<double>(
+                                population_old_positive_frequency + i*genome_size,
+                                genome_size)
+                        #ifdef DEAC_TWO_SIDED_POPULATION
+                            , std::span<double>(
+                                    population_old_negative_frequency + i*genome_size,
+                                    genome_size)
+                        #endif
+                        );
+                if (!valid) {
+                    fail_with_error(
+                            "initial population contains an unrepresentable "
+                            "normalization row");
                 }
             }
         #endif
@@ -1210,30 +1215,31 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         if (normalize) {
             #ifdef USE_GPU
                 #ifdef USE_BLAS
-                    gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0/zeroth_moment, d_population_new_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
+                    gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_new_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
                     GPU_ASSERT(deac_wait(default_stream));
                     #ifdef DEAC_TWO_SIDED_POPULATION
-                        gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0/zeroth_moment, d_population_new_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
+                        gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_new_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
                         GPU_ASSERT(deac_wait(default_stream));
                     #endif
                 #else
-                    gpu_deac_gemv(default_stream, population_size, genome_size, 1.0/zeroth_moment, d_population_new_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
+                    gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_new_positive_frequency, d_normalization_term_positive_frequency, 0.0, d_normalization);
                     GPU_ASSERT(deac_wait(default_stream));
                     #ifdef DEAC_TWO_SIDED_POPULATION
-                        gpu_deac_gemv(default_stream, population_size, genome_size, 1.0/zeroth_moment, d_population_new_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
+                        gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_new_negative_frequency, d_normalization_term_negative_frequency, 1.0, d_normalization);
                         GPU_ASSERT(deac_wait(default_stream));
                     #endif
                 #endif
 
-                gpu_deac_dgmmDiv1D(stream_array[0], d_population_new_positive_frequency, d_normalization, population_size, genome_size); 
+                gpu_deac_dgmmDiv1D(default_stream,
+                        d_population_new_positive_frequency,
                 #ifdef DEAC_TWO_SIDED_POPULATION
-                    gpu_deac_dgmmDiv1D(stream_array[1 % MAX_GPU_STREAMS], d_population_new_negative_frequency, d_normalization, population_size, genome_size); 
-                    GPU_ASSERT(deac_wait(stream_array[1 % MAX_GPU_STREAMS]));
-                    #if MAX_GPU_STREAMS > 1
-                        GPU_ASSERT(deac_wait(stream_array[1]));
-                    #endif
+                        d_population_new_negative_frequency,
+                #else
+                        nullptr,
                 #endif
-                GPU_ASSERT(deac_wait(stream_array[0]));
+                        d_normalization, d_normalization_valid, zeroth_moment,
+                        population_size, genome_size);
+                GPU_ASSERT(deac_wait(default_stream));
             #else
                 for (size_t i=0; i<population_size; i++) {
                     normalization[i] = 0.0;
@@ -1245,13 +1251,17 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                             normalization_term_negative_frequency, population_size, genome_size);
                 #endif
                 for (size_t i=0; i<population_size; i++) {
-                    double _norm = normalization[i];
-                    for (size_t j=0; j<genome_size; j++) {
-                        population_new_positive_frequency[i*genome_size + j] *= zeroth_moment/_norm;
-                        #ifdef DEAC_TWO_SIDED_POPULATION
-                            population_new_negative_frequency[i*genome_size + j] *= zeroth_moment/_norm;
-                        #endif
-                    }
+                    normalization_valid[i] = deac_numerics::try_apply_normalization(
+                            zeroth_moment, normalization[i],
+                            std::span<double>(
+                                    population_new_positive_frequency + i*genome_size,
+                                    genome_size)
+                            #ifdef DEAC_TWO_SIDED_POPULATION
+                                , std::span<double>(
+                                        population_new_negative_frequency + i*genome_size,
+                                        genome_size)
+                            #endif
+                            );
                 }
             #endif
         }
@@ -1400,7 +1410,10 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             size_t grid_size_swap_control_parameters = (population_size + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE;
             size_t grid_size_swap_populations = (population_size*genome_size + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE;
 
-            gpu_set_rejection_indices(default_stream, grid_size_set_rejection_indices, d_rejection_indices, d_fitness_new, d_fitness_old, population_size);
+            gpu_set_rejection_indices(default_stream,
+                    grid_size_set_rejection_indices, d_rejection_indices,
+                    d_fitness_new, d_fitness_old, d_normalization_valid,
+                    normalize, population_size);
             GPU_ASSERT(deac_wait(default_stream));
 
             gpu_swap_control_parameters(stream_array[0], grid_size_swap_control_parameters, d_crossover_probabilities_old_positive_frequency, d_crossover_probabilities_new_positive_frequency, d_rejection_indices, population_size);
@@ -1447,7 +1460,11 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                     _fitness += pow((third_moment - third_moments[i])/third_moment_error,2);
                 }
                 // Rejection step
-                if (_fitness <= fitness_old[i]) {
+                if (normalize && !normalization_valid[i]) {
+                    _fitness = std::numeric_limits<double>::max();
+                }
+                if ((!normalize || normalization_valid[i])
+                        && _fitness <= fitness_old[i]) {
                     fitness_old[i] = _fitness;
                     crossover_probabilities_old_positive_frequency[i] = crossover_probabilities_new_positive_frequency[i];
                     differential_weights_old_positive_frequency[i] = differential_weights_new_positive_frequency[i];
@@ -1703,6 +1720,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     free(population_new_positive_frequency);
     if (normalize) {
         free(normalization);
+        free(normalization_valid);
         free(normalization_term_positive_frequency);
     }
     if (use_first_moment) {
@@ -1775,7 +1793,8 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         GPU_ASSERT(deac_free(d_isf_model,                         stream_array[13 % MAX_GPU_STREAMS]));
         if (normalize) {
             GPU_ASSERT(deac_free(d_normalization,                         stream_array[14 % MAX_GPU_STREAMS]));
-            GPU_ASSERT(deac_free(d_normalization_term_positive_frequency, stream_array[15 % MAX_GPU_STREAMS]));
+            GPU_ASSERT(deac_free(d_normalization_valid,                   stream_array[15 % MAX_GPU_STREAMS]));
+            GPU_ASSERT(deac_free(d_normalization_term_positive_frequency, stream_array[16 % MAX_GPU_STREAMS]));
         }
         if (use_first_moment) {
             GPU_ASSERT(deac_free(d_first_moments,                         stream_array[16 % MAX_GPU_STREAMS]));
@@ -1873,7 +1892,9 @@ int deac_main (int argc, char *argv[]) {
     program.add_argument("--frequency_file")
         .help("Filename containing frequency partition (genome_size and omega_max will be ignored).");
     program.add_argument("--normalize")
-        .help("Normalize spectrum to the zeroeth moment.")
+        .help("Normalize spectrum to the zeroth moment from the first ISF "
+              "value, which must be finite, positive, normal, and representable "
+              "for the selected model and frequency grid.")
         .default_value(false)
         .implicit_value(true);
     program.add_argument("--use_negative_first_moment")
@@ -1968,7 +1989,6 @@ int deac_main (int argc, char *argv[]) {
     if (uuid_str == "") {
         uuid_str = std::to_string(program.get<unsigned long>("--seed"));
     }
-    std::cout << "uuid: " << uuid_str << std::endl;
 
     std::string spectra_type = program.get<std::string>("--spectra_type");
     #ifdef ZEROT
@@ -2008,6 +2028,14 @@ int deac_main (int argc, char *argv[]) {
     double * const imaginary_time = numpy_data.data();
     double * const isf = numpy_data.data() + number_of_timeslices;
     double * const isf_error = numpy_data.data() + 2*number_of_timeslices;
+    bool normalize = program.get<bool>("--normalize");
+    if (normalize) {
+        deac_numerics::validate_normalization_target(isf[0]);
+        #ifdef ALLOW_NEGATIVE_SPECTRAL_WEIGHT
+            fail_with_error(
+                    "--normalize is incompatible with negative spectral weights");
+        #endif
+    }
     for (size_t i=0; i<number_of_timeslices; i++) {
         if (!std::isfinite(imaginary_time[i]) || !std::isfinite(isf[i]) || !std::isfinite(isf_error[i])) {
             fail_with_error("ISF input file contains non-finite values");
@@ -2074,8 +2102,16 @@ int deac_main (int argc, char *argv[]) {
             fail_with_error("frequencies must be strictly increasing");
         }
     }
+    if (normalize) {
+        const std::vector<double> frequency_weights =
+                deac_numerics::trapezoidal_weights(frequency_data);
+        const deac_numerics::NormalizationTerms normalization_terms =
+                deac_numerics::make_normalization_terms(
+                        frequency_data, frequency_weights, temperature);
+        deac_numerics::validate_initial_normalization_scale(
+                isf[0], normalization_terms.maximum_initial_denominator);
+    }
 
-    bool normalize = program.get<bool>("--normalize");
     bool use_negative_first_moment = program.get<bool>("--use_negative_first_moment");
     #if !defined(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF) || defined(ZEROT)
         if (use_negative_first_moment) {
@@ -2100,6 +2136,7 @@ int deac_main (int argc, char *argv[]) {
     bool track_stats = program.get<bool>("--track_stats");
     std::string save_directory_str = program.get<std::string>("--save_directory");
     fs::path save_directory(save_directory_str);
+    std::cout << "uuid: " << uuid_str << std::endl;
     deac_io::ensure_result_directory(save_directory);
 
     //Write to log file

--- a/src/deac/src/deac_gpu.cu
+++ b/src/deac/src/deac_gpu.cu
@@ -403,38 +403,30 @@ void gpu_get_minimum(double* __restrict__ minimum, double* __restrict__ array, s
     }
 }
 
-__global__ void gpu_deac_dgmmDiv1D(double* __restrict__ positive_matrix,
-        double* __restrict__ negative_matrix,
-        const double* __restrict__ vector, bool* __restrict__ valid_rows,
+__global__ void gpu_deac_dgmmDiv1D(double* __restrict__ matrix,
+        double* __restrict__ vector, size_t rows, size_t cols) {
+    size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < rows * cols) {
+        size_t row = idx % rows;
+        double reciprocal = 1.0/vector[row];
+        matrix[idx] *= reciprocal;
+    }
+}
+
+__global__ void gpu_validate_normalization_rows_kernel(
+        const double* __restrict__ matrix,
+        const double* __restrict__ vector, int* __restrict__ valid_rows,
         double target, size_t rows, size_t cols) {
-    const size_t row = blockIdx.x * blockDim.x + threadIdx.x;
-    if (row < rows) {
-        const double scale = target/vector[row];
-        bool valid = vector[row] >= DBL_MIN && vector[row] <= DBL_MAX
-                && scale >= DBL_MIN && scale <= DBL_MAX;
-        if (valid) {
-            for (size_t col=0; col<cols; ++col) {
-                const size_t idx = row + col*rows;
-                positive_matrix[idx] *= scale;
-                valid = valid && isfinite(positive_matrix[idx]);
-            }
-            if (negative_matrix != nullptr) {
-                for (size_t col=0; col<cols; ++col) {
-                    const size_t idx = row + col*rows;
-                    negative_matrix[idx] *= scale;
-                    valid = valid && isfinite(negative_matrix[idx]);
-                }
-            }
+    const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < rows*cols) {
+        const size_t row = idx % rows;
+        const double denominator = vector[row]*target;
+        const double reciprocal = 1.0/vector[row];
+        if (!(denominator >= DBL_MIN && denominator <= DBL_MAX
+                    && reciprocal >= DBL_MIN && reciprocal <= DBL_MAX
+                    && isfinite(matrix[idx]))) {
+            atomicExch(valid_rows + row, 0);
         }
-        if (!valid) {
-            for (size_t col=0; col<cols; ++col) {
-                positive_matrix[row + col*rows] = 0.0;
-                if (negative_matrix != nullptr) {
-                    negative_matrix[row + col*rows] = 0.0;
-                }
-            }
-        }
-        valid_rows[row] = valid;
     }
 }
 
@@ -575,14 +567,14 @@ void gpu_match_population_zero(double* __restrict__ population_negative_frequenc
 __global__
 void gpu_set_rejection_indices(bool* __restrict__ rejection_indices,
         double* __restrict__ fitness_new, double* __restrict__ fitness_old,
-        const bool* __restrict__ normalization_valid, bool normalize,
+        const int* __restrict__ normalization_valid, bool normalize,
         size_t population_size) {
     size_t global_idx = blockDim.x*blockIdx.x + threadIdx.x;
     if (global_idx < population_size) {
-        if (normalize && !normalization_valid[global_idx]) {
+        if (normalize && normalization_valid[global_idx] == 0) {
             fitness_new[global_idx] = DBL_MAX;
         }
-        bool accept = (!normalize || normalization_valid[global_idx])
+        bool accept = (!normalize || normalization_valid[global_idx] != 0)
                 && fitness_new[global_idx] <= fitness_old[global_idx];
         rejection_indices[global_idx] = accept;
         if (accept) {
@@ -693,14 +685,41 @@ void gpu_get_minimum(cudaStream_t s, double* __restrict__ minimum, double* __res
     gpu_get_minimum<<<dim3(1), dim3(GPU_BLOCK_SIZE), 0, s>>>(minimum, array, N);
 }
 
-void gpu_deac_dgmmDiv1D(cudaStream_t s, double* __restrict__ positive_matrix,
-        double* __restrict__ negative_matrix,
-        const double* __restrict__ vector, bool* __restrict__ valid_rows,
-        double target, size_t rows, size_t cols) {
-    gpu_deac_dgmmDiv1D<<<dim3((rows + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE),
+void gpu_deac_dgmmDiv1D(cudaStream_t s, double* __restrict__ matrix,
+        double* __restrict__ vector, size_t rows, size_t cols) {
+    gpu_deac_dgmmDiv1D<<<dim3((rows*cols + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE),
             dim3(GPU_BLOCK_SIZE), 0, s>>>(
-                    positive_matrix, negative_matrix, vector, valid_rows,
-                    target, rows, cols);
+                    matrix, vector, rows, cols);
+}
+
+void gpu_validate_normalization_rows(cudaStream_t s,
+        const double* __restrict__ matrix,
+        const double* __restrict__ vector, int* __restrict__ valid_rows,
+        double target, size_t rows, size_t cols) {
+    gpu_validate_normalization_rows_kernel<<<
+            dim3((rows*cols + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE),
+            dim3(GPU_BLOCK_SIZE), 0, s>>>(
+                    matrix, vector, valid_rows, target, rows, cols);
+}
+
+__global__ void gpu_cleanup_invalid_normalization_rows_kernel(
+        double* __restrict__ matrix, const int* __restrict__ valid_rows,
+        size_t rows, size_t cols) {
+    const size_t row = blockDim.x*blockIdx.x + threadIdx.x;
+    if (row < rows && valid_rows[row] == 0) {
+        for (size_t col=0; col<cols; ++col) {
+            matrix[row + rows*col] = 0.0;
+        }
+    }
+}
+
+void gpu_cleanup_invalid_normalization_rows(cudaStream_t s,
+        double* __restrict__ matrix, const int* __restrict__ valid_rows,
+        size_t rows, size_t cols) {
+    const size_t grid_size = (rows + GPU_BLOCK_SIZE - 1)/GPU_BLOCK_SIZE;
+    gpu_cleanup_invalid_normalization_rows_kernel<<<
+            dim3(grid_size), dim3(GPU_BLOCK_SIZE), 0, s>>>(
+                    matrix, valid_rows, rows, cols);
 }
 
 void gpu_deac_reduced_chi_squared(cudaStream_t s, const double* __restrict__ calculated_data, const double* __restrict__ observed_data, const double* __restrict__ standard_deviations, double* __restrict__ reduced_chi_squared, size_t m, size_t n, size_t ddof, double beta) {
@@ -730,7 +749,7 @@ void gpu_match_population_zero(cudaStream_t s, size_t grid_size, double* __restr
 void gpu_set_rejection_indices(cudaStream_t s, size_t grid_size,
         bool* __restrict__ rejection_indices, double* __restrict__ fitness_new,
         double* __restrict__ fitness_old,
-        const bool* __restrict__ normalization_valid, bool normalize,
+        const int* __restrict__ normalization_valid, bool normalize,
         size_t population_size) {
     gpu_set_rejection_indices<<<dim3(grid_size), dim3(GPU_BLOCK_SIZE), 0, s>>>(
             rejection_indices, fitness_new, fitness_old,

--- a/src/deac/src/deac_gpu.cu
+++ b/src/deac/src/deac_gpu.cu
@@ -403,14 +403,38 @@ void gpu_get_minimum(double* __restrict__ minimum, double* __restrict__ array, s
     }
 }
 
-__global__ void gpu_deac_dgmmDiv1D(double* __restrict__ matrix, double* __restrict__ vector, size_t rows, size_t cols) {
-    size_t idx = blockIdx.x * blockDim.x + threadIdx.x; // 1D index for the entire matrix
-    if (idx < rows * cols) { // Ensure we do not go out of bounds
-        size_t row = idx % rows; // Calculate the row index
-        //size_t col = idx / rows; // Calculate the column index, assuming column-major order
-        double reciprocal = 1.0/vector[row];
-        // Perform the division operation
-        matrix[idx] *= reciprocal;
+__global__ void gpu_deac_dgmmDiv1D(double* __restrict__ positive_matrix,
+        double* __restrict__ negative_matrix,
+        const double* __restrict__ vector, bool* __restrict__ valid_rows,
+        double target, size_t rows, size_t cols) {
+    const size_t row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row < rows) {
+        const double scale = target/vector[row];
+        bool valid = vector[row] >= DBL_MIN && vector[row] <= DBL_MAX
+                && scale >= DBL_MIN && scale <= DBL_MAX;
+        if (valid) {
+            for (size_t col=0; col<cols; ++col) {
+                const size_t idx = row + col*rows;
+                positive_matrix[idx] *= scale;
+                valid = valid && isfinite(positive_matrix[idx]);
+            }
+            if (negative_matrix != nullptr) {
+                for (size_t col=0; col<cols; ++col) {
+                    const size_t idx = row + col*rows;
+                    negative_matrix[idx] *= scale;
+                    valid = valid && isfinite(negative_matrix[idx]);
+                }
+            }
+        }
+        if (!valid) {
+            for (size_t col=0; col<cols; ++col) {
+                positive_matrix[row + col*rows] = 0.0;
+                if (negative_matrix != nullptr) {
+                    negative_matrix[row + col*rows] = 0.0;
+                }
+            }
+        }
+        valid_rows[row] = valid;
     }
 }
 
@@ -549,10 +573,17 @@ void gpu_match_population_zero(double* __restrict__ population_negative_frequenc
 }
 
 __global__
-void gpu_set_rejection_indices(bool* __restrict__ rejection_indices, double* __restrict__ fitness_new, double* __restrict__ fitness_old, size_t population_size) {
+void gpu_set_rejection_indices(bool* __restrict__ rejection_indices,
+        double* __restrict__ fitness_new, double* __restrict__ fitness_old,
+        const bool* __restrict__ normalization_valid, bool normalize,
+        size_t population_size) {
     size_t global_idx = blockDim.x*blockIdx.x + threadIdx.x;
     if (global_idx < population_size) {
-        bool accept = fitness_new[global_idx] <= fitness_old[global_idx];
+        if (normalize && !normalization_valid[global_idx]) {
+            fitness_new[global_idx] = DBL_MAX;
+        }
+        bool accept = (!normalize || normalization_valid[global_idx])
+                && fitness_new[global_idx] <= fitness_old[global_idx];
         rejection_indices[global_idx] = accept;
         if (accept) {
             fitness_old[global_idx] = fitness_new[global_idx];
@@ -662,8 +693,14 @@ void gpu_get_minimum(cudaStream_t s, double* __restrict__ minimum, double* __res
     gpu_get_minimum<<<dim3(1), dim3(GPU_BLOCK_SIZE), 0, s>>>(minimum, array, N);
 }
 
-void gpu_deac_dgmmDiv1D(cudaStream_t s, double* __restrict__ matrix, double* __restrict__ vector, size_t rows, size_t cols) {
-    gpu_deac_dgmmDiv1D<<<dim3((rows*cols + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE), dim3(GPU_BLOCK_SIZE), 0, s>>>(matrix, vector, rows, cols);
+void gpu_deac_dgmmDiv1D(cudaStream_t s, double* __restrict__ positive_matrix,
+        double* __restrict__ negative_matrix,
+        const double* __restrict__ vector, bool* __restrict__ valid_rows,
+        double target, size_t rows, size_t cols) {
+    gpu_deac_dgmmDiv1D<<<dim3((rows + GPU_BLOCK_SIZE - 1) / GPU_BLOCK_SIZE),
+            dim3(GPU_BLOCK_SIZE), 0, s>>>(
+                    positive_matrix, negative_matrix, vector, valid_rows,
+                    target, rows, cols);
 }
 
 void gpu_deac_reduced_chi_squared(cudaStream_t s, const double* __restrict__ calculated_data, const double* __restrict__ observed_data, const double* __restrict__ standard_deviations, double* __restrict__ reduced_chi_squared, size_t m, size_t n, size_t ddof, double beta) {
@@ -690,8 +727,14 @@ void gpu_match_population_zero(cudaStream_t s, size_t grid_size, double* __restr
     gpu_match_population_zero<<<dim3(grid_size), dim3(GPU_BLOCK_SIZE), 0, s>>>(population_negative_frequency, population_positive_frequency, population_size, genome_size);
 }
 
-void gpu_set_rejection_indices(cudaStream_t s, size_t grid_size, bool* __restrict__ rejection_indices, double* __restrict__ fitness_new, double* __restrict__ fitness_old, size_t population_size) {
-    gpu_set_rejection_indices<<<dim3(grid_size), dim3(GPU_BLOCK_SIZE), 0, s>>>(rejection_indices, fitness_new, fitness_old, population_size);
+void gpu_set_rejection_indices(cudaStream_t s, size_t grid_size,
+        bool* __restrict__ rejection_indices, double* __restrict__ fitness_new,
+        double* __restrict__ fitness_old,
+        const bool* __restrict__ normalization_valid, bool normalize,
+        size_t population_size) {
+    gpu_set_rejection_indices<<<dim3(grid_size), dim3(GPU_BLOCK_SIZE), 0, s>>>(
+            rejection_indices, fitness_new, fitness_old,
+            normalization_valid, normalize, population_size);
 }
 
 void gpu_swap_control_parameters(cudaStream_t s, size_t grid_size, double* __restrict__ control_parameter_old, double* __restrict__ control_parameter_new, bool* __restrict__ rejection_indices, size_t population_size) {

--- a/src/deac/src/normalization.hpp
+++ b/src/deac/src/normalization.hpp
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace deac_numerics {
+
+inline void validate_normalization_target(double target) {
+    if (!std::isfinite(target)
+            || target < std::numeric_limits<double>::min()) {
+        throw std::invalid_argument(
+                "--normalize requires the first ISF value (zeroth moment) "
+                "to be finite, positive, and at least the smallest normal double");
+    }
+}
+
+struct NormalizationTerms {
+    std::vector<double> positive_frequency;
+    std::vector<double> negative_frequency;
+    double maximum_initial_denominator = 0.0;
+};
+
+inline NormalizationTerms make_normalization_terms(
+        std::span<const double> frequency,
+        std::span<const double> frequency_weights,
+        double temperature) {
+    NormalizationTerms terms;
+    terms.positive_frequency.resize(frequency.size());
+    #if !defined(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF) && !defined(ZEROT)
+        terms.negative_frequency.resize(frequency.size());
+    #endif
+
+    #ifndef ZEROT
+        [[maybe_unused]] const double beta = 1.0/temperature;
+    #else
+        (void) temperature;
+    #endif
+
+    for (std::size_t index=0; index<frequency.size(); ++index) {
+        [[maybe_unused]] const double value = frequency[index];
+        const double weight = frequency_weights[index];
+        double positive_term;
+        #if !defined(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF) && !defined(ZEROT)
+            double negative_term;
+        #endif
+
+        #ifndef ZEROT
+            #ifdef USE_HYPERBOLIC_MODEL
+                #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    positive_term = weight*std::cosh(0.5*beta*value);
+                #else
+                    positive_term = 0.5*weight/std::exp(-0.5*beta*value);
+                    negative_term = 0.5*weight*std::exp(-0.5*beta*value);
+                #endif
+            #endif
+            #ifdef USE_STANDARD_MODEL
+                #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    positive_term = weight*(1.0 + std::exp(-beta*value));
+                #else
+                    positive_term = weight;
+                    negative_term = weight;
+                #endif
+            #endif
+            #ifdef USE_NORMALIZATION_MODEL
+                #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                    positive_term = weight;
+                #else
+                    positive_term = weight*(1.0/(1.0 + std::exp(-beta*value)));
+                    const double e_to_bf = std::exp(-beta*value);
+                    negative_term = weight*(e_to_bf/(1.0 + e_to_bf));
+                #endif
+            #endif
+        #else
+            positive_term = weight;
+        #endif
+
+        if (!std::isfinite(positive_term) || positive_term < 0.0) {
+            throw std::invalid_argument(
+                    "normalization weights must be finite and non-negative");
+        }
+        terms.positive_frequency[index] = positive_term;
+        terms.maximum_initial_denominator += positive_term;
+
+        #if !defined(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF) && !defined(ZEROT)
+            if (!std::isfinite(negative_term) || negative_term < 0.0) {
+                throw std::invalid_argument(
+                        "normalization weights must be finite and non-negative");
+            }
+            terms.negative_frequency[index] = negative_term;
+            terms.maximum_initial_denominator += negative_term;
+        #endif
+        if (!std::isfinite(terms.maximum_initial_denominator)) {
+            throw std::invalid_argument(
+                    "normalization weight sum must be finite");
+        }
+    }
+
+    if (terms.maximum_initial_denominator <= 0.0) {
+        throw std::invalid_argument(
+                "normalization weight sum must be positive");
+    }
+    return terms;
+}
+
+inline void validate_initial_normalization_scale(
+        double target, double maximum_initial_denominator) {
+    validate_normalization_target(target);
+    const double minimum_scale = target/maximum_initial_denominator;
+    if (!std::isnormal(maximum_initial_denominator)
+            || !std::isnormal(minimum_scale)) {
+        throw std::invalid_argument(
+                "--normalize target is outside the representable normal range "
+                "for this model and frequency grid");
+    }
+}
+
+inline double checked_normalization_scale(double target, double denominator) {
+    validate_normalization_target(target);
+    if (!std::isnormal(denominator) || denominator <= 0.0) {
+        throw std::runtime_error(
+                "population normalization denominator must be finite, positive, "
+                "and normal");
+    }
+
+    const double scale = target/denominator;
+    if (!std::isnormal(scale)) {
+        throw std::runtime_error(
+                "population normalization scale must be finite, positive, and normal");
+    }
+    return scale;
+}
+
+inline bool try_apply_normalization(
+        double target,
+        double denominator,
+        std::span<double> positive_frequency,
+        std::span<double> negative_frequency = {}) {
+    if (!std::isnormal(denominator) || denominator <= 0.0) {
+        std::fill(positive_frequency.begin(), positive_frequency.end(), 0.0);
+        std::fill(negative_frequency.begin(), negative_frequency.end(), 0.0);
+        return false;
+    }
+
+    const double scale = target/denominator;
+    if (!std::isnormal(scale) || scale <= 0.0) {
+        std::fill(positive_frequency.begin(), positive_frequency.end(), 0.0);
+        std::fill(negative_frequency.begin(), negative_frequency.end(), 0.0);
+        return false;
+    }
+
+    bool valid = true;
+    for (double& value : positive_frequency) {
+        value *= scale;
+        valid = valid && std::isfinite(value);
+    }
+    for (double& value : negative_frequency) {
+        value *= scale;
+        valid = valid && std::isfinite(value);
+    }
+    if (!valid) {
+        std::fill(positive_frequency.begin(), positive_frequency.end(), 0.0);
+        std::fill(negative_frequency.begin(), negative_frequency.end(), 0.0);
+    }
+    return valid;
+}
+
+} // namespace deac_numerics

--- a/test/deac_invalid_normalization_evolution_test.py
+++ b/test/deac_invalid_normalization_evolution_test.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+import argparse
+import math
+import shutil
+import struct
+import subprocess
+from pathlib import Path
+
+
+def write_doubles(path, values):
+    path.write_bytes(struct.pack("<" + "d" * len(values), *values))
+
+
+def read_doubles(path):
+    data = path.read_bytes()
+    if len(data) % 8:
+        raise AssertionError(f"{path} does not contain whole doubles")
+    return struct.unpack("<" + "d" * (len(data) // 8), data)
+
+
+def run_solver(
+    exe,
+    workdir,
+    fixture,
+    frequency_file,
+    save_dir,
+    uuid,
+    stop_minimum_fitness,
+    detailed_balance,
+    zero_temperature,
+):
+    command = [
+        exe,
+        "--temperature",
+        "0" if zero_temperature else "1",
+        "--number_of_generations",
+        "2",
+        "--population_size",
+        "4",
+        "--frequency_file",
+        str(frequency_file),
+        "--normalize",
+        "--crossover_probability",
+        "1",
+        "--self_adapting_crossover_probability",
+        "0",
+        "--differential_weight",
+        "2",
+        "--self_adapting_differential_weight_probability",
+        "0",
+        "--stop_minimum_fitness",
+        stop_minimum_fitness,
+        "--track_stats",
+        "--save_directory",
+        str(save_dir),
+        "--seed",
+        "17",
+        "--uuid",
+        uuid,
+    ]
+    if not detailed_balance and not zero_temperature:
+        command.extend(["--spectra_type", "bfull"])
+    command.append(str(fixture))
+    result = subprocess.run(
+        command,
+        cwd=workdir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode:
+        raise AssertionError(
+            f"solver failed with {result.returncode}\n"
+            f"command: {' '.join(command)}\noutput:\n{result.stdout}"
+        )
+    return result
+
+
+def prefix(detailed_balance, zero_temperature):
+    if zero_temperature:
+        return "deac-zT"
+    return "deac-bdsf" if detailed_balance else "deac-bfull"
+
+
+def assert_normalized(spectrum, detailed_balance, zero_temperature):
+    weights = (1.5, 1.5)
+    if zero_temperature:
+        moment = sum(weight * value for weight, value in zip(weights, spectrum))
+    elif detailed_balance:
+        frequency = (0.0, 3.0)
+        moment = sum(
+            weight * value * (1.0 + math.exp(-omega))
+            for weight, value, omega in zip(weights, spectrum, frequency)
+        )
+    else:
+        # Two-sided bfull output is ordered [-3, 0, 3].  The zero-frequency
+        # value participates in both population halves in the solver's rule.
+        moment = weights[0] * (spectrum[1] + spectrum[1])
+        moment += weights[1] * (spectrum[2] + spectrum[0])
+    if not math.isclose(moment, 1.0, rel_tol=1e-12, abs_tol=1e-12):
+        raise AssertionError(f"incumbent lost normalization: {moment}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reference-exe", required=True)
+    parser.add_argument("--forced-exe", required=True)
+    parser.add_argument("--workdir", required=True)
+    parser.add_argument("--detailed-balance", action="store_true")
+    parser.add_argument("--zero-temperature", action="store_true")
+    args = parser.parse_args()
+
+    workdir = Path(args.workdir)
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+    fixture = workdir / "positive-isf.bin"
+    frequency_file = workdir / "frequency.bin"
+    write_doubles(
+        fixture,
+        [0.0, 0.2, 0.4, 0.6]
+        + [1.0, 0.85, 0.72, 0.61]
+        + [0.05, 0.05, 0.05, 0.05],
+    )
+    write_doubles(frequency_file, [0.0, 3.0])
+
+    initial_dir = workdir / "initial"
+    forced_dir = workdir / "forced"
+    run_solver(
+        args.reference_exe,
+        workdir,
+        fixture,
+        frequency_file,
+        initial_dir,
+        "initial",
+        "1e300",
+        args.detailed_balance,
+        args.zero_temperature,
+    )
+    forced = run_solver(
+        args.forced_exe,
+        workdir,
+        fixture,
+        frequency_file,
+        forced_dir,
+        "forced",
+        "-1",
+        args.detailed_balance,
+        args.zero_temperature,
+    )
+    if "generation: 1" not in forced.stdout:
+        raise AssertionError(f"forced run did not complete evolution:\n{forced.stdout}")
+    if "test_forced_invalid_normalization_trials: 4" not in forced.stdout:
+        raise AssertionError(
+            f"forced run did not reach the evolved normalization path:\n{forced.stdout}"
+        )
+    if "test_invalid_normalization_fitness: DBL_MAX" not in forced.stdout:
+        raise AssertionError(
+            f"forced rows did not receive DBL_MAX fitness:\n{forced.stdout}"
+        )
+
+    output_prefix = prefix(args.detailed_balance, args.zero_temperature)
+    initial_spectrum_path = initial_dir / f"{output_prefix}_dsf_initial.bin"
+    forced_spectrum_path = forced_dir / f"{output_prefix}_dsf_forced.bin"
+    if initial_spectrum_path.read_bytes() != forced_spectrum_path.read_bytes():
+        raise AssertionError("invalid evolved trials changed the incumbent spectrum")
+    initial_frequency_path = initial_dir / f"{output_prefix}_frequency_initial.bin"
+    forced_frequency_path = forced_dir / f"{output_prefix}_frequency_forced.bin"
+    if initial_frequency_path.read_bytes() != forced_frequency_path.read_bytes():
+        raise AssertionError("invalid evolved trials changed the output grid")
+
+    spectrum = read_doubles(forced_spectrum_path)
+    if any(not math.isfinite(value) for value in spectrum):
+        raise AssertionError(
+            f"invalid evolved rows contaminated the spectrum: {spectrum}"
+        )
+    assert_normalized(spectrum, args.detailed_balance, args.zero_temperature)
+
+    for stat_name in ("fitness-mean", "fitness-minimum", "fitness-squared-mean"):
+        initial_stats = read_doubles(
+            initial_dir
+            / f"{output_prefix}_stats_{stat_name}_initial.bin"
+        )
+        forced_stats = read_doubles(
+            forced_dir
+            / f"{output_prefix}_stats_{stat_name}_forced.bin"
+        )
+        if len(initial_stats) != 2 or len(forced_stats) != 2:
+            raise AssertionError(
+                f"unexpected {stat_name} lengths: {initial_stats}, {forced_stats}"
+            )
+        if initial_stats != (initial_stats[0], initial_stats[0]):
+            raise AssertionError(
+                f"stop-before-evolution reference changed {stat_name}: "
+                f"{initial_stats}"
+            )
+        if forced_stats != initial_stats:
+            raise AssertionError(
+                f"invalid trials contaminated {stat_name}: "
+                f"initial={initial_stats}, forced={forced_stats}"
+            )
+        if any(not math.isfinite(value) for value in forced_stats):
+            raise AssertionError(f"non-finite {stat_name}: {forced_stats}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/deac_parity_test.py
+++ b/test/deac_parity_test.py
@@ -53,6 +53,7 @@ def run_deac(
     negative_first_moment=False,
     population_size="8",
     zero_temperature=False,
+    detailed_balance=False,
 ):
     workdir.mkdir(parents=True)
     save_dir = workdir / "results"
@@ -81,6 +82,8 @@ def run_deac(
     ]
     if normalize:
         command.append("--normalize")
+        if not detailed_balance and not zero_temperature:
+            command.extend(["--spectra_type", "bfull"])
     if negative_first_moment:
         command.append("--use_negative_first_moment")
     command.append(str(fixture))
@@ -130,9 +133,12 @@ def assert_outputs_match(
     relative_tolerance,
     detailed_balance=False,
     zero_temperature=False,
+    normalize=False,
 ):
     if zero_temperature:
         prefix = "deac-zT"
+    elif normalize and not detailed_balance:
+        prefix = "deac-bfull"
     else:
         prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
     for suffix in [
@@ -196,13 +202,21 @@ def main():
     workdir.mkdir(parents=True)
 
     fixture = workdir / "tiny-isf.bin"
-    if args.zero_temperature:
-        isf = [1.0, 0.85, 0.72, 0.61]
-    else:
-        isf = [-1.0, -0.85, -0.72, -0.61]
+    positive_fixture = workdir / "positive-isf.bin"
+    isf = (
+        [1.0, 0.85, 0.72, 0.61]
+        if args.zero_temperature
+        else [-1.0, -0.85, -0.72, -0.61]
+    )
     write_doubles(
         fixture,
         [0.0, 0.2, 0.4, 0.6] + isf + [0.05, 0.05, 0.05, 0.05],
+    )
+    write_doubles(
+        positive_fixture,
+        [0.0, 0.2, 0.4, 0.6]
+        + [1.0, 0.85, 0.72, 0.61]
+        + [0.05, 0.05, 0.05, 0.05],
     )
     frequency_file = workdir / "frequency.bin"
     write_doubles(frequency_file, [0.0, 0.7, 1.8, 3.0])
@@ -216,9 +230,10 @@ def main():
     if args.detailed_balance and not args.zero_temperature:
         cases.append(("negative_first_moment", "23", False, True, "8"))
     for case_name, seed, normalize, negative_first_moment, population_size in cases:
+        case_fixture = positive_fixture if normalize else fixture
         reference_dir = run_deac(
             reference_exe,
-            fixture,
+            case_fixture,
             frequency_file,
             workdir / case_name / "reference",
             seed,
@@ -226,10 +241,11 @@ def main():
             negative_first_moment=negative_first_moment,
             population_size=population_size,
             zero_temperature=args.zero_temperature,
+            detailed_balance=args.detailed_balance,
         )
         candidate_dir = run_deac(
             candidate_exe,
-            fixture,
+            case_fixture,
             frequency_file,
             workdir / case_name / "candidate",
             seed,
@@ -237,6 +253,7 @@ def main():
             negative_first_moment=negative_first_moment,
             population_size=population_size,
             zero_temperature=args.zero_temperature,
+            detailed_balance=args.detailed_balance,
         )
         assert_outputs_match(
             reference_dir,
@@ -246,6 +263,7 @@ def main():
             args.relative_tolerance,
             args.detailed_balance,
             args.zero_temperature,
+            normalize,
         )
 
 

--- a/test/deac_smoke_test.py
+++ b/test/deac_smoke_test.py
@@ -32,6 +32,11 @@ VALIDATION_CASES = [
     "uneven_isf_arrays",
     "too_few_timeslices",
     "nonfinite_isf",
+    "normalize_zero_target",
+    "normalize_negative_target",
+    "normalize_subnormal_target",
+    "normalize_nonfinite_target",
+    "normalize_unrepresentable_scale",
     "missing_isf",
     "positive_isf_single_particle",
     "bad_third_moment_error",
@@ -169,7 +174,10 @@ def run_deac_case(
     exe, workdir, case_name, detailed_balance=False, zero_temperature=False
 ):
     fixture = workdir / "tiny-isf.bin"
-    if zero_temperature:
+    if zero_temperature or case_name in (
+        "normalize",
+        "normalize_large_population",
+    ):
         write_positive_fixture(fixture)
     else:
         write_fixture(fixture)
@@ -204,6 +212,8 @@ def run_deac_case(
         extra_args.extend(["--frequency_file", str(frequency_file)])
     elif case_name in ("normalize", "normalize_large_population"):
         extra_args.append("--normalize")
+        if not detailed_balance and not zero_temperature:
+            extra_args.extend(["--spectra_type", "bfull"])
         if case_name == "normalize_large_population":
             population_size = "1028"
     elif case_name == "first_moment":
@@ -262,6 +272,11 @@ def run_deac_case(
     ) * 8
     if zero_temperature:
         prefix = "deac-zT"
+    elif (
+        case_name in ("normalize", "normalize_large_population")
+        and not detailed_balance
+    ):
+        prefix = "deac-bfull"
     else:
         prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
     assert_file_size(save_dir / f"{prefix}_dsf_{seed}.bin", expected_spectrum_bytes)
@@ -348,6 +363,36 @@ def run_validation_case(
     elif case_name == "nonfinite_isf":
         write_fixture(fixture, isf=[-1.0, float("nan"), -0.72, -0.61])
         expected_output = "ISF input file contains non-finite values"
+    elif case_name in {
+        "normalize_zero_target",
+        "normalize_negative_target",
+        "normalize_subnormal_target",
+        "normalize_nonfinite_target",
+    }:
+        target = {
+            "normalize_zero_target": 0.0,
+            "normalize_negative_target": -1.0,
+            "normalize_subnormal_target": math.ulp(0.0),
+            "normalize_nonfinite_target": float("nan"),
+        }[case_name]
+        write_fixture(fixture, isf=[target, 0.85, 0.72, 0.61])
+        extra_args = ["--normalize"]
+        if not detailed_balance and not zero_temperature:
+            extra_args.extend(["--spectra_type", "bfull"])
+        expected_output = (
+            "--normalize requires the first ISF value (zeroth moment) to be "
+            "finite, positive, and at least the smallest normal double"
+        )
+    elif case_name == "normalize_unrepresentable_scale":
+        target = float.fromhex("0x1.0p-1022")
+        write_fixture(fixture, isf=[target, target, target, target])
+        extra_args = ["--normalize"]
+        if not detailed_balance and not zero_temperature:
+            extra_args.extend(["--spectra_type", "bfull"])
+        expected_output = (
+            "--normalize target is outside the representable normal range "
+            "for this model and frequency grid"
+        )
     elif case_name == "missing_isf":
         expected_output = "could not open binary input"
     elif case_name == "positive_isf_single_particle":
@@ -559,6 +604,23 @@ def run_validation_case(
             prefix = "deac-bdsf" if detailed_balance else "deac-spfsf"
         if (save_dir / f"{prefix}_frequency_{uuid}.bin").exists():
             raise AssertionError("solver continued writing after the first result I/O failure")
+    elif case_name in {
+        "normalize_zero_target",
+        "normalize_negative_target",
+        "normalize_subnormal_target",
+        "normalize_nonfinite_target",
+        "normalize_unrepresentable_scale",
+    }:
+        if "uuid:" in result.stdout:
+            raise AssertionError(
+                "invalid normalization target emitted a run identifier"
+            )
+        if "minimum_fitness:" in result.stdout:
+            raise AssertionError("evolution started despite an invalid normalization target")
+        if save_dir.exists():
+            raise AssertionError(
+                f"invalid normalization target created output directory {save_dir}"
+            )
     elif case_name in {
         "nonfinite_frequency",
         "negative_frequency",

--- a/test/deac_smoke_test.py
+++ b/test/deac_smoke_test.py
@@ -37,6 +37,7 @@ VALIDATION_CASES = [
     "normalize_subnormal_target",
     "normalize_nonfinite_target",
     "normalize_unrepresentable_scale",
+    "normalize_signed_weights",
     "missing_isf",
     "positive_isf_single_particle",
     "bad_third_moment_error",
@@ -393,6 +394,14 @@ def run_validation_case(
             "--normalize target is outside the representable normal range "
             "for this model and frequency grid"
         )
+    elif case_name == "normalize_signed_weights":
+        write_positive_fixture(fixture)
+        extra_args = ["--normalize"]
+        if not detailed_balance and not zero_temperature:
+            extra_args.extend(["--spectra_type", "bfull"])
+        expected_output = (
+            "--normalize is incompatible with negative spectral weights"
+        )
     elif case_name == "missing_isf":
         expected_output = "could not open binary input"
     elif case_name == "positive_isf_single_particle":
@@ -610,6 +619,7 @@ def run_validation_case(
         "normalize_subnormal_target",
         "normalize_nonfinite_target",
         "normalize_unrepresentable_scale",
+        "normalize_signed_weights",
     }:
         if "uuid:" in result.stdout:
             raise AssertionError(

--- a/test/gpu_normalization_test.cpp
+++ b/test/gpu_normalization_test.cpp
@@ -1,0 +1,119 @@
+#if defined(USE_CUDA)
+#include "deac_gpu.cuh"
+#elif defined(USE_HIP)
+#include "deac_gpu.hip.hpp"
+#elif defined(USE_SYCL)
+#include "deac_gpu.sycl.h"
+#else
+#error "gpu_normalization_test requires a GPU backend"
+#endif
+
+#include <array>
+#include <cfloat>
+#include <iostream>
+#include <limits>
+
+int main() {
+    constexpr std::size_t rows = 4;
+    constexpr std::size_t cols = 2;
+    constexpr std::size_t matrix_elements = rows*cols;
+
+    // Column-major candidate rows: the first has a valid denominator and the
+    // other rows model a zero denominator, a subnormal denominator, and a
+    // denominator that would produce a subnormal scale, respectively.
+    std::array<double, matrix_elements> positive{
+            1.0, 9.0, 8.0, 7.0, 3.0, 6.0, 5.0, 4.0};
+    std::array<double, matrix_elements> negative{
+            2.0, 8.0, 7.0, 6.0, 4.0, 5.0, 4.0, 3.0};
+    const std::array<double, rows> denominator{
+            4.0,
+            0.0,
+            std::numeric_limits<double>::denorm_min(),
+            DBL_MAX};
+    std::array<bool, rows> valid{};
+    std::array<double, rows> fitness_new{1.0, 0.25, 0.5, 0.75};
+    std::array<double, rows> fitness_old{2.0, 2.0, 2.0, 2.0};
+    std::array<bool, rows> accepted{};
+
+    deac_stream_t stream;
+    GPU_ASSERT(deac_stream_create(stream));
+    double* d_positive;
+    double* d_negative;
+    double* d_denominator;
+    bool* d_valid;
+    double* d_fitness_new;
+    double* d_fitness_old;
+    bool* d_accepted;
+    GPU_ASSERT(deac_malloc_device(double, d_positive, matrix_elements, stream));
+    GPU_ASSERT(deac_malloc_device(double, d_negative, matrix_elements, stream));
+    GPU_ASSERT(deac_malloc_device(double, d_denominator, rows, stream));
+    GPU_ASSERT(deac_malloc_device(bool, d_valid, rows, stream));
+    GPU_ASSERT(deac_malloc_device(double, d_fitness_new, rows, stream));
+    GPU_ASSERT(deac_malloc_device(double, d_fitness_old, rows, stream));
+    GPU_ASSERT(deac_malloc_device(bool, d_accepted, rows, stream));
+    GPU_ASSERT(deac_memcpy_host_to_device(
+            d_positive, positive.data(), sizeof(positive), stream));
+    GPU_ASSERT(deac_memcpy_host_to_device(
+            d_negative, negative.data(), sizeof(negative), stream));
+    GPU_ASSERT(deac_memcpy_host_to_device(
+            d_denominator, denominator.data(), sizeof(denominator), stream));
+    GPU_ASSERT(deac_memcpy_host_to_device(
+            d_fitness_new, fitness_new.data(), sizeof(fitness_new), stream));
+    GPU_ASSERT(deac_memcpy_host_to_device(
+            d_fitness_old, fitness_old.data(), sizeof(fitness_old), stream));
+    GPU_ASSERT(deac_wait(stream));
+
+    gpu_deac_dgmmDiv1D(
+            stream, d_positive, d_negative, d_denominator, d_valid,
+            2.0, rows, cols);
+    gpu_set_rejection_indices(
+            stream, 1, d_accepted, d_fitness_new, d_fitness_old,
+            d_valid, true, rows);
+    GPU_ASSERT(deac_memcpy_device_to_host(
+            positive.data(), d_positive, sizeof(positive), stream));
+    GPU_ASSERT(deac_memcpy_device_to_host(
+            negative.data(), d_negative, sizeof(negative), stream));
+    GPU_ASSERT(deac_memcpy_device_to_host(
+            valid.data(), d_valid, sizeof(valid), stream));
+    GPU_ASSERT(deac_memcpy_device_to_host(
+            fitness_new.data(), d_fitness_new, sizeof(fitness_new), stream));
+    GPU_ASSERT(deac_memcpy_device_to_host(
+            fitness_old.data(), d_fitness_old, sizeof(fitness_old), stream));
+    GPU_ASSERT(deac_memcpy_device_to_host(
+            accepted.data(), d_accepted, sizeof(accepted), stream));
+    GPU_ASSERT(deac_wait(stream));
+
+    const bool valid_row_unchanged = valid[0]
+            && positive[0] == 0.5 && positive[rows] == 1.5
+            && negative[0] == 1.0 && negative[rows] == 2.0
+            && accepted[0] && fitness_old[0] == 1.0;
+    bool invalid_rows_rejected = true;
+    for (std::size_t row=1; row<rows; ++row) {
+        invalid_rows_rejected = invalid_rows_rejected
+                && !valid[row]
+                && positive[row] == 0.0 && positive[row + rows] == 0.0
+                && negative[row] == 0.0 && negative[row + rows] == 0.0
+                && !accepted[row] && fitness_new[row] == DBL_MAX
+                && fitness_old[row] == 2.0;
+    }
+
+    GPU_ASSERT(deac_free(d_positive, stream));
+    GPU_ASSERT(deac_free(d_negative, stream));
+    GPU_ASSERT(deac_free(d_denominator, stream));
+    GPU_ASSERT(deac_free(d_valid, stream));
+    GPU_ASSERT(deac_free(d_fitness_new, stream));
+    GPU_ASSERT(deac_free(d_fitness_old, stream));
+    GPU_ASSERT(deac_free(d_accepted, stream));
+    GPU_ASSERT(deac_wait(stream));
+    GPU_ASSERT(deac_stream_destroy(stream));
+
+    if (!valid_row_unchanged) {
+        std::cerr << "valid GPU normalization row changed unexpectedly\n";
+        return 1;
+    }
+    if (!invalid_rows_rejected) {
+        std::cerr << "degenerate GPU normalization row was not rejected\n";
+        return 1;
+    }
+    return 0;
+}

--- a/test/gpu_normalization_test.cpp
+++ b/test/gpu_normalization_test.cpp
@@ -12,27 +12,43 @@
 #include <cfloat>
 #include <iostream>
 #include <limits>
+#include <vector>
 
 int main() {
-    constexpr std::size_t rows = 4;
-    constexpr std::size_t cols = 2;
+    constexpr std::size_t rows = 5;
+    // Span more than one device block so every element-parallel normalization
+    // pass is exercised beyond a single launch block.
+    constexpr std::size_t cols = GPU_BLOCK_SIZE + 17;
     constexpr std::size_t matrix_elements = rows*cols;
 
     // Column-major candidate rows: the first has a valid denominator and the
-    // other rows model a zero denominator, a subnormal denominator, and a
-    // denominator that would produce a subnormal scale, respectively.
-    std::array<double, matrix_elements> positive{
-            1.0, 9.0, 8.0, 7.0, 3.0, 6.0, 5.0, 4.0};
-    std::array<double, matrix_elements> negative{
-            2.0, 8.0, 7.0, 6.0, 4.0, 5.0, 4.0, 3.0};
+    // other rows model a zero denominator, a subnormal denominator, a
+    // denominator that would produce a subnormal scale, and one isolated
+    // overflowing matrix product, respectively.
+    std::vector<double> positive(matrix_elements);
+    std::vector<double> negative(matrix_elements);
+    for (std::size_t col=0; col<cols; ++col) {
+        for (std::size_t row=0; row<rows; ++row) {
+            const std::size_t index = row + rows*col;
+            positive[index] = static_cast<double>(1 + col%7 + row);
+            negative[index] = static_cast<double>(2 + col%5 + row);
+        }
+    }
+    // These values distinguish the legacy x*(1/scaled_denominator) sequence
+    // from regrouping it as x*(target/(scaled_denominator*target)): the latter
+    // rounds the first positive result one ulp below 1.0.
+    positive[0] = 0.1;
+    negative[0] = 0.2;
+    positive[4] = DBL_MAX;
     const std::array<double, rows> denominator{
-            4.0,
+            0.1,
             0.0,
             std::numeric_limits<double>::denorm_min(),
-            DBL_MAX};
-    std::array<bool, rows> valid{};
-    std::array<double, rows> fitness_new{1.0, 0.25, 0.5, 0.75};
-    std::array<double, rows> fitness_old{2.0, 2.0, 2.0, 2.0};
+            DBL_MAX/2.0,
+            0.5};
+    std::array<int, rows> valid{};
+    std::array<double, rows> fitness_new{1.0, 0.25, 0.5, 0.75, 1.25};
+    std::array<double, rows> fitness_old{2.0, 2.0, 2.0, 2.0, 2.0};
     std::array<bool, rows> accepted{};
 
     deac_stream_t stream;
@@ -40,21 +56,21 @@ int main() {
     double* d_positive;
     double* d_negative;
     double* d_denominator;
-    bool* d_valid;
+    int* d_valid;
     double* d_fitness_new;
     double* d_fitness_old;
     bool* d_accepted;
     GPU_ASSERT(deac_malloc_device(double, d_positive, matrix_elements, stream));
     GPU_ASSERT(deac_malloc_device(double, d_negative, matrix_elements, stream));
     GPU_ASSERT(deac_malloc_device(double, d_denominator, rows, stream));
-    GPU_ASSERT(deac_malloc_device(bool, d_valid, rows, stream));
+    GPU_ASSERT(deac_malloc_device(int, d_valid, rows, stream));
     GPU_ASSERT(deac_malloc_device(double, d_fitness_new, rows, stream));
     GPU_ASSERT(deac_malloc_device(double, d_fitness_old, rows, stream));
     GPU_ASSERT(deac_malloc_device(bool, d_accepted, rows, stream));
     GPU_ASSERT(deac_memcpy_host_to_device(
-            d_positive, positive.data(), sizeof(positive), stream));
+            d_positive, positive.data(), matrix_elements*sizeof(double), stream));
     GPU_ASSERT(deac_memcpy_host_to_device(
-            d_negative, negative.data(), sizeof(negative), stream));
+            d_negative, negative.data(), matrix_elements*sizeof(double), stream));
     GPU_ASSERT(deac_memcpy_host_to_device(
             d_denominator, denominator.data(), sizeof(denominator), stream));
     GPU_ASSERT(deac_memcpy_host_to_device(
@@ -63,16 +79,29 @@ int main() {
             d_fitness_old, fitness_old.data(), sizeof(fitness_old), stream));
     GPU_ASSERT(deac_wait(stream));
 
+    GPU_ASSERT(deac_memset(d_valid, 1, sizeof(valid), stream));
     gpu_deac_dgmmDiv1D(
-            stream, d_positive, d_negative, d_denominator, d_valid,
-            2.0, rows, cols);
+            stream, d_positive, d_denominator, rows, cols);
+    gpu_deac_dgmmDiv1D(
+            stream, d_negative, d_denominator, rows, cols);
+    GPU_ASSERT(deac_wait(stream));
+    gpu_validate_normalization_rows(
+            stream, d_positive, d_denominator, d_valid, 0.1, rows, cols);
+    gpu_validate_normalization_rows(
+            stream, d_negative, d_denominator, d_valid, 0.1, rows, cols);
+    GPU_ASSERT(deac_wait(stream));
+    gpu_cleanup_invalid_normalization_rows(
+            stream, d_positive, d_valid, rows, cols);
+    gpu_cleanup_invalid_normalization_rows(
+            stream, d_negative, d_valid, rows, cols);
+    GPU_ASSERT(deac_wait(stream));
     gpu_set_rejection_indices(
             stream, 1, d_accepted, d_fitness_new, d_fitness_old,
             d_valid, true, rows);
     GPU_ASSERT(deac_memcpy_device_to_host(
-            positive.data(), d_positive, sizeof(positive), stream));
+            positive.data(), d_positive, matrix_elements*sizeof(double), stream));
     GPU_ASSERT(deac_memcpy_device_to_host(
-            negative.data(), d_negative, sizeof(negative), stream));
+            negative.data(), d_negative, matrix_elements*sizeof(double), stream));
     GPU_ASSERT(deac_memcpy_device_to_host(
             valid.data(), d_valid, sizeof(valid), stream));
     GPU_ASSERT(deac_memcpy_device_to_host(
@@ -83,18 +112,25 @@ int main() {
             accepted.data(), d_accepted, sizeof(accepted), stream));
     GPU_ASSERT(deac_wait(stream));
 
-    const bool valid_row_unchanged = valid[0]
-            && positive[0] == 0.5 && positive[rows] == 1.5
-            && negative[0] == 1.0 && negative[rows] == 2.0
+    bool valid_row_unchanged = valid[0] != 0
             && accepted[0] && fitness_old[0] == 1.0;
     bool invalid_rows_rejected = true;
-    for (std::size_t row=1; row<rows; ++row) {
-        invalid_rows_rejected = invalid_rows_rejected
-                && !valid[row]
-                && positive[row] == 0.0 && positive[row + rows] == 0.0
-                && negative[row] == 0.0 && negative[row + rows] == 0.0
-                && !accepted[row] && fitness_new[row] == DBL_MAX
-                && fitness_old[row] == 2.0;
+    for (std::size_t col=0; col<cols; ++col) {
+        const double expected_positive = col == 0
+                ? 1.0 : static_cast<double>(1 + col%7)*10.0;
+        const double expected_negative = col == 0
+                ? 2.0 : static_cast<double>(2 + col%5)*10.0;
+        valid_row_unchanged = valid_row_unchanged
+                && positive[rows*col] == expected_positive
+                && negative[rows*col] == expected_negative;
+        for (std::size_t row=1; row<rows; ++row) {
+            invalid_rows_rejected = invalid_rows_rejected
+                    && !valid[row]
+                    && positive[row + rows*col] == 0.0
+                    && negative[row + rows*col] == 0.0
+                    && !accepted[row] && fitness_new[row] == DBL_MAX
+                    && fitness_old[row] == 2.0;
+        }
     }
 
     GPU_ASSERT(deac_free(d_positive, stream));

--- a/test/normalization_test.cpp
+++ b/test/normalization_test.cpp
@@ -64,6 +64,14 @@ int main() {
     }
     try {
         deac_numerics::validate_initial_normalization_scale(
+                std::numeric_limits<double>::min(), 0.5);
+    } catch (const std::exception& error) {
+        std::cerr << "rejected DBL_MIN despite a representable grid scale: "
+                  << error.what() << '\n';
+        return 1;
+    }
+    try {
+        deac_numerics::validate_initial_normalization_scale(
                 std::numeric_limits<double>::min(), 6.0);
         std::cerr << "accepted an initial normalization scale that is subnormal\n";
         return 1;
@@ -132,7 +140,7 @@ int main() {
             ? 0.0 : std::numeric_limits<double>::max();
     if (degenerate_valid
             || degenerate_candidate != std::array<double, 2>{0.0, 0.0}
-            || degenerate_fitness <= 1.0
+            || degenerate_fitness != std::numeric_limits<double>::max()
             || incumbent != std::array<double, 2>{0.5, 1.5}) {
         std::cerr << "degenerate evolved normalization row was not rejected\n";
         return 1;

--- a/test/normalization_test.cpp
+++ b/test/normalization_test.cpp
@@ -1,0 +1,142 @@
+#include "normalization.hpp"
+
+#include <array>
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+
+namespace {
+
+bool rejects_target(double target) {
+    try {
+        deac_numerics::validate_normalization_target(target);
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
+bool rejects_denominator(double denominator) {
+    try {
+        (void) deac_numerics::checked_normalization_scale(1.0, denominator);
+    } catch (const std::runtime_error&) {
+        return true;
+    }
+    return false;
+}
+
+} // namespace
+
+int main() {
+    const std::array<double, 5> invalid_targets{
+            0.0,
+            -1.0,
+            std::numeric_limits<double>::denorm_min(),
+            std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::quiet_NaN()};
+    for (const double target : invalid_targets) {
+        if (!rejects_target(target)) {
+            std::cerr << "accepted invalid normalization target " << target << '\n';
+            return 1;
+        }
+    }
+
+    const std::array<double, 3> valid_targets{
+            std::numeric_limits<double>::min(),
+            1.0,
+            std::numeric_limits<double>::max()};
+    for (const double target : valid_targets) {
+        try {
+            deac_numerics::validate_normalization_target(target);
+        } catch (const std::exception& error) {
+            std::cerr << "rejected valid normalization target " << target
+                      << ": " << error.what() << '\n';
+            return 1;
+        }
+    }
+    try {
+        deac_numerics::validate_initial_normalization_scale(1.0, 6.0);
+    } catch (const std::exception& error) {
+        std::cerr << "rejected a representable initial normalization scale: "
+                  << error.what() << '\n';
+        return 1;
+    }
+    try {
+        deac_numerics::validate_initial_normalization_scale(
+                std::numeric_limits<double>::min(), 6.0);
+        std::cerr << "accepted an initial normalization scale that is subnormal\n";
+        return 1;
+    } catch (const std::invalid_argument&) {
+    }
+    try {
+        deac_numerics::validate_initial_normalization_scale(
+                std::numeric_limits<double>::min(),
+                std::numeric_limits<double>::denorm_min());
+        std::cerr << "accepted a subnormal initial denominator bound\n";
+        return 1;
+    } catch (const std::invalid_argument&) {
+    }
+
+    const std::array<double, 5> invalid_denominators{
+            0.0,
+            -1.0,
+            std::numeric_limits<double>::infinity(),
+            -std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::quiet_NaN()};
+    for (const double denominator : invalid_denominators) {
+        if (!rejects_denominator(denominator)) {
+            std::cerr << "accepted invalid normalization denominator "
+                      << denominator << '\n';
+            return 1;
+        }
+    }
+
+    if (deac_numerics::checked_normalization_scale(1.0, 2.0) != 0.5) {
+        std::cerr << "changed the valid normalization scale\n";
+        return 1;
+    }
+    if (!rejects_denominator(std::numeric_limits<double>::denorm_min())) {
+        std::cerr << "accepted a denominator whose scale overflows\n";
+        return 1;
+    }
+    try {
+        (void) deac_numerics::checked_normalization_scale(
+                std::numeric_limits<double>::min(),
+                std::numeric_limits<double>::denorm_min());
+        std::cerr << "accepted a subnormal normalization denominator\n";
+        return 1;
+    } catch (const std::runtime_error&) {
+    }
+    try {
+        (void) deac_numerics::checked_normalization_scale(
+                std::numeric_limits<double>::min(), 2.0);
+        std::cerr << "accepted a subnormal normalization scale\n";
+        return 1;
+    } catch (const std::runtime_error&) {
+    }
+
+    std::array<double, 2> valid_candidate{1.0, 3.0};
+    if (!deac_numerics::try_apply_normalization(
+                2.0, 4.0, valid_candidate)
+            || valid_candidate != std::array<double, 2>{0.5, 1.5}) {
+        std::cerr << "changed a representable evolved normalization row\n";
+        return 1;
+    }
+
+    const std::array<double, 2> incumbent{0.5, 1.5};
+    std::array<double, 2> degenerate_candidate{0.0, 0.0};
+    const bool degenerate_valid = deac_numerics::try_apply_normalization(
+            2.0, 0.0, degenerate_candidate);
+    const double degenerate_fitness = degenerate_valid
+            ? 0.0 : std::numeric_limits<double>::max();
+    if (degenerate_valid
+            || degenerate_candidate != std::array<double, 2>{0.0, 0.0}
+            || degenerate_fitness <= 1.0
+            || incumbent != std::array<double, 2>{0.5, 1.5}) {
+        std::cerr << "degenerate evolved normalization row was not rejected\n";
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Closes #33.

## Summary

- reject nonpositive, nonfinite, subnormal, and unrepresentable normalization targets before UUID or output creation
- validate every initial and evolved population row while preserving the legacy valid CPU and accelerator arithmetic paths
- quarantine invalid evolved rows without changing the incumbent spectrum, grid, or statistics
- document the positive finite normalization contract and add direct, parity, boundary, and complete-evolution regressions

## Validation

- GCC 14.3: 56/56 tests for standard, detailed-balance, hyperbolic, normalization-model, and ZeroT; signed-weight 52/52
- IntelLLVM 2026.1 CPU: 56/56 standard and detailed
- real Level Zero: 58/58 standard and detailed, including forced-invalid full-loop coverage
- GCC ASan+UBSan: 56/56 with leak detection and halt-on-error
- valid CPU and Level Zero output directories byte-identical to base at initial and evolved cases; fixed-seed reruns byte-identical
- alternating Level Zero performance at P64/M4096/N500: base median 3.49 s, candidate 3.54 s (+1.433%, within 5% gate)
- CUDA/HIP inspected statically; runtime toolchains are unavailable on this host

Independent exact-head review reported no findings at b1dbbe6d255a4e6ff5e099eb06114a8017a3fb64.