### PR TITLE
fix: keep CUDA and HIP status calls active in Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ As above, and with further details below, but you should consider using the foll
 Executables will be installed to `CMAKE_INSTALL_PREFIX` location or, if the install is skipped, they will be located in `build/deac`.
 Executables produced are `deac.e`, `deacd.e`, `deac-zT.e`, and `deac-zTd.e` for `CMAKE_BUILD_TYPE=Release|Debug|ZeroT|ZeroTDebug` respectively.
 
+### Accelerator error handling
+
+CUDA and HIP runtime and BLAS operations are evaluated and checked in every
+build type, including Release builds with `NDEBUG`. A failed operation throws a
+`deac_gpu_status::status_error`; the command-line boundary reports the error
+and exits nonzero rather than continuing with invalid device state. Diagnostics
+identify the backend, runtime or BLAS category, failed expression, numeric
+status, available runtime description, and source file and line. SYCL retains
+its native synchronous and asynchronous exception behavior, including
+`wait_and_throw` at synchronization points.
+
 ### Build identity and provenance
 
 `deac.e --version` (or `-v`) retains the legacy one-line semantic-version

--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -309,6 +309,31 @@ add_test(
     NAME deac_unit_normalization
     COMMAND deac_normalization_test)
 
+find_package(Python3 COMPONENTS Interpreter)
+foreach(status_mode IN ITEMS debug ndebug)
+    set(status_target deac_gpu_status_${status_mode}_test)
+    add_executable(${status_target}
+        ${CMAKE_SOURCE_DIR}/../test/gpu_status_test.cpp)
+    set_target_properties(${status_target} PROPERTIES
+        CXX_STANDARD 14
+        CXX_STANDARD_REQUIRED TRUE
+        CXX_EXTENSIONS FALSE)
+    target_include_directories(${status_target} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    if(status_mode STREQUAL "ndebug")
+        target_compile_definitions(${status_target} PRIVATE
+            DEAC_TEST_WITH_NDEBUG=1)
+    endif()
+    if(Python3_Interpreter_FOUND)
+        add_test(
+            NAME deac_unit_gpu_status_${status_mode}
+            COMMAND
+                ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/../test/gpu_status_driver_test.py
+                --exe $<TARGET_FILE:${status_target}>)
+    endif()
+endforeach()
+
 if(NOT "${GPU_BACKEND}" STREQUAL "none")
     set(DEAC_GPU_NORMALIZATION_TEST_SOURCES
         ${CMAKE_SOURCE_DIR}/../test/gpu_normalization_test.cpp)
@@ -447,8 +472,13 @@ if(NOT USE_ALLOW_NEGATIVE_SPECTRAL_WEIGHT)
     endif()
 endif()
 
-find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
+    add_test(
+        NAME deac_gpu_status_source_policy
+        COMMAND
+            ${Python3_EXECUTABLE}
+            ${CMAKE_SOURCE_DIR}/../test/gpu_status_policy_test.py
+            --source-root ${CMAKE_SOURCE_DIR}/..)
     set(DEAC_SMOKE_TEST "${CMAKE_SOURCE_DIR}/../test/deac_smoke_test.py")
     set(DEAC_PARITY_TEST "${CMAKE_SOURCE_DIR}/../test/deac_parity_test.py")
     set(DEAC_BUILD_IDENTITY_TEST

--- a/src/deac/include/common_gpu.hpp
+++ b/src/deac/include/common_gpu.hpp
@@ -1,6 +1,6 @@
 #ifndef COMMON_GPU_H 
 #define COMMON_GPU_H
-#include <cassert>
+#include "gpu_status.hpp"
 
 #define IS_POWER_OF_TWO(x) ((x != 0) && ((x & (x - 1)) == 0))
 
@@ -27,7 +27,12 @@
     #endif
     #ifdef USE_HIP
         #include "hip/hip_runtime.h"
-        #define GPU_ASSERT(x) (assert((x)==hipSuccess))
+        #define GPU_ASSERT(expression)                              \
+            DEAC_GPU_STATUS_CHECK(                                 \
+                    expression, hipSuccess, "HIP", "runtime",    \
+                    [](hipError_t status) {                        \
+                        return hipGetErrorString(status);          \
+                    })
         typedef hipStream_t deac_stream_t;
         #define deac_stream_create(x) hipStreamCreate(&x)
         #define deac_stream_destroy(x) hipStreamDestroy(x)
@@ -40,7 +45,11 @@
         #ifdef USE_BLAS
             #include <hipblas/hipblas.h>
             typedef hipblasHandle_t deac_blas_handle_t;
-            #define GPU_BLAS_ASSERT(x) (assert((x)==HIPBLAS_STATUS_SUCCESS))
+            #define GPU_BLAS_ASSERT(expression)                    \
+                DEAC_GPU_STATUS_CHECK(                             \
+                        expression, HIPBLAS_STATUS_SUCCESS,        \
+                        "HIP", "BLAS",                          \
+                        deac_gpu_status::no_description{})
             #define deac_create_blas_handle(x) hipblasCreate(&x)
             #define deac_destroy_blas_handle(x) hipblasDestroy(x)
             #define deac_set_stream(x, y) hipblasSetStream(x, y)
@@ -48,7 +57,12 @@
     #endif
     #ifdef USE_CUDA
         #include <cuda_runtime.h>
-        #define GPU_ASSERT(x) (assert((x)==cudaSuccess))
+        #define GPU_ASSERT(expression)                             \
+            DEAC_GPU_STATUS_CHECK(                                \
+                    expression, cudaSuccess, "CUDA", "runtime", \
+                    [](cudaError_t status) {                      \
+                        return cudaGetErrorString(status);        \
+                    })
         typedef cudaStream_t deac_stream_t;
         #define deac_stream_create(x) cudaStreamCreate(&x)
         #define deac_stream_destroy(x) cudaStreamDestroy(x)
@@ -61,7 +75,11 @@
         #ifdef USE_BLAS
             #include "cublas_v2.h"
             typedef cublasHandle_t deac_blas_handle_t;
-            #define GPU_BLAS_ASSERT(x) (assert((x)==CUBLAS_STATUS_SUCCESS))
+            #define GPU_BLAS_ASSERT(expression)                    \
+                DEAC_GPU_STATUS_CHECK(                             \
+                        expression, CUBLAS_STATUS_SUCCESS,         \
+                        "CUDA", "BLAS",                         \
+                        deac_gpu_status::no_description{})
             #define deac_create_blas_handle(x) cublasCreate(&x)
             #define deac_destroy_blas_handle(x) cublasDestroy(x)
             #define deac_set_stream(x, y) cublasSetStream(x, y)

--- a/src/deac/include/gpu_status.hpp
+++ b/src/deac/include/gpu_status.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <sstream>
+#include <stdexcept>
+
+namespace deac_gpu_status {
+class status_error : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+struct no_description {
+    template<typename Status>
+    const char* operator()(Status) const noexcept {
+        return nullptr;
+    }
+};
+
+template<typename Status, typename Success, typename Describe>
+void check(
+        Status status,
+        Success success,
+        const char* backend,
+        const char* category,
+        const char* expression,
+        const char* file,
+        int line,
+        Describe describe) {
+    if (status == success) {
+        return;
+    }
+
+    std::ostringstream message;
+    message << backend << ' ' << category << " call failed: "
+            << expression << "; status=" << static_cast<long long>(status);
+    const char* description = describe(status);
+    if (description != nullptr && description[0] != '\0') {
+        message << " (" << description << ')';
+    }
+    message << "; location=" << file << ':' << line;
+    throw status_error(message.str());
+}
+} // namespace deac_gpu_status
+
+// The operation expression occurs exactly once outside standard assert, so it
+// is evaluated identically whether or not NDEBUG is defined.
+#define DEAC_GPU_STATUS_CHECK(                                      \
+        expression, success, backend, category, describe)          \
+    ::deac_gpu_status::check(                                      \
+            (expression), (success), (backend), (category),        \
+            #expression, __FILE__, __LINE__, (describe))

--- a/test/gpu_status_driver_test.py
+++ b/test/gpu_status_driver_test.py
@@ -1,0 +1,64 @@
+import argparse
+import re
+import subprocess
+
+SUCCESS_MARKER = (
+    "success checks passed; runtime_evaluations=1; blas_evaluations=1\n"
+)
+FAILURE_MARKER = (
+    "controlled failure checks passed; runtime_evaluations=1; "
+    "blas_evaluations=1\n"
+)
+
+
+def run(executable, *arguments):
+    return subprocess.run(
+        [executable, *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exe", required=True)
+    args = parser.parse_args()
+
+    success = run(args.exe)
+    require(success.returncode == 0, f"success return code: {success.returncode}")
+    require(success.stdout == SUCCESS_MARKER, f"success stdout: {success.stdout!r}")
+    require(success.stderr == "", f"success stderr: {success.stderr!r}")
+
+    failure = run(args.exe, "--failure")
+    require(failure.returncode == 1, f"failure return code: {failure.returncode}")
+    require(failure.stdout == "", f"failure stdout: {failure.stdout!r}")
+    require(
+        failure.stderr.count(FAILURE_MARKER) == 1,
+        f"controlled failure marker count: {failure.stderr!r}",
+    )
+    require("did not throw" not in failure.stderr, failure.stderr)
+
+    runtime_prefix = (
+        "FAKE runtime call failed: counted_status(evaluations, failure); "
+        "status=17 (controlled runtime failure); location="
+    )
+    blas_prefix = (
+        "FAKE BLAS call failed: counted_status(evaluations, failure); "
+        "status=29; location="
+    )
+    require(failure.stderr.count(runtime_prefix) == 1, failure.stderr)
+    require(failure.stderr.count(blas_prefix) == 1, failure.stderr)
+    locations = re.findall(r"gpu_status_test\.cpp:[0-9]+", failure.stderr)
+    require(len(locations) == 2, failure.stderr)
+    require(failure.stderr.endswith(FAILURE_MARKER), failure.stderr)
+    print("Debug/NDEBUG GPU status-check driver passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/gpu_status_policy_test.py
+++ b/test/gpu_status_policy_test.py
@@ -1,0 +1,120 @@
+import argparse
+import re
+from pathlib import Path
+
+STATUS_MACRO = re.compile(
+    r"^\s*#\s*define\s+(GPU_ASSERT|GPU_BLAS_ASSERT)\s*\(", re.MULTILINE
+)
+STANDARD_ASSERT = re.compile(r"\bassert\s*\(")
+ESSENTIAL_BACKEND_CALL = re.compile(
+    r"\b(?:cuda|hip|cublas|hipblas)[A-Za-z0-9_]*\s*\("
+    r"|\bdeac_(?:stream_create|stream_destroy|malloc_device|"
+    r"memcpy_host_to_device|memcpy_device_to_host|wait|memset|free|"
+    r"create_blas_handle|destroy_blas_handle|set_stream)\s*\("
+)
+SOURCE_SUFFIXES = {".cpp", ".cu", ".cuh", ".h", ".hpp"}
+
+
+def logical_lines(text):
+    pending = ""
+    for physical_line in text.splitlines():
+        pending += physical_line
+        if physical_line.rstrip().endswith("\\"):
+            pending += "\n"
+            continue
+        yield pending
+        pending = ""
+    if pending:
+        yield pending
+
+
+def check_status_macros(common_gpu):
+    common_gpu_text = common_gpu.read_text()
+    definitions = [
+        line
+        for line in logical_lines(common_gpu_text)
+        if STATUS_MACRO.match(line)
+    ]
+    errors = []
+    if STANDARD_ASSERT.search(common_gpu_text):
+        errors.append(f"{common_gpu}: standard assert is forbidden")
+    for macro_name in ("GPU_ASSERT", "GPU_BLAS_ASSERT"):
+        matching = [
+            definition
+            for definition in definitions
+            if STATUS_MACRO.match(definition).group(1) == macro_name
+        ]
+        checked = [
+            definition
+            for definition in matching
+            if "DEAC_GPU_STATUS_CHECK" in definition
+        ]
+        if len(matching) != 3 or len(checked) != 2:
+            errors.append(
+                f"{common_gpu}: expected two checked CUDA/HIP and one "
+                f"SYCL {macro_name} definitions, got {len(checked)} checked "
+                f"of {len(matching)} total"
+            )
+        expected_category = "runtime" if macro_name == "GPU_ASSERT" else "BLAS"
+        for backend in ("CUDA", "HIP"):
+            backend_definitions = [
+                definition
+                for definition in checked
+                if f'"{backend}"' in definition
+                and f'"{expected_category}"' in definition
+            ]
+            if len(backend_definitions) != 1:
+                errors.append(
+                    f"{common_gpu}: expected one checked {backend} "
+                    f"{expected_category} {macro_name} definition"
+                )
+        for definition in matching:
+            if STANDARD_ASSERT.search(definition):
+                errors.append(
+                    f"{common_gpu}: {macro_name} delegates to standard assert"
+                )
+    return errors
+
+
+def check_asserted_backend_calls(source_root):
+    errors = []
+    for search_root in (source_root / "src" / "deac", source_root / "test"):
+        for path in sorted(search_root.rglob("*")):
+            if not path.is_file() or path.suffix not in SOURCE_SUFFIXES:
+                continue
+            text = path.read_text()
+            for match in STANDARD_ASSERT.finditer(text):
+                # An assert expression ends at its statement semicolon.  The
+                # bounded fallback also covers a macro with no semicolon.
+                statement_end = text.find(";", match.end())
+                if statement_end < 0 or statement_end - match.start() > 2000:
+                    statement_end = min(len(text), match.start() + 2000)
+                expression = text[match.start():statement_end]
+                if ESSENTIAL_BACKEND_CALL.search(expression):
+                    line = text.count("\n", 0, match.start()) + 1
+                    errors.append(
+                        f"{path}:{line}: essential backend call is inside "
+                        "standard assert"
+                    )
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-root", required=True)
+    args = parser.parse_args()
+
+    source_root = Path(args.source_root).resolve()
+    common_gpu = source_root / "src" / "deac" / "include" / "common_gpu.hpp"
+    gpu_status = source_root / "src" / "deac" / "include" / "gpu_status.hpp"
+    errors = check_status_macros(common_gpu)
+    if STANDARD_ASSERT.search(gpu_status.read_text()):
+        errors.append(f"{gpu_status}: standard assert is forbidden")
+    errors.extend(check_asserted_backend_calls(source_root))
+    if errors:
+        raise SystemExit("\n".join(errors))
+    print("CUDA/HIP status-check source policy passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/gpu_status_test.cpp
+++ b/test/gpu_status_test.cpp
@@ -1,0 +1,172 @@
+#ifdef DEAC_TEST_WITH_NDEBUG
+    #ifdef NDEBUG
+        #undef NDEBUG
+    #endif
+    #define NDEBUG 1
+#else
+    #ifdef NDEBUG
+        #undef NDEBUG
+    #endif
+#endif
+
+#include "gpu_status.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#ifdef DEAC_TEST_WITH_NDEBUG
+    #ifndef NDEBUG
+        #error "NDEBUG status-check regression did not define NDEBUG"
+    #endif
+#else
+    #ifdef NDEBUG
+        #error "Debug status-check regression did not clear NDEBUG"
+    #endif
+#endif
+
+namespace {
+enum class fake_status {
+    success = 0,
+    runtime_failure = 17,
+    blas_failure = 29,
+};
+
+fake_status counted_status(int& evaluations, fake_status result) {
+    ++evaluations;
+    return result;
+}
+
+struct counted_description {
+    int* evaluations;
+    const char* text;
+
+    const char* operator()(fake_status) const {
+        ++*evaluations;
+        return text;
+    }
+};
+
+bool contains(const std::string& text, const std::string& expected) {
+    if (text.find(expected) == std::string::npos) {
+        std::cerr << "missing diagnostic fragment " << expected
+                  << " in: " << text << '\n';
+        return false;
+    }
+    return true;
+}
+
+template<typename Describe>
+bool check_success(
+        const char* category,
+        Describe describe,
+        int& evaluations,
+        int& description_evaluations) {
+    DEAC_GPU_STATUS_CHECK(
+            counted_status(evaluations, fake_status::success),
+            fake_status::success, "FAKE", category, describe);
+    if (evaluations != 1 || description_evaluations != 0) {
+        std::cerr << category << " success evaluated operation "
+                  << evaluations << " times and description "
+                  << description_evaluations << " times\n";
+        return false;
+    }
+    return true;
+}
+
+template<typename Describe>
+bool check_failure(
+        const char* category,
+        fake_status failure,
+        int expected_code,
+        Describe describe,
+        int& description_evaluations,
+        int expected_description_evaluations,
+        const char* expected_description,
+        std::string& diagnostic) {
+    int evaluations = 0;
+    try {
+        DEAC_GPU_STATUS_CHECK(
+                counted_status(evaluations, failure),
+                fake_status::success, "FAKE", category, describe);
+        std::cerr << category << " failure did not throw\n";
+        return false;
+    } catch (const deac_gpu_status::status_error& error) {
+        diagnostic = error.what();
+    }
+
+    bool valid = true;
+    if (evaluations != 1
+            || description_evaluations != expected_description_evaluations) {
+        std::cerr << category << " failure evaluated operation "
+                  << evaluations << " times and description "
+                  << description_evaluations << " times\n";
+        valid = false;
+    }
+    valid = contains(diagnostic, std::string("FAKE ") + category
+            + " call failed: counted_status(evaluations, failure)") && valid;
+    std::string status_fragment =
+            "status=" + std::to_string(expected_code);
+    if (expected_description == nullptr) {
+        status_fragment += "; location=";
+    } else {
+        status_fragment +=
+                std::string(" (") + expected_description + "); location=";
+    }
+    valid = contains(diagnostic, status_fragment) && valid;
+    valid = contains(diagnostic, "gpu_status_test.cpp:") && valid;
+    return valid;
+}
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc == 1) {
+        int runtime_evaluations = 0;
+        int blas_evaluations = 0;
+        int runtime_descriptions = 0;
+        int blas_descriptions = 0;
+        const bool runtime_valid = check_success(
+                "runtime",
+                counted_description{
+                        &runtime_descriptions,
+                        "unused runtime description"},
+                runtime_evaluations, runtime_descriptions);
+        const bool blas_valid = check_success(
+                "BLAS", deac_gpu_status::no_description{},
+                blas_evaluations, blas_descriptions);
+        if (!runtime_valid || !blas_valid) {
+            return EXIT_FAILURE;
+        }
+        std::cout << "success checks passed; runtime_evaluations=1; "
+                     "blas_evaluations=1\n";
+        return EXIT_SUCCESS;
+    }
+
+    if (argc != 2 || std::string(argv[1]) != "--failure") {
+        std::cerr << "usage: gpu_status_test [--failure]\n";
+        return 2;
+    }
+
+    std::string runtime_diagnostic;
+    std::string blas_diagnostic;
+    int runtime_descriptions = 0;
+    int blas_descriptions = 0;
+    const bool runtime_valid = check_failure(
+            "runtime", fake_status::runtime_failure, 17,
+            counted_description{
+                    &runtime_descriptions, "controlled runtime failure"},
+            runtime_descriptions, 1, "controlled runtime failure",
+            runtime_diagnostic);
+    const bool blas_valid = check_failure(
+            "BLAS", fake_status::blas_failure, 29,
+            deac_gpu_status::no_description{},
+            blas_descriptions, 0, nullptr, blas_diagnostic);
+    if (!runtime_valid || !blas_valid) {
+        return 2;
+    }
+
+    std::cerr << runtime_diagnostic << '\n' << blas_diagnostic << '\n'
+              << "controlled failure checks passed; runtime_evaluations=1; "
+                 "blas_evaluations=1\n";
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

- replace CUDA/HIP runtime and BLAS checks backed by standard `assert` with a C++14 always-evaluating status helper
- evaluate every wrapped operation exactly once in Debug and `NDEBUG` builds, and propagate actionable failures through the existing CLI exception boundary
- add controlled success/failure regressions plus a source-policy guard against essential backend operations being hidden in `assert`
- preserve CUDA/HIP call order and successful-path behavior, and leave the SYCL macros and `wait_and_throw` behavior unchanged

## Exact change

- base: `16ce1ec80933fa3e54329ede7c2f09de4949c5fb`
- commit: `9732a651bbd9ee06fc80bd1bba8aee820fb99055`
- seven-path pre-commit Git patch-stream SHA-256: `930a2373d771acab78bb365b0f28f0cb4be397f7d9458bb622e21bc380a94acd`
- canonical full-index commit diff SHA-256: `3e7502d22976119e538329ea78e606f782efa5d9cef16d3332fde23a77278c57`
- independent exact static review: `PUBLISH`

## Validation

- Intel oneAPI DPC++/C++ 2026.1.0, Release CPU: **64/64 CTests passed**
- Spack GCC 14.3.0, Release CPU: **64/64 CTests passed**
- Intel oneAPI DPC++/C++ 2026.1.0, `-fsycl`, Level Zero on six Intel Data Center GPU Max 1550 devices: **66/66 CTests passed**, including candidate-matched CPU-reference parity
- clean CPU and SYCL binaries both report exact source SHA `9732a651bbd9ee06fc80bd1bba8aee820fb99055` with `source_state=clean`
- focused Ruff 0.16.5 and the live CUDA/HIP source-policy scan passed
- Release status seams used effective `-O3 -DNDEBUG -std=c++14`; success/failure paths passed with exact once-only evaluation and return-code checks
- install gate included `gpu_status.hpp`; an installed-header C++14 syntax consumer passed

## Outstanding accelerator gates

This Intel node has no CUDA or ROCm compiler, headers, runtime, module, or device. Therefore real CUDA and HIP Release compile/device smoke and parity gates are **outstanding**, not passing. The PR remains draft until their disposition is reviewed; release support remains governed by #14 and #48.

Refs #48.
