### PR TITLE
perf: vectorize CPU trial-row mutation

### DIFF
--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -367,6 +367,20 @@ add_test(
     NAME deac_unit_trial_population
     COMMAND deac_trial_population_test)
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|IntelLLVM"
+        AND NOT GPU_BACKEND STREQUAL "cuda"
+        AND NOT GPU_BACKEND STREQUAL "hip")
+    add_executable(deac_trial_population_no_contract_test
+        ${CMAKE_SOURCE_DIR}/../test/trial_population_test.cpp)
+    target_include_directories(deac_trial_population_no_contract_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    target_compile_options(deac_trial_population_no_contract_test PRIVATE
+        -ffp-contract=off)
+    add_test(
+        NAME deac_unit_trial_population_no_contract
+        COMMAND deac_trial_population_no_contract_test)
+endif()
+
 add_executable(deac_result_io_test
     ${CMAKE_SOURCE_DIR}/../test/result_io_test.cpp)
 target_include_directories(deac_result_io_test PRIVATE

--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -359,6 +359,14 @@ add_test(
     NAME deac_unit_population_projection
     COMMAND deac_population_projection_test)
 
+add_executable(deac_trial_population_test
+    ${CMAKE_SOURCE_DIR}/../test/trial_population_test.cpp)
+target_include_directories(deac_trial_population_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_test(
+    NAME deac_unit_trial_population
+    COMMAND deac_trial_population_test)
+
 add_executable(deac_result_io_test
     ${CMAKE_SOURCE_DIR}/../test/result_io_test.cpp)
 target_include_directories(deac_result_io_test PRIVATE

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -19,6 +19,7 @@
 #include "normalization.hpp"
 #include "population_projection.hpp"
 #include "result_io.hpp"
+#include "trial_population.hpp"
 #include "zero_temperature_kernel.hpp"
 #include "trapezoidal_weights.hpp"
 #include "build_identity.hpp"
@@ -1194,6 +1195,11 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 GPU_ASSERT(deac_wait(default_stream));
             #endif
         #else
+            #ifdef ALLOW_NEGATIVE_SPECTRAL_WEIGHT
+                constexpr bool allow_negative_spectral_weight = true;
+            #else
+                constexpr bool allow_negative_spectral_weight = false;
+            #endif
             for (size_t i=0; i<population_size; i++) {
                 double F_positive_frequency = differential_weights_new_positive_frequency[i];
                 #ifdef DEAC_TWO_SIDED_POPULATION
@@ -1202,48 +1208,31 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 size_t mutant_index1 = mutant_indices[3*i];
                 size_t mutant_index2 = mutant_indices[3*i + 1];
                 size_t mutant_index3 = mutant_indices[3*i + 2];
-                for (size_t j=0; j<genome_size; j++) {
-                    bool mutate_positive_frequency = mutate_indices_positive_frequency[i*genome_size + j];
-                    #ifdef DEAC_TWO_SIDED_POPULATION
-                        bool mutate_negative_frequency = mutate_indices_negative_frequency[i*genome_size + j];
-                    #endif
-                    if (mutate_positive_frequency) {
-                        #ifdef ALLOW_NEGATIVE_SPECTRAL_WEIGHT
-                            population_new_positive_frequency[i*genome_size + j] =
-                                population_old_positive_frequency[mutant_index1*genome_size + j] + F_positive_frequency*(
-                                        population_old_positive_frequency[mutant_index2*genome_size + j] -
-                                        population_old_positive_frequency[mutant_index3*genome_size + j]);
-                        #else
-                            population_new_positive_frequency[i*genome_size + j] = fabs( 
-                                population_old_positive_frequency[mutant_index1*genome_size + j] + F_positive_frequency*(
-                                        population_old_positive_frequency[mutant_index2*genome_size + j] -
-                                        population_old_positive_frequency[mutant_index3*genome_size + j]));
-                        #endif
-                    } else {
-                        population_new_positive_frequency[i*genome_size + j] = population_old_positive_frequency[i*genome_size + j];
-                    }
-                    #ifdef DEAC_TWO_SIDED_POPULATION
-                        if (mutate_negative_frequency) {
-                            #ifdef ALLOW_NEGATIVE_SPECTRAL_WEIGHT
-                                population_new_negative_frequency[i*genome_size + j] =
-                                    population_old_negative_frequency[mutant_index1*genome_size + j] + F_negative_frequency*(
-                                            population_old_negative_frequency[mutant_index2*genome_size + j] -
-                                            population_old_negative_frequency[mutant_index3*genome_size + j]);
-                            #else
-                                population_new_negative_frequency[i*genome_size + j] = fabs( 
-                                    population_old_negative_frequency[mutant_index1*genome_size + j] + F_negative_frequency*(
-                                            population_old_negative_frequency[mutant_index2*genome_size + j] -
-                                            population_old_negative_frequency[mutant_index3*genome_size + j]));
-                            #endif
-                        } else {
-                            population_new_negative_frequency[i*genome_size + j] = population_old_negative_frequency[i*genome_size + j];
-                        }
-                        if (j == 0) {
-                            // Set zero frequency to same value
-                            population_new_negative_frequency[i*genome_size + j] = population_new_positive_frequency[i*genome_size + j];
-                        }
-                    #endif
-                }
+                deac_numerics::form_trial_population_row<
+                        allow_negative_spectral_weight>(
+                        population_new_positive_frequency + i*genome_size,
+                        population_old_positive_frequency + i*genome_size,
+                        population_old_positive_frequency + mutant_index1*genome_size,
+                        population_old_positive_frequency + mutant_index2*genome_size,
+                        population_old_positive_frequency + mutant_index3*genome_size,
+                        mutate_indices_positive_frequency + i*genome_size,
+                        F_positive_frequency,
+                        genome_size);
+                #ifdef DEAC_TWO_SIDED_POPULATION
+                    deac_numerics::form_trial_population_row<
+                            allow_negative_spectral_weight>(
+                            population_new_negative_frequency + i*genome_size,
+                            population_old_negative_frequency + i*genome_size,
+                            population_old_negative_frequency + mutant_index1*genome_size,
+                            population_old_negative_frequency + mutant_index2*genome_size,
+                            population_old_negative_frequency + mutant_index3*genome_size,
+                            mutate_indices_negative_frequency + i*genome_size,
+                            F_negative_frequency,
+                            genome_size);
+                    deac_numerics::couple_trial_population_zero(
+                            population_new_negative_frequency + i*genome_size,
+                            population_new_positive_frequency + i*genome_size);
+                #endif
             }
         #endif
 

--- a/src/deac/src/trial_population.hpp
+++ b/src/deac/src/trial_population.hpp
@@ -43,6 +43,44 @@ DEAC_NOINLINE void form_trial_population_row(
                 _mm512_set1_pd(differential_weight);
         const __m512i magnitude_mask = _mm512_set1_epi64(
                 static_cast<long long>(UINT64_C(0x7fffffffffffffff)));
+        const auto form_vector_chunk = [=](
+                std::size_t chunk_index,
+                __mmask8 lane_mask,
+                __mmask8 valid_mask) {
+            // Sanitize every arithmetic input before exposing it to the
+            // compiler's contraction policy. The boundary makes all lanes of
+            // these vectors observable, so inactive values must remain benign
+            // zeros even when later arithmetic is emitted without predicates.
+            __m512d mutant_values1 = _mm512_maskz_loadu_pd(
+                    lane_mask, mutant_row1 + chunk_index);
+            __m512d mutant_values2 = _mm512_maskz_loadu_pd(
+                    lane_mask, mutant_row2 + chunk_index);
+            __m512d mutant_values3 = _mm512_maskz_loadu_pd(
+                    lane_mask, mutant_row3 + chunk_index);
+            __m512d differential_weights = _mm512_maskz_mov_pd(
+                    lane_mask, differential_weight_vector);
+            __asm__ volatile(
+                    ""
+                    : "+v"(mutant_values1),
+                      "+v"(mutant_values2),
+                      "+v"(mutant_values3),
+                      "+v"(differential_weights));
+
+            __m512d evolved_values = mutant_values1
+                    + differential_weights*(mutant_values2 - mutant_values3);
+            if constexpr (!AllowNegativeSpectralWeight) {
+                evolved_values = _mm512_castsi512_pd(_mm512_and_epi64(
+                        _mm512_castpd_si512(evolved_values),
+                        magnitude_mask));
+            }
+            const __m512d current_values = _mm512_maskz_loadu_pd(
+                    valid_mask, current_row + chunk_index);
+            _mm512_mask_storeu_pd(
+                    trial_row + chunk_index,
+                    valid_mask,
+                    _mm512_mask_mov_pd(
+                            current_values, lane_mask, evolved_values));
+        };
         for (; genome_index + 8 <= genome_size; genome_index += 8) {
             // Reading bool values through their declared type preserves the
             // mask representation contract while producing an AVX-512 k-mask.
@@ -63,39 +101,31 @@ DEAC_NOINLINE void form_trial_population_row(
                     | (static_cast<unsigned>(
                             mutation_mask[genome_index + 7]) << 7));
 
-            // Sanitize every arithmetic input before exposing it to the
-            // compiler's contraction policy. The boundary makes all lanes of
-            // these vectors observable, so inactive values must remain benign
-            // zeros even when later arithmetic is emitted without predicates.
-            __m512d mutant_values1 = _mm512_maskz_loadu_pd(
-                    lane_mask, mutant_row1 + genome_index);
-            __m512d mutant_values2 = _mm512_maskz_loadu_pd(
-                    lane_mask, mutant_row2 + genome_index);
-            __m512d mutant_values3 = _mm512_maskz_loadu_pd(
-                    lane_mask, mutant_row3 + genome_index);
-            __m512d differential_weights = _mm512_maskz_mov_pd(
-                    lane_mask, differential_weight_vector);
-            __asm__ volatile(
-                    ""
-                    : "+v"(mutant_values1),
-                      "+v"(mutant_values2),
-                      "+v"(mutant_values3),
-                      "+v"(differential_weights));
-
-            __m512d evolved_values = mutant_values1
-                    + differential_weights*(mutant_values2 - mutant_values3);
-            if constexpr (!AllowNegativeSpectralWeight) {
-                evolved_values = _mm512_castsi512_pd(_mm512_and_epi64(
-                        _mm512_castpd_si512(evolved_values),
-                        magnitude_mask));
-            }
-            const __m512d current_values =
-                    _mm512_loadu_pd(current_row + genome_index);
-            _mm512_storeu_pd(
-                    trial_row + genome_index,
-                    _mm512_mask_mov_pd(
-                            current_values, lane_mask, evolved_values));
+            form_vector_chunk(genome_index, lane_mask, UINT8_MAX);
         }
+        if (genome_index < genome_size) {
+            const std::size_t remaining = genome_size - genome_index;
+            unsigned lane_bits = 0;
+            for (std::size_t lane=0; lane<remaining; ++lane) {
+                lane_bits |= static_cast<unsigned>(
+                        mutation_mask[genome_index + lane]) << lane;
+            }
+            const auto valid_mask = static_cast<__mmask8>(
+                    (UINT16_C(1) << remaining) - UINT16_C(1));
+            form_vector_chunk(
+                    genome_index,
+                    static_cast<__mmask8>(lane_bits),
+                    valid_mask);
+            genome_index = genome_size;
+        }
+    #endif
+    // The fallback must retain a real control dependency: if-converting this
+    // loop can evaluate signaling or otherwise exceptional mutant inputs for
+    // inactive lanes. AVX-512 uses explicitly sanitized masked vectors above.
+    #if defined(__clang__)
+        #pragma clang loop vectorize(disable)
+    #elif defined(__GNUC__)
+        #pragma GCC novector
     #endif
     for (; genome_index<genome_size; ++genome_index) {
         if (mutation_mask[genome_index]) {

--- a/src/deac/src/trial_population.hpp
+++ b/src/deac/src/trial_population.hpp
@@ -4,7 +4,8 @@
 #include <cstddef>
 #include <cstdint>
 
-#if defined(__AVX512F__) && defined(__FMA__) && !defined(USE_GPU)
+#if (defined(__GNUC__) || defined(__clang__)) \
+        && defined(__AVX512F__) && !defined(USE_GPU)
     #include <immintrin.h>
     #define DEAC_TRIAL_POPULATION_AVX512 1
 #endif
@@ -23,9 +24,9 @@ namespace deac_numerics {
 // current, three mutant, and mask ranges must be pairwise non-overlapping.
 // Solver mutant selection guarantees that the four input population rows are
 // distinct, while the trial row and mask live in separate allocations. Making
-// that ownership contract explicit lets CPU compilers predicate/vectorize the
-// masked row operation without changing its scalar arithmetic, selected value
-// bits, floating-point exception behavior, or RNG order.
+// that ownership contract explicit lets CPU compilers vectorize the selected
+// row operation without changing scalar arithmetic, selected value bits,
+// floating-point exception behavior, or RNG order.
 template<bool AllowNegativeSpectralWeight>
 DEAC_NOINLINE void form_trial_population_row(
         double* __restrict__ trial_row,
@@ -61,31 +62,42 @@ DEAC_NOINLINE void form_trial_population_row(
                             mutation_mask[genome_index + 6]) << 6)
                     | (static_cast<unsigned>(
                             mutation_mask[genome_index + 7]) << 7));
-            const __m512d current_values =
-                    _mm512_loadu_pd(current_row + genome_index);
-            const __m512d mutant_difference = _mm512_maskz_sub_pd(
-                    lane_mask,
-                    _mm512_loadu_pd(mutant_row2 + genome_index),
-                    _mm512_loadu_pd(mutant_row3 + genome_index));
-            __m512d evolved_values = _mm512_maskz_fmadd_pd(
-                    lane_mask,
-                    differential_weight_vector,
-                    mutant_difference,
-                    _mm512_loadu_pd(mutant_row1 + genome_index));
+
+            // Sanitize every arithmetic input before exposing it to the
+            // compiler's contraction policy. The boundary makes all lanes of
+            // these vectors observable, so inactive values must remain benign
+            // zeros even when later arithmetic is emitted without predicates.
+            __m512d mutant_values1 = _mm512_maskz_loadu_pd(
+                    lane_mask, mutant_row1 + genome_index);
+            __m512d mutant_values2 = _mm512_maskz_loadu_pd(
+                    lane_mask, mutant_row2 + genome_index);
+            __m512d mutant_values3 = _mm512_maskz_loadu_pd(
+                    lane_mask, mutant_row3 + genome_index);
+            __m512d differential_weights = _mm512_maskz_mov_pd(
+                    lane_mask, differential_weight_vector);
+            __asm__ volatile(
+                    ""
+                    : "+v"(mutant_values1),
+                      "+v"(mutant_values2),
+                      "+v"(mutant_values3),
+                      "+v"(differential_weights));
+
+            __m512d evolved_values = mutant_values1
+                    + differential_weights*(mutant_values2 - mutant_values3);
             if constexpr (!AllowNegativeSpectralWeight) {
                 evolved_values = _mm512_castsi512_pd(_mm512_and_epi64(
                         _mm512_castpd_si512(evolved_values),
                         magnitude_mask));
             }
+            const __m512d current_values =
+                    _mm512_loadu_pd(current_row + genome_index);
             _mm512_storeu_pd(
                     trial_row + genome_index,
                     _mm512_mask_mov_pd(
                             current_values, lane_mask, evolved_values));
         }
     #endif
-    for (;
-            genome_index<genome_size;
-            ++genome_index) {
+    for (; genome_index<genome_size; ++genome_index) {
         if (mutation_mask[genome_index]) {
             const double mutant_value =
                     mutant_row1[genome_index]

--- a/src/deac/src/trial_population.hpp
+++ b/src/deac/src/trial_population.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+
+#if defined(__AVX512F__) && defined(__FMA__) && !defined(USE_GPU)
+    #include <immintrin.h>
+    #define DEAC_TRIAL_POPULATION_AVX512 1
+#endif
+
+namespace deac_numerics {
+
+#if defined(__GNUC__) || defined(__clang__)
+    #define DEAC_NOINLINE __attribute__((noinline))
+#else
+    #define DEAC_NOINLINE
+#endif
+
+// Form one differential-evolution trial row.
+//
+// Every pointer names a contiguous range of genome_size elements. The output,
+// current, three mutant, and mask ranges must be pairwise non-overlapping.
+// Solver mutant selection guarantees that the four input population rows are
+// distinct, while the trial row and mask live in separate allocations. Making
+// that ownership contract explicit lets CPU compilers predicate/vectorize the
+// masked row operation without changing its scalar arithmetic, selected value
+// bits, floating-point exception behavior, or RNG order.
+template<bool AllowNegativeSpectralWeight>
+DEAC_NOINLINE void form_trial_population_row(
+        double* __restrict__ trial_row,
+        const double* __restrict__ current_row,
+        const double* __restrict__ mutant_row1,
+        const double* __restrict__ mutant_row2,
+        const double* __restrict__ mutant_row3,
+        const bool* __restrict__ mutation_mask,
+        double differential_weight,
+        std::size_t genome_size) {
+    std::size_t genome_index = 0;
+    #ifdef DEAC_TRIAL_POPULATION_AVX512
+        const __m512d differential_weight_vector =
+                _mm512_set1_pd(differential_weight);
+        const __m512i magnitude_mask = _mm512_set1_epi64(
+                static_cast<long long>(UINT64_C(0x7fffffffffffffff)));
+        for (; genome_index + 8 <= genome_size; genome_index += 8) {
+            // Reading bool values through their declared type preserves the
+            // mask representation contract while producing an AVX-512 k-mask.
+            const __mmask8 lane_mask = static_cast<__mmask8>(
+                    static_cast<unsigned>(mutation_mask[genome_index])
+                    | (static_cast<unsigned>(
+                            mutation_mask[genome_index + 1]) << 1)
+                    | (static_cast<unsigned>(
+                            mutation_mask[genome_index + 2]) << 2)
+                    | (static_cast<unsigned>(
+                            mutation_mask[genome_index + 3]) << 3)
+                    | (static_cast<unsigned>(
+                            mutation_mask[genome_index + 4]) << 4)
+                    | (static_cast<unsigned>(
+                            mutation_mask[genome_index + 5]) << 5)
+                    | (static_cast<unsigned>(
+                            mutation_mask[genome_index + 6]) << 6)
+                    | (static_cast<unsigned>(
+                            mutation_mask[genome_index + 7]) << 7));
+            const __m512d current_values =
+                    _mm512_loadu_pd(current_row + genome_index);
+            const __m512d mutant_difference = _mm512_maskz_sub_pd(
+                    lane_mask,
+                    _mm512_loadu_pd(mutant_row2 + genome_index),
+                    _mm512_loadu_pd(mutant_row3 + genome_index));
+            __m512d evolved_values = _mm512_maskz_fmadd_pd(
+                    lane_mask,
+                    differential_weight_vector,
+                    mutant_difference,
+                    _mm512_loadu_pd(mutant_row1 + genome_index));
+            if constexpr (!AllowNegativeSpectralWeight) {
+                evolved_values = _mm512_castsi512_pd(_mm512_and_epi64(
+                        _mm512_castpd_si512(evolved_values),
+                        magnitude_mask));
+            }
+            _mm512_storeu_pd(
+                    trial_row + genome_index,
+                    _mm512_mask_mov_pd(
+                            current_values, lane_mask, evolved_values));
+        }
+    #endif
+    for (;
+            genome_index<genome_size;
+            ++genome_index) {
+        if (mutation_mask[genome_index]) {
+            const double mutant_value =
+                    mutant_row1[genome_index]
+                    + differential_weight*(
+                            mutant_row2[genome_index]
+                            - mutant_row3[genome_index]);
+            if constexpr (AllowNegativeSpectralWeight) {
+                trial_row[genome_index] = mutant_value;
+            } else {
+                trial_row[genome_index] = std::fabs(mutant_value);
+            }
+        } else {
+            trial_row[genome_index] = current_row[genome_index];
+        }
+    }
+}
+
+// Two-sided finite-temperature spectra share the evolved zero-frequency value.
+// Both rows must contain at least one element and must not overlap.
+inline void couple_trial_population_zero(
+        double* __restrict__ negative_trial_row,
+        const double* __restrict__ positive_trial_row) {
+    negative_trial_row[0] = positive_trial_row[0];
+}
+
+#undef DEAC_NOINLINE
+#ifdef DEAC_TRIAL_POPULATION_AVX512
+    #undef DEAC_TRIAL_POPULATION_AVX512
+#endif
+
+} // namespace deac_numerics

--- a/test/trial_population_test.cpp
+++ b/test/trial_population_test.cpp
@@ -170,6 +170,8 @@ bool check_inactive_lane_bits() {
     }
 
     std::feclearexcept(FE_ALL_EXCEPT);
+    const double inactive_differential_weight = std::bit_cast<double>(
+            UINT64_C(0x7ff0000000000043));
     deac_numerics::form_trial_population_row<false>(
             actual.data(),
             current.data(),
@@ -177,7 +179,7 @@ bool check_inactive_lane_bits() {
             mutant2.data(),
             mutant3.data(),
             mask.data(),
-            2.0,
+            inactive_differential_weight,
             actual.size());
 
     if (std::fetestexcept(FE_ALL_EXCEPT) != 0) {

--- a/test/trial_population_test.cpp
+++ b/test/trial_population_test.cpp
@@ -1,0 +1,280 @@
+#include "trial_population.hpp"
+
+#include <array>
+#include <bit>
+#include <cfenv>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <vector>
+
+namespace {
+
+enum class MaskPattern {
+    all_false,
+    all_true,
+    alternating,
+    seeded_random,
+};
+
+template<bool AllowNegativeSpectralWeight>
+void reference_form_trial_population_row(
+        double* trial_row,
+        const double* current_row,
+        const double* mutant_row1,
+        const double* mutant_row2,
+        const double* mutant_row3,
+        const bool* mutation_mask,
+        double differential_weight,
+        std::size_t genome_size) {
+    for (std::size_t genome_index=0;
+            genome_index<genome_size;
+            ++genome_index) {
+        if (mutation_mask[genome_index]) {
+            const double mutant_value =
+                    mutant_row1[genome_index]
+                    + differential_weight*(
+                            mutant_row2[genome_index]
+                            - mutant_row3[genome_index]);
+            if constexpr (AllowNegativeSpectralWeight) {
+                trial_row[genome_index] = mutant_value;
+            } else {
+                trial_row[genome_index] = std::fabs(mutant_value);
+            }
+        } else {
+            trial_row[genome_index] = current_row[genome_index];
+        }
+    }
+}
+
+double row_value(std::size_t row, std::size_t genome_index) {
+    const std::size_t encoded = (row*37 + genome_index*19 + 11)%127;
+    const double magnitude = static_cast<double>(encoded + 1)/16.0;
+    return (row + genome_index)%3 == 0 ? -magnitude : magnitude;
+}
+
+void fill_masks(
+        bool* positive_mask,
+        bool* negative_mask,
+        MaskPattern pattern,
+        std::size_t genome_size) {
+    std::uint64_t state = UINT64_C(0x6a09e667f3bcc909);
+    for (std::size_t genome_index=0;
+            genome_index<genome_size;
+            ++genome_index) {
+        bool mutate = false;
+        switch (pattern) {
+            case MaskPattern::all_false:
+                mutate = false;
+                break;
+            case MaskPattern::all_true:
+                mutate = true;
+                break;
+            case MaskPattern::alternating:
+                mutate = genome_index%2 == 0;
+                break;
+            case MaskPattern::seeded_random:
+                state = state*UINT64_C(6364136223846793005) + UINT64_C(1);
+                mutate = (state >> 63) != 0;
+                break;
+        }
+        positive_mask[genome_index] = mutate;
+        negative_mask[genome_index] = !mutate;
+    }
+}
+
+bool same_bits(double left, double right) {
+    return std::bit_cast<std::uint64_t>(left)
+            == std::bit_cast<std::uint64_t>(right);
+}
+
+bool check_inactive_lane_bits() {
+    constexpr std::array<std::uint64_t, 9> current_bits{
+            UINT64_C(0x8000000000000000), // negative zero
+            UINT64_C(0x7ff8000000000042), // quiet NaN with payload
+            UINT64_C(0xfff0000000000000), // negative infinity
+            UINT64_C(0x0000000000000001), // least positive subnormal
+            UINT64_C(0x0000000000000000), // positive zero
+            UINT64_C(0x7ff0000000000042), // signaling NaN with payload
+            UINT64_C(0x7fefffffffffffff), // greatest finite value
+            UINT64_C(0xffefffffffffffff), // least finite value
+            UINT64_C(0x8000000000000001)}; // least negative subnormal
+    std::array<double, current_bits.size()> current{};
+    std::array<double, current_bits.size()> mutant1{};
+    std::array<double, current_bits.size()> mutant2{};
+    std::array<double, current_bits.size()> mutant3{};
+    std::array<double, current_bits.size()> actual{};
+    std::array<bool, current_bits.size()> mask{};
+
+    for (std::size_t index=0; index<current.size(); ++index) {
+        current[index] = std::bit_cast<double>(current_bits[index]);
+        mutant1[index] = std::numeric_limits<double>::max();
+        mutant2[index] = std::numeric_limits<double>::infinity();
+        mutant3[index] = std::numeric_limits<double>::infinity();
+    }
+
+    std::feclearexcept(FE_ALL_EXCEPT);
+    deac_numerics::form_trial_population_row<false>(
+            actual.data(),
+            current.data(),
+            mutant1.data(),
+            mutant2.data(),
+            mutant3.data(),
+            mask.data(),
+            2.0,
+            actual.size());
+
+    if (std::fetestexcept(FE_ALL_EXCEPT) != 0) {
+        std::cerr << "inactive trial lanes raised a floating-point exception\n";
+        return false;
+    }
+
+    for (std::size_t index=0; index<actual.size(); ++index) {
+        if (std::bit_cast<std::uint64_t>(actual[index])
+                != current_bits[index]) {
+            std::cerr << "inactive trial lane changed bits at index=" << index
+                      << ": expected 0x" << std::hex << current_bits[index]
+                      << ", got 0x"
+                      << std::bit_cast<std::uint64_t>(actual[index]) << '\n';
+            return false;
+        }
+    }
+    return true;
+}
+
+template<bool AllowNegativeSpectralWeight>
+bool check_case(
+        std::size_t genome_size,
+        MaskPattern pattern,
+        double positive_weight,
+        double negative_weight) {
+    std::array<std::vector<double>, 4> positive_rows;
+    std::array<std::vector<double>, 4> negative_rows;
+    for (std::size_t row=0; row<positive_rows.size(); ++row) {
+        positive_rows[row].resize(genome_size);
+        negative_rows[row].resize(genome_size);
+        for (std::size_t genome_index=0;
+                genome_index<genome_size;
+                ++genome_index) {
+            positive_rows[row][genome_index] = row_value(row, genome_index);
+            negative_rows[row][genome_index] =
+                    row_value(row + positive_rows.size(), genome_index);
+        }
+    }
+
+    const std::unique_ptr<bool[]> positive_mask(new bool[genome_size]);
+    const std::unique_ptr<bool[]> negative_mask(new bool[genome_size]);
+    fill_masks(
+            positive_mask.get(),
+            negative_mask.get(),
+            pattern,
+            genome_size);
+
+    std::vector<double> expected_positive(genome_size, -901.0);
+    std::vector<double> actual_positive(genome_size, -902.0);
+    std::vector<double> expected_negative(genome_size, -903.0);
+    std::vector<double> actual_negative(genome_size, -904.0);
+
+    reference_form_trial_population_row<AllowNegativeSpectralWeight>(
+            expected_positive.data(),
+            positive_rows[0].data(),
+            positive_rows[1].data(),
+            positive_rows[2].data(),
+            positive_rows[3].data(),
+            positive_mask.get(),
+            positive_weight,
+            genome_size);
+    reference_form_trial_population_row<AllowNegativeSpectralWeight>(
+            expected_negative.data(),
+            negative_rows[0].data(),
+            negative_rows[1].data(),
+            negative_rows[2].data(),
+            negative_rows[3].data(),
+            negative_mask.get(),
+            negative_weight,
+            genome_size);
+    expected_negative[0] = expected_positive[0];
+
+    deac_numerics::form_trial_population_row<AllowNegativeSpectralWeight>(
+            actual_positive.data(),
+            positive_rows[0].data(),
+            positive_rows[1].data(),
+            positive_rows[2].data(),
+            positive_rows[3].data(),
+            positive_mask.get(),
+            positive_weight,
+            genome_size);
+    deac_numerics::form_trial_population_row<AllowNegativeSpectralWeight>(
+            actual_negative.data(),
+            negative_rows[0].data(),
+            negative_rows[1].data(),
+            negative_rows[2].data(),
+            negative_rows[3].data(),
+            negative_mask.get(),
+            negative_weight,
+            genome_size);
+    deac_numerics::couple_trial_population_zero(
+            actual_negative.data(), actual_positive.data());
+
+    for (std::size_t index=0; index<genome_size; ++index) {
+        if (!same_bits(expected_positive[index], actual_positive[index])
+                || !same_bits(expected_negative[index], actual_negative[index])) {
+            std::cerr << "trial row mismatch for width=" << genome_size
+                      << ", mask=" << static_cast<int>(pattern)
+                      << ", positive F=" << positive_weight
+                      << ", negative F=" << negative_weight
+                      << ", signed=" << AllowNegativeSpectralWeight
+                      << ", index=" << index
+                      << ": expected positive " << std::hexfloat
+                      << expected_positive[index] << ", got "
+                      << actual_positive[index] << "; expected negative "
+                      << expected_negative[index] << ", got "
+                      << actual_negative[index] << '\n';
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    constexpr std::array<std::size_t, 9> genome_sizes{
+            1, 2, 7, 8, 9, 15, 16, 17, 1024};
+    constexpr std::array<MaskPattern, 4> patterns{
+            MaskPattern::all_false,
+            MaskPattern::all_true,
+            MaskPattern::alternating,
+            MaskPattern::seeded_random};
+    constexpr std::array<double, 3> differential_weights{0.0, 0.5, 2.0};
+
+    if (!check_inactive_lane_bits()) {
+        return 1;
+    }
+
+    for (const std::size_t genome_size : genome_sizes) {
+        for (const MaskPattern pattern : patterns) {
+            for (const double positive_weight : differential_weights) {
+                for (const double negative_weight : differential_weights) {
+                    if (!check_case<false>(
+                                genome_size,
+                                pattern,
+                                positive_weight,
+                                negative_weight)
+                            || !check_case<true>(
+                                genome_size,
+                                pattern,
+                                positive_weight,
+                                negative_weight)) {
+                        return 1;
+                    }
+                }
+            }
+        }
+    }
+    return 0;
+}

--- a/test/trial_population_test.cpp
+++ b/test/trial_population_test.cpp
@@ -14,6 +14,12 @@
 
 namespace {
 
+#if defined(__GNUC__) || defined(__clang__)
+    #define DEAC_TEST_NOINLINE __attribute__((noinline))
+#else
+    #define DEAC_TEST_NOINLINE
+#endif
+
 enum class MaskPattern {
     all_false,
     all_true,
@@ -22,7 +28,7 @@ enum class MaskPattern {
 };
 
 template<bool AllowNegativeSpectralWeight>
-void reference_form_trial_population_row(
+DEAC_TEST_NOINLINE void reference_form_trial_population_row(
         double* trial_row,
         const double* current_row,
         const double* mutant_row1,
@@ -92,6 +98,51 @@ bool same_bits(double left, double right) {
             == std::bit_cast<std::uint64_t>(right);
 }
 
+bool check_contraction_policy() {
+    constexpr std::size_t genome_size = 8;
+    std::array<double, genome_size> current{};
+    std::array<double, genome_size> mutant1{};
+    std::array<double, genome_size> mutant2{};
+    std::array<double, genome_size> mutant3{};
+    std::array<double, genome_size> expected{};
+    std::array<double, genome_size> actual{};
+    std::array<bool, genome_size> mask{};
+    mutant1.fill(-1.0);
+    mutant2.fill(std::nextafter(1.0, 0.0));
+    mutant3.fill(0.0);
+    mask.fill(true);
+    const double differential_weight = std::nextafter(1.0, 2.0);
+
+    reference_form_trial_population_row<true>(
+            expected.data(),
+            current.data(),
+            mutant1.data(),
+            mutant2.data(),
+            mutant3.data(),
+            mask.data(),
+            differential_weight,
+            genome_size);
+    deac_numerics::form_trial_population_row<true>(
+            actual.data(),
+            current.data(),
+            mutant1.data(),
+            mutant2.data(),
+            mutant3.data(),
+            mask.data(),
+            differential_weight,
+            genome_size);
+    for (std::size_t index=0; index<genome_size; ++index) {
+        if (!same_bits(expected[index], actual[index])) {
+            std::cerr << "trial row changed the compiler's contraction policy"
+                      << " at index=" << index << ": expected "
+                      << std::hexfloat << expected[index] << ", got "
+                      << actual[index] << '\n';
+            return false;
+        }
+    }
+    return true;
+}
+
 bool check_inactive_lane_bits() {
     constexpr std::array<std::uint64_t, 9> current_bits{
             UINT64_C(0x8000000000000000), // negative zero
@@ -112,7 +163,8 @@ bool check_inactive_lane_bits() {
 
     for (std::size_t index=0; index<current.size(); ++index) {
         current[index] = std::bit_cast<double>(current_bits[index]);
-        mutant1[index] = std::numeric_limits<double>::max();
+        mutant1[index] = std::bit_cast<double>(
+                UINT64_C(0x7ff0000000000042));
         mutant2[index] = std::numeric_limits<double>::infinity();
         mutant3[index] = std::numeric_limits<double>::infinity();
     }
@@ -252,7 +304,7 @@ int main() {
             MaskPattern::seeded_random};
     constexpr std::array<double, 3> differential_weights{0.0, 0.5, 2.0};
 
-    if (!check_inactive_lane_bits()) {
+    if (!check_inactive_lane_bits() || !check_contraction_policy()) {
         return 1;
     }
 
@@ -278,3 +330,5 @@ int main() {
     }
     return 0;
 }
+
+#undef DEAC_TEST_NOINLINE


### PR DESCRIPTION
Closes #39.

## Summary

- extract trial-row formation into a noinline helper with an explicit, locally provable non-overlap contract;
- use sanitized AVX-512 masked loads for all arithmetic inputs, including partial tails, while preserving the compiler-selected contraction policy;
- retain a genuinely branch-controlled scalar fallback on AVX2/generic targets so inactive exceptional inputs are not evaluated;
- preserve RNG order, mask generation, mutant selection, signed/fabs behavior, positive/negative row separation, and two-sided `j=0` coupling;
- add bit-level oracle, inactive signaling-NaN/fenv, contraction-policy, tail-width, and fallback coverage.

## Exact provenance

- base: `4437428d7ef6f3b8de81ba27394155e7a282caeb`
- candidate: `e243c35987dfee61f7a52bb5f5444ef863bc8b86`
- GCC: 14.3
- IntelLLVM: 2026.1.0
- CPU: Intel Xeon Max 9470C
- SYCL: Intel Data Center GPU Max 1550 through real Level Zero execution
- profiling input SHA-256: `4e75b45bee9d48122d781e025a9b172b8bba79da68e97f188e546e30c6f9e968`

## Correctness and portability

- GCC full matrices: standard, detailed, hyperbolic, normalization, and ZeroT 61/61 each; signed 57/57; ASan+UBSan 61/61.
- IntelLLVM full matrices: standard, detailed, hyperbolic, normalization, and ZeroT 61/61 each; signed 57/57.
- Real Level Zero SYCL: standard and detailed 62/62 each.
- Exact end-to-end parity per compiler: 54/54 cases (`6 configurations × 3 seeds × crossover {0, 0.9, 1}`), 270/270 binary artifacts and 54/54 normalized logs byte-identical.
- Independent exception/contraction matrix: 96/96 each for native AVX-512, AVX2 fallback, and generic x86 fallback across both compilers, signed/fabs modes, widths 7/8/9/17, default contraction and `-ffp-contract=off`, ordinary fenv and enabled traps.
- Assembly inspection confirms masked mutant and weight inputs, predicated partial-tail load/store, FMA under default policy, and separate multiply/add with contraction disabled.
- CUDA/HIP production paths are unchanged; `USE_GPU+USE_CUDA` and `USE_GPU+USE_HIP` header/unit simulations compile and pass with GCC and IntelLLVM. Native CUDA/HIP toolchains are unavailable on this host.

## Paired performance

Five alternating post-warm-up pairs, one thread pinned to CPU 1, exact baseline/candidate identities, identical output files, and unchanged maximum RSS:

| Compiler | Family | Baseline | Candidate | Change |
|---|---|---:|---:|---:|
| GCC 14.3 | standard | 5.59 s | 4.03 s | 27.91% faster |
| GCC 14.3 | detailed | 3.01 s | 1.93 s | 35.88% faster |
| IntelLLVM 2026.1 | standard | 3.11 s | 2.81 s | 9.65% faster |
| IntelLLVM 2026.1 | detailed | 1.50 s | 1.32 s | 12.00% faster |

GCC standard `perf stat -r 3`, with exact outputs:

- cycles: 18,768,509,067 → 13,570,083,173 (-27.70%);
- instructions: 33,796,356,926 → 29,874,403,808 (-11.60%);
- branches: 3,201,779,583 → 1,500,654,858 (-53.13%);
- branch misses: 294,678,506 → 2,472,817 (-99.16%).

## Review

Independent review of exact `e243c359` returned `PUBLISH` with no correctness or portability blockers. Earlier `d337aea`, `db9606c`, and `80f4373` candidates were explicitly rejected and are superseded; issue #39 records the correction and root causes.

Hosted Actions may report the already-tracked account-level zero-step failure; local exact-head evidence above is authoritative until that external blocker is cleared.
