### PR TITLE
fix: make zero first-moment fitness finite

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ normalization is fatal because there is no valid incumbent. During evolution,
 a candidate with a zero, non-finite, or otherwise unrepresentable denominator
 or scale is assigned noncompetitive fitness and rejected; it cannot contaminate
 the incumbent population or its statistics.
+
+When `--first_moment` is non-negative, it is an active constraint, including
+the valid target value zero. The fitness contribution is
+`((candidate_first_moment - target_first_moment) / 1.0)^2` on every backend.
+The unit standard deviation is fixed because the CLI does not yet expose a
+first-moment uncertainty; negative `--first_moment` values disable the
+constraint.
 	
 The general recommendation is to generate several spectra using different seeds (`--seed`) and average the final results. A sample bash script to generate a command file with multiple seeds can be found in the tools directory `tools/generate_commands.sh`.
 	

--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -327,6 +327,14 @@ if(NOT "${GPU_BACKEND}" STREQUAL "none")
         COMMAND deac_gpu_normalization_test)
 endif()
 
+add_executable(deac_moment_fitness_test
+    ${CMAKE_SOURCE_DIR}/../test/moment_fitness_test.cpp)
+target_include_directories(deac_moment_fitness_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_test(
+    NAME deac_unit_moment_fitness
+    COMMAND deac_moment_fitness_test)
+
 add_executable(deac_population_projection_test
     ${CMAKE_SOURCE_DIR}/../test/population_projection_test.cpp)
 target_include_directories(deac_population_projection_test PRIVATE
@@ -503,6 +511,16 @@ if(Python3_Interpreter_FOUND)
                 ${DEAC_SMOKE_VARIANT_ARGS}
         )
     endif()
+
+    add_test(
+        NAME deac_first_moment_fitness
+        COMMAND
+            ${Python3_EXECUTABLE}
+            ${CMAKE_SOURCE_DIR}/../test/deac_first_moment_fitness_test.py
+            --exe $<TARGET_FILE:${exe}>
+            --workdir ${CMAKE_CURRENT_BINARY_DIR}/first-moment-fitness
+            ${DEAC_SMOKE_VARIANT_ARGS}
+    )
     set(DEAC_PARITY_REFERENCE_EXE "" CACHE FILEPATH "Reference deac executable for backend parity tests.")
     if(NOT "${DEAC_PARITY_REFERENCE_EXE}" STREQUAL "")
         add_test(

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 #include <rng.hpp>
 #include "evolution_controls.hpp"
+#include "moment_fitness.hpp"
 #include "normalization.hpp"
 #include "population_projection.hpp"
 #include "result_io.hpp"
@@ -569,11 +570,9 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         #endif
     #endif
 
-    //FIXME it doesn't make sense for first moment term to have no error. If there was no error, it should have infinite importance in the fitness function. Setting error to 1.0 here.
-    double first_moment_error = 1.0;
-    #ifndef USE_GPU
-        (void) first_moment_error;
-    #endif
+    // The CLI does not yet expose an uncertainty for the first moment. Use a
+    // unit standard deviation consistently on every backend until it does.
+    constexpr double first_moment_error = 1.0;
     if (use_first_moment) {
         std::cout << "WARNING: setting first_moment_error to 1.0." << std::endl;
         first_moments_term_positive_frequency = (double*) malloc(bytes_first_moments_term);
@@ -896,7 +895,8 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 //FIXME inverse first moment not implemented
             #endif
             if (use_first_moment) {
-                _fitness += pow(first_moments[i] - first_moment,2)/first_moment;
+                _fitness += deac_numerics::scalar_chi_square_penalty(
+                        first_moments[i], first_moment, first_moment_error);
             }
             if (use_third_moment) {
                 _fitness += pow((third_moment - third_moments[i])/third_moment_error,2);
@@ -1549,7 +1549,8 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                     //FIXME inverse first moment not implemented
                 #endif
                 if (use_first_moment) {
-                    _fitness += pow(first_moments[i] - first_moment,2)/first_moment;
+                    _fitness += deac_numerics::scalar_chi_square_penalty(
+                            first_moments[i], first_moment, first_moment_error);
                 }
                 if (use_third_moment) {
                     _fitness += pow((third_moment - third_moments[i])/third_moment_error,2);
@@ -1780,6 +1781,9 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             }
         #endif
         log << "first_moment: " << first_moment << std::endl;
+        if (use_first_moment) {
+            log << "first_moment_error: " << first_moment_error << std::endl;
+        }
         log << "third_moment: " << third_moment << std::endl;
         log << "third_moment_error: " << third_moment_error << std::endl;
         log << "crossover_probability: " << crossover_probability << std::endl;

--- a/src/deac/src/moment_fitness.hpp
+++ b/src/deac/src/moment_fitness.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace deac_numerics {
+
+inline double scalar_chi_square_penalty(
+        double calculated, double observed, double standard_deviation) {
+    const double term = (observed - calculated)/standard_deviation;
+    return term*term;
+}
+
+} // namespace deac_numerics

--- a/test/deac_first_moment_fitness_test.py
+++ b/test/deac_first_moment_fitness_test.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+import argparse
+import math
+import shutil
+import struct
+import subprocess
+from pathlib import Path
+
+
+def write_doubles(path, values):
+    path.write_bytes(struct.pack("<" + "d" * len(values), *values))
+
+
+def read_doubles(path):
+    data = path.read_bytes()
+    if len(data) % 8 != 0:
+        raise AssertionError(f"{path} does not contain a whole number of doubles")
+    return struct.unpack("<" + "d" * (len(data) // 8), data)
+
+
+def run_zero_target(
+    exe,
+    workdir,
+    fixture,
+    seed,
+    detailed_balance,
+    zero_temperature,
+    run_label=None,
+):
+    save_dir = workdir / f"results-{run_label or seed}"
+    command = [
+        exe,
+        "--temperature",
+        "0" if zero_temperature else "1",
+        "--number_of_generations",
+        "2",
+        "--population_size",
+        "4",
+        "--genome_size",
+        "8",
+        "--omega_max",
+        "4",
+        "--first_moment",
+        "0",
+        "--crossover_probability",
+        "1",
+        "--self_adapting_crossover_probability",
+        "0",
+        "--differential_weight",
+        "2",
+        "--self_adapting_differential_weight_probability",
+        "0",
+        "--stop_minimum_fitness",
+        "-1",
+        "--track_stats",
+        "--save_directory",
+        str(save_dir),
+        "--seed",
+        seed,
+        "--uuid",
+        seed,
+        str(fixture),
+    ]
+    result = subprocess.run(
+        command,
+        cwd=workdir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"zero first-moment run failed with {result.returncode}\n"
+            f"command: {' '.join(map(str, command))}\noutput:\n{result.stdout}"
+        )
+    if "generation: 1" not in result.stdout:
+        raise AssertionError(
+            f"seed {seed} did not complete the evolved-population step:\n"
+            f"{result.stdout}"
+        )
+    prefix = (
+        "deac-zT"
+        if zero_temperature
+        else "deac-bdsf"
+        if detailed_balance
+        else "deac-spfsf"
+    )
+    minima = read_doubles(save_dir / f"{prefix}_stats_fitness-minimum_{seed}.bin")
+    if len(minima) != 2 or any(not math.isfinite(value) for value in minima):
+        raise AssertionError(
+            f"seed {seed} produced non-finite initial/evolved fitness: {minima}"
+        )
+    log_text = (save_dir / f"{prefix}_log_{seed}.dat").read_text()
+    if "first_moment: 0\n" not in log_text:
+        raise AssertionError("zero first moment was not recorded as active")
+    if "first_moment_error: 1\n" not in log_text:
+        raise AssertionError("unit first-moment uncertainty was not recorded")
+    return minima[1] < minima[0], minima
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exe", required=True)
+    parser.add_argument("--workdir", required=True)
+    parser.add_argument("--detailed-balance", action="store_true")
+    parser.add_argument("--zero-temperature", action="store_true")
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        default=("3", "6", "14", "17", "23", "47"),
+    )
+    args = parser.parse_args()
+
+    exe = str(Path(args.exe))
+    if not Path(exe).is_file():
+        raise AssertionError(f"expected executable {exe} to exist")
+    workdir = Path(args.workdir)
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+
+    tau = [0.0, 0.2, 0.4, 0.6]
+    observed = (
+        [1.0, 0.85, 0.72, 0.61]
+        if args.zero_temperature
+        else [-1.0, -0.85, -0.72, -0.61]
+    )
+    fixture = workdir / "tiny-isf.bin"
+    write_doubles(fixture, tau + observed + [0.05, 0.05, 0.05, 0.05])
+
+    accepted_improved_trial = False
+    first_minima = None
+    for seed in args.seeds:
+        improved, minima = run_zero_target(
+            exe,
+            workdir,
+            fixture,
+            seed,
+            args.detailed_balance,
+            args.zero_temperature,
+        )
+        accepted_improved_trial |= improved
+        if first_minima is None:
+            first_minima = minima
+    if not accepted_improved_trial:
+        raise AssertionError(
+            "zero first-moment regression did not accept an improved evolved trial"
+        )
+
+    _, repeated_minima = run_zero_target(
+        exe,
+        workdir,
+        fixture,
+        args.seeds[0],
+        args.detailed_balance,
+        args.zero_temperature,
+        run_label=f"{args.seeds[0]}-repeat",
+    )
+    if repeated_minima != first_minima:
+        raise AssertionError(
+            "zero first-moment fitness was not deterministic for a fixed seed: "
+            f"first={first_minima}, repeated={repeated_minima}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/deac_parity_test.py
+++ b/test/deac_parity_test.py
@@ -51,6 +51,7 @@ def run_deac(
     *,
     normalize=False,
     negative_first_moment=False,
+    first_moment=False,
     population_size="8",
     zero_temperature=False,
     detailed_balance=False,
@@ -86,6 +87,8 @@ def run_deac(
             command.extend(["--spectra_type", "bfull"])
     if negative_first_moment:
         command.append("--use_negative_first_moment")
+    if first_moment:
+        command.extend(["--first_moment", "0"])
     command.append(str(fixture))
     run_command(command, workdir)
     return save_dir
@@ -222,14 +225,26 @@ def main():
     write_doubles(frequency_file, [0.0, 0.7, 1.8, 3.0])
 
     cases = [
-        ("default", "17", False, False, "8"),
+        ("default", "17", False, False, False, "8"),
+        # A zero-valued first moment is active. It previously divided the CPU
+        # fitness by the target while GPU backends used a unit uncertainty.
+        ("first_moment_zero", "29", False, False, True, "8"),
         # Exercise both GEMV beta paths and a partial second work-group even
         # with the default GPU_BLOCK_SIZE=1024.
-        ("normalize_large_population", "19", True, False, "1028"),
+        ("normalize_large_population", "19", True, False, False, "1028"),
     ]
     if args.detailed_balance and not args.zero_temperature:
-        cases.append(("negative_first_moment", "23", False, True, "8"))
-    for case_name, seed, normalize, negative_first_moment, population_size in cases:
+        cases.append(
+            ("negative_first_moment", "23", False, True, False, "8")
+        )
+    for (
+        case_name,
+        seed,
+        normalize,
+        negative_first_moment,
+        first_moment,
+        population_size,
+    ) in cases:
         case_fixture = positive_fixture if normalize else fixture
         reference_dir = run_deac(
             reference_exe,
@@ -239,6 +254,7 @@ def main():
             seed,
             normalize=normalize,
             negative_first_moment=negative_first_moment,
+            first_moment=first_moment,
             population_size=population_size,
             zero_temperature=args.zero_temperature,
             detailed_balance=args.detailed_balance,
@@ -251,6 +267,7 @@ def main():
             seed,
             normalize=normalize,
             negative_first_moment=negative_first_moment,
+            first_moment=first_moment,
             population_size=population_size,
             zero_temperature=args.zero_temperature,
             detailed_balance=args.detailed_balance,

--- a/test/moment_fitness_test.cpp
+++ b/test/moment_fitness_test.cpp
@@ -1,0 +1,21 @@
+#include "moment_fitness.hpp"
+
+#include <cmath>
+#include <iostream>
+
+int main() {
+    if (deac_numerics::scalar_chi_square_penalty(2.0, 0.0, 1.0) != 4.0) {
+        std::cerr << "zero-target first-moment penalty is not finite and squared\n";
+        return 1;
+    }
+    if (deac_numerics::scalar_chi_square_penalty(2.0, 1.0, 0.5) != 4.0) {
+        std::cerr << "scalar penalty does not divide by the error before squaring\n";
+        return 1;
+    }
+    if (!std::isfinite(
+                deac_numerics::scalar_chi_square_penalty(0.0, 0.0, 1.0))) {
+        std::cerr << "matching zero moment produced a non-finite penalty\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Closes #30.

## Summary

- use the same scalar chi-square penalty on CPU and accelerator paths for initial and evolved populations
- treat a zero first-moment target as an active finite constraint with the existing unit uncertainty
- document and log the effective unit uncertainty while retaining negative values as the disable sentinel
- add focused unit, full evolution, deterministic-repeat, and CPU↔accelerator parity coverage

The separate CLI/API decision for a configurable first-moment uncertainty remains tracked in #36.

## Validation

- GCC 14.3 standard, detailed-balance, hyperbolic, normalization-model, and ZeroT: 58/58 each; signed-weight: 54/54
- IntelLLVM 2026.1 CPU standard and detailed: 58/58 each
- GCC ASan+UBSan with leak detection and halt-on-error: 58/58
- real Level Zero standard and detailed, block 256/subgroup 16: 60/60 each
- direct Intel CPU↔Level Zero parity passed, including first_moment_zero
- fixed-seed Level Zero numerical artifacts byte-identical on repeat
- inactive standard/detailed output directories byte-identical to base; active target-1 spectra/grids byte-identical with only the expected last-bit statistics change from matching accelerator arithmetic
- CUDA/HIP inspected statically; toolchains unavailable on this host

Independent exact-head review reported no findings at 94b6732305bb6b0aaefd02fb2622f0375e0371c8.