### PR TITLE
fix: overwrite zero-beta accelerator fitness

### DIFF
--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -413,6 +413,40 @@ if(NOT "${GPU_BACKEND}" STREQUAL "none")
     add_test(
         NAME deac_unit_gpu_normalization
         COMMAND deac_gpu_normalization_test)
+
+    set(DEAC_GPU_FITNESS_TEST_SOURCES
+        ${CMAKE_SOURCE_DIR}/../test/gpu_fitness_test.cpp)
+    if("${GPU_BACKEND}" STREQUAL "cuda")
+        list(APPEND DEAC_GPU_FITNESS_TEST_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/deac_gpu.cu)
+    endif()
+    add_executable(deac_gpu_fitness_test
+        ${DEAC_GPU_FITNESS_TEST_SOURCES})
+    list(APPEND DEAC_HIPBLAS_CONSUMER_TARGETS
+        deac_gpu_fitness_test)
+    target_include_directories(deac_gpu_fitness_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    if("${GPU_BACKEND}" STREQUAL "cuda")
+        set_target_properties(deac_gpu_fitness_test PROPERTIES
+            CUDA_SEPARABLE_COMPILATION ON)
+    endif()
+    if(USE_BLAS AND "${GPU_BACKEND}" STREQUAL "cuda")
+        target_link_libraries(deac_gpu_fitness_test CUDA::cublas)
+    endif()
+    if(USE_BLAS AND "${GPU_BACKEND}" STREQUAL "sycl")
+        target_link_libraries(deac_gpu_fitness_test
+            ${MKL_SYCL_BLAS_LIBRARY}
+            ${MKL_SYCL_LIBRARY}
+            ${MKL_INTEL_ILP64_LIBRARY}
+            ${MKL_SEQUENTIAL_LIBRARY}
+            ${MKL_CORE_LIBRARY}
+            pthread
+            m
+            dl)
+    endif()
+    add_test(
+        NAME deac_unit_gpu_fitness
+        COMMAND deac_gpu_fitness_test)
 endif()
 
 add_executable(deac_moment_fitness_test
@@ -492,6 +526,11 @@ if(NOT USE_ALLOW_NEGATIVE_SPECTRAL_WEIGHT)
     target_compile_definitions(
         deac_invalid_normalization_evolution_test_exe PRIVATE
         DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS=1)
+    if(NOT "${GPU_BACKEND}" STREQUAL "none")
+        target_compile_definitions(
+            deac_invalid_normalization_evolution_test_exe PRIVATE
+            DEAC_TEST_POISON_GPU_FITNESS=1)
+    endif()
     target_include_directories(
         deac_invalid_normalization_evolution_test_exe PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -618,6 +657,11 @@ if(Python3_Interpreter_FOUND)
         )
     endforeach()
     if(NOT USE_ALLOW_NEGATIVE_SPECTRAL_WEIGHT)
+        set(DEAC_INVALID_NORMALIZATION_TEST_ARGS)
+        if(NOT "${GPU_BACKEND}" STREQUAL "none")
+            list(APPEND DEAC_INVALID_NORMALIZATION_TEST_ARGS
+                --expect-poisoned-gpu-fitness)
+        endif()
         add_test(
             NAME deac_normalization_evolution
             COMMAND
@@ -636,6 +680,7 @@ if(Python3_Interpreter_FOUND)
                 --forced-exe $<TARGET_FILE:deac_invalid_normalization_evolution_test_exe>
                 --workdir ${CMAKE_CURRENT_BINARY_DIR}/invalid-normalization-evolution
                 ${DEAC_SMOKE_VARIANT_ARGS}
+                ${DEAC_INVALID_NORMALIZATION_TEST_ARGS}
         )
     endif()
 

--- a/src/deac/include/deac_gpu.hip.hpp
+++ b/src/deac/include/deac_gpu.hip.hpp
@@ -466,7 +466,11 @@ __global__ void gpu_deac_reduced_chi_squared(const double* __restrict__ calculat
 
     // Have the first thread in the block write the result for this row to global memory
     if (tid == 0) {
-        reduced_chi_squared[row] = sdata[0]/(n - ddof) + beta*reduced_chi_squared[row];
+        if (beta == 0.0) {
+            reduced_chi_squared[row] = sdata[0]/(n - ddof);
+        } else {
+            reduced_chi_squared[row] = sdata[0]/(n - ddof) + beta*reduced_chi_squared[row];
+        }
     }
 }
 

--- a/src/deac/include/deac_gpu.sycl.h
+++ b/src/deac/include/deac_gpu.sycl.h
@@ -549,7 +549,11 @@ void gpu_deac_reduced_chi_squared(sycl::queue q, const double* __restrict__ calc
 
             // Have the first thread in the block write the result for this row to global memory
             if (tid == 0) {
-                reduced_chi_squared[row] = sdata[0]/(n - ddof) + beta*reduced_chi_squared[row];
+                if (beta == 0.0) {
+                    reduced_chi_squared[row] = sdata[0]/(n - ddof);
+                } else {
+                    reduced_chi_squared[row] = sdata[0]/(n - ddof) + beta*reduced_chi_squared[row];
+                }
             }
         });
     });

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -51,6 +51,10 @@
     throw std::runtime_error(error_message);
 }
 
+#ifdef DEAC_TEST_POISON_GPU_FITNESS
+    #define DEAC_TEST_GPU_CALL(expression) GPU_ASSERT(expression)
+#endif
+
 void print_build_identity(std::ostream& output) {
     output << deac_build_identity::canonical_json() << std::endl;
 }
@@ -870,6 +874,61 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         GPU_ASSERT(deac_malloc_device(double, d_fitness_new, population_size, default_stream));
         GPU_ASSERT(deac_wait(default_stream));
 
+        #ifdef DEAC_TEST_POISON_GPU_FITNESS
+            // Test-only full-solver seam: poison both destinations at their
+            // production allocation point, before either scoring pass can
+            // define them.  The shared GPU status path evaluates and checks
+            // each call exactly once in every build type.
+            std::fill(
+                    fitness_old, fitness_old + population_size,
+                    std::numeric_limits<double>::quiet_NaN());
+            DEAC_TEST_GPU_CALL(deac_memcpy_host_to_device(
+                    d_fitness_old, fitness_old,
+                    bytes_fitness, default_stream));
+            DEAC_TEST_GPU_CALL(deac_memcpy_host_to_device(
+                    d_fitness_new, fitness_old,
+                    bytes_fitness, default_stream));
+            DEAC_TEST_GPU_CALL(deac_wait(default_stream));
+            const auto test_require_poisoned_gpu_fitness =
+                    [&](double* device_fitness, const char* buffer) {
+                std::fill(
+                        fitness_old, fitness_old + population_size, 0.0);
+                DEAC_TEST_GPU_CALL(deac_memcpy_device_to_host(
+                        fitness_old, device_fitness,
+                        bytes_fitness, default_stream));
+                DEAC_TEST_GPU_CALL(deac_wait(default_stream));
+                if (!std::all_of(
+                        fitness_old, fitness_old + population_size,
+                        [](double value) { return std::isnan(value); })) {
+                    fail_with_error(
+                            std::string("GPU fitness buffer was not poisoned: ")
+                            + buffer);
+                }
+            };
+            test_require_poisoned_gpu_fitness(d_fitness_old, "old");
+            test_require_poisoned_gpu_fitness(d_fitness_new, "new");
+            std::cout << "test_poisoned_gpu_fitness_buffers: old,new\n";
+            const auto test_require_finite_gpu_fitness =
+                    [&](double* device_fitness, const char* phase) {
+                std::fill(
+                        fitness_old, fitness_old + population_size,
+                        std::numeric_limits<double>::quiet_NaN());
+                DEAC_TEST_GPU_CALL(deac_memcpy_device_to_host(
+                        fitness_old, device_fitness,
+                        bytes_fitness, default_stream));
+                DEAC_TEST_GPU_CALL(deac_wait(default_stream));
+                if (!std::all_of(
+                        fitness_old, fitness_old + population_size,
+                        [](double value) { return std::isfinite(value); })) {
+                    fail_with_error(
+                            std::string("poisoned GPU fitness remained non-finite ")
+                            + phase);
+                }
+                std::cout << "test_poisoned_gpu_fitness_" << phase
+                          << ": finite\n";
+            };
+        #endif
+
         gpu_deac_reduced_chi_squared(default_stream, d_isf_model, d_isf, d_isf_error, d_fitness_old, population_size, number_of_timeslices, 0, 0.0);
         GPU_ASSERT(deac_wait(default_stream));
 
@@ -889,6 +948,9 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             gpu_deac_add_scalar_reduced_chi_squared(default_stream, d_third_moments, third_moment, third_moment_error, d_fitness_old, population_size);
             GPU_ASSERT(deac_wait(default_stream));
         }
+        #ifdef DEAC_TEST_POISON_GPU_FITNESS
+            test_require_finite_gpu_fitness(d_fitness_old, "initial");
+        #endif
     #else
         for (size_t i=0; i<population_size; i++) {
             double _fitness = reduced_chi_square_statistic(isf,
@@ -1475,6 +1537,9 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
                 gpu_deac_add_scalar_reduced_chi_squared(default_stream, d_third_moments, third_moment, third_moment_error, d_fitness_new, population_size);
                 GPU_ASSERT(deac_wait(default_stream));
             }
+            #ifdef DEAC_TEST_POISON_GPU_FITNESS
+                test_require_finite_gpu_fitness(d_fitness_new, "evolved");
+            #endif
         #else
             // Fitness set in rejection step
         #endif

--- a/src/deac/src/deac_gpu.cu
+++ b/src/deac/src/deac_gpu.cu
@@ -459,7 +459,11 @@ __global__ void gpu_deac_reduced_chi_squared(const double* __restrict__ calculat
 
     // Have the first thread in the block write the result for this row to global memory
     if (tid == 0) {
-        reduced_chi_squared[row] = sdata[0]/(n - ddof) + beta*reduced_chi_squared[row];
+        if (beta == 0.0) {
+            reduced_chi_squared[row] = sdata[0]/(n - ddof);
+        } else {
+            reduced_chi_squared[row] = sdata[0]/(n - ddof) + beta*reduced_chi_squared[row];
+        }
     }
 }
 

--- a/test/cmake/RunHipblasProjectConfigureTest.cmake
+++ b/test/cmake/RunHipblasProjectConfigureTest.cmake
@@ -88,6 +88,7 @@ endfunction()
 foreach(_deac_consumer IN ITEMS
         deac.e
         deac_gpu_normalization_test
+        deac_gpu_fitness_test
         deac_invalid_normalization_evolution_test_exe)
     _deac_assert_literal_count(_deac_graph_text
         "${_deac_consumer} -> deac_hipblas_link_contract" 1)

--- a/test/cmake/hipblas_link_contract/CMakeLists.txt
+++ b/test/cmake/hipblas_link_contract/CMakeLists.txt
@@ -13,6 +13,7 @@ endforeach()
 set(_deac_hipblas_consumers
     deac.e
     deac_gpu_normalization_test
+    deac_gpu_fitness_test
     deac_invalid_normalization_evolution_test_exe)
 foreach(_deac_consumer IN LISTS _deac_hipblas_consumers)
     add_executable("${_deac_consumer}" EXCLUDE_FROM_ALL dummy.cpp)

--- a/test/deac_invalid_normalization_evolution_test.py
+++ b/test/deac_invalid_normalization_evolution_test.py
@@ -108,6 +108,7 @@ def main():
     parser.add_argument("--workdir", required=True)
     parser.add_argument("--detailed-balance", action="store_true")
     parser.add_argument("--zero-temperature", action="store_true")
+    parser.add_argument("--expect-poisoned-gpu-fitness", action="store_true")
     args = parser.parse_args()
 
     workdir = Path(args.workdir)
@@ -126,7 +127,7 @@ def main():
 
     initial_dir = workdir / "initial"
     forced_dir = workdir / "forced"
-    run_solver(
+    reference = run_solver(
         args.reference_exe,
         workdir,
         fixture,
@@ -157,6 +158,40 @@ def main():
     if "test_invalid_normalization_fitness: DBL_MAX" not in forced.stdout:
         raise AssertionError(
             f"forced rows did not receive DBL_MAX fitness:\n{forced.stdout}"
+        )
+    poison_markers = (
+        "test_poisoned_gpu_fitness_buffers: old,new",
+        "test_poisoned_gpu_fitness_initial: finite",
+        "test_poisoned_gpu_fitness_evolved: finite",
+    )
+    reference_marker_counts = {
+        marker: reference.stdout.count(marker) for marker in poison_markers
+    }
+    leaked_markers = {
+        marker: count
+        for marker, count in reference_marker_counts.items()
+        if count != 0
+    }
+    if leaked_markers:
+        raise AssertionError(
+            "production solver unexpectedly enabled the poison seam: "
+            f"{leaked_markers}\n{reference.stdout}"
+        )
+    forced_marker_counts = {
+        marker: forced.stdout.count(marker) for marker in poison_markers
+    }
+    if args.expect_poisoned_gpu_fitness and any(
+        count != 1 for count in forced_marker_counts.values()
+    ):
+        raise AssertionError(
+            "forced GPU run did not prove finite initial and evolved scoring "
+            "after poisoning both buffers exactly once: "
+            f"observed={forced_marker_counts}\n{forced.stdout}"
+        )
+    if not args.expect_poisoned_gpu_fitness and any(forced_marker_counts.values()):
+        raise AssertionError(
+            "non-GPU helper unexpectedly enabled the poison seam: "
+            f"{forced_marker_counts}\n{forced.stdout}"
         )
 
     output_prefix = prefix(args.detailed_balance, args.zero_temperature)

--- a/test/gpu_fitness_test.cpp
+++ b/test/gpu_fitness_test.cpp
@@ -1,0 +1,190 @@
+#if defined(USE_CUDA)
+#include "deac_gpu.cuh"
+#elif defined(USE_HIP)
+#include "deac_gpu.hip.hpp"
+#elif defined(USE_SYCL)
+#include "deac_gpu.sycl.h"
+#else
+#error "gpu_fitness_test requires a GPU backend"
+#endif
+
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+namespace {
+// Keep the negative-control harness independent of production GPU_ASSERT:
+// exact base 16ce erases CUDA/HIP GPU_ASSERT operations under NDEBUG, which
+// would confound a proof that changes only the beta-zero kernel semantics.
+#if defined(USE_CUDA)
+void check_gpu_call(cudaError_t status, const char* expression) {
+    if (status != cudaSuccess) {
+        std::cerr << expression << " failed: " << cudaGetErrorString(status)
+                  << '\n';
+        std::exit(EXIT_FAILURE);
+    }
+}
+#define TEST_GPU_CALL(expression) check_gpu_call((expression), #expression)
+#elif defined(USE_HIP)
+void check_gpu_call(hipError_t status, const char* expression) {
+    if (status != hipSuccess) {
+        std::cerr << expression << " failed: " << hipGetErrorString(status)
+                  << '\n';
+        std::exit(EXIT_FAILURE);
+    }
+}
+#define TEST_GPU_CALL(expression) check_gpu_call((expression), #expression)
+#else
+// SYCL operations either throw directly or report asynchronous errors through
+// the explicit deac_wait calls below.
+#define TEST_GPU_CALL(expression) \
+    do {                          \
+        expression;              \
+    } while (false)
+#endif
+
+bool check_values(
+        const char* label,
+        const std::vector<double>& actual,
+        const std::vector<double>& expected,
+        std::size_t dimension) {
+    for (std::size_t row=0; row<dimension; ++row) {
+        if (!std::isfinite(actual[row]) || actual[row] != expected[row]) {
+            std::cerr << label << " mismatch at dimension " << dimension
+                      << ", row " << row << ": expected " << std::hexfloat
+                      << expected[row] << ", got " << actual[row] << '\n';
+            return false;
+        }
+    }
+    return true;
+}
+
+bool check_dimension(deac_stream_t stream, std::size_t dimension) {
+    const std::size_t matrix_elements = dimension*dimension;
+    std::vector<double> calculated(matrix_elements);
+    std::vector<double> observed(dimension, 8.0);
+    std::vector<double> standard_deviations(dimension, 2.0);
+    std::vector<double> scalar_calculated(dimension);
+    std::vector<double> base_expected(dimension);
+    std::vector<double> scalar_expected(dimension);
+    std::vector<double> nonzero_beta_expected(dimension);
+    std::vector<double> sentinels(dimension);
+    std::vector<double> fitness(
+            dimension, std::numeric_limits<double>::quiet_NaN());
+
+    // Each row has one exact integer residual across every column.  Its mean
+    // square is therefore residual^2 regardless of the reduction tree.
+    for (std::size_t row=0; row<dimension; ++row) {
+        const double residual = static_cast<double>(row%3 + 1);
+        base_expected[row] = residual*residual;
+        scalar_expected[row] = 5.0*base_expected[row];
+        sentinels[row] = 0.25*static_cast<double>(row%4 + 1);
+        nonzero_beta_expected[row] =
+                base_expected[row] + 2.0*sentinels[row];
+        scalar_calculated[row] =
+                observed[0] - standard_deviations[0]*residual;
+        for (std::size_t column=0; column<dimension; ++column) {
+            calculated[row + dimension*column] =
+                    observed[column]
+                    - standard_deviations[column]*residual;
+        }
+    }
+
+    double* d_calculated = nullptr;
+    double* d_observed = nullptr;
+    double* d_standard_deviations = nullptr;
+    double* d_scalar_calculated = nullptr;
+    double* d_fitness = nullptr;
+    TEST_GPU_CALL(deac_malloc_device(
+            double, d_calculated, matrix_elements, stream));
+    TEST_GPU_CALL(deac_malloc_device(
+            double, d_observed, dimension, stream));
+    TEST_GPU_CALL(deac_malloc_device(
+            double, d_standard_deviations, dimension, stream));
+    TEST_GPU_CALL(deac_malloc_device(
+            double, d_scalar_calculated, dimension, stream));
+    TEST_GPU_CALL(deac_malloc_device(
+            double, d_fitness, dimension, stream));
+    TEST_GPU_CALL(deac_memcpy_host_to_device(
+            d_calculated, calculated.data(),
+            matrix_elements*sizeof(double), stream));
+    TEST_GPU_CALL(deac_memcpy_host_to_device(
+            d_observed, observed.data(), dimension*sizeof(double), stream));
+    TEST_GPU_CALL(deac_memcpy_host_to_device(
+            d_standard_deviations, standard_deviations.data(),
+            dimension*sizeof(double), stream));
+    TEST_GPU_CALL(deac_memcpy_host_to_device(
+            d_scalar_calculated, scalar_calculated.data(),
+            dimension*sizeof(double), stream));
+    TEST_GPU_CALL(deac_wait(stream));
+
+    // A zero beta must overwrite every poisoned destination without reading it.
+    TEST_GPU_CALL(deac_memcpy_host_to_device(
+            d_fitness, fitness.data(), dimension*sizeof(double), stream));
+    TEST_GPU_CALL(deac_wait(stream));
+    gpu_deac_reduced_chi_squared(
+            stream, d_calculated, d_observed, d_standard_deviations,
+            d_fitness, dimension, dimension, 0, 0.0);
+    TEST_GPU_CALL(deac_wait(stream));
+    TEST_GPU_CALL(deac_memcpy_device_to_host(
+            fitness.data(), d_fitness, dimension*sizeof(double), stream));
+    TEST_GPU_CALL(deac_wait(stream));
+    bool valid = check_values(
+            "zero-beta reduced chi squared",
+            fitness, base_expected, dimension);
+
+    // The next production step must add its scalar penalty to the overwritten
+    // values, including rows in a partial block beyond the first block.
+    gpu_deac_add_scalar_reduced_chi_squared(
+            stream, d_scalar_calculated, observed[0], 1.0,
+            d_fitness, dimension);
+    TEST_GPU_CALL(deac_wait(stream));
+    TEST_GPU_CALL(deac_memcpy_device_to_host(
+            fitness.data(), d_fitness, dimension*sizeof(double), stream));
+    TEST_GPU_CALL(deac_wait(stream));
+    valid = check_values(
+            "scalar reduced chi squared",
+            fitness, scalar_expected, dimension) && valid;
+
+    // Preserve the existing nonzero-beta arithmetic and destination read.
+    TEST_GPU_CALL(deac_memcpy_host_to_device(
+            d_fitness, sentinels.data(), dimension*sizeof(double), stream));
+    TEST_GPU_CALL(deac_wait(stream));
+    gpu_deac_reduced_chi_squared(
+            stream, d_calculated, d_observed, d_standard_deviations,
+            d_fitness, dimension, dimension, 0, 2.0);
+    TEST_GPU_CALL(deac_wait(stream));
+    TEST_GPU_CALL(deac_memcpy_device_to_host(
+            fitness.data(), d_fitness, dimension*sizeof(double), stream));
+    TEST_GPU_CALL(deac_wait(stream));
+    valid = check_values(
+            "nonzero-beta reduced chi squared",
+            fitness, nonzero_beta_expected, dimension) && valid;
+
+    TEST_GPU_CALL(deac_free(d_calculated, stream));
+    TEST_GPU_CALL(deac_free(d_observed, stream));
+    TEST_GPU_CALL(deac_free(d_standard_deviations, stream));
+    TEST_GPU_CALL(deac_free(d_scalar_calculated, stream));
+    TEST_GPU_CALL(deac_free(d_fitness, stream));
+    TEST_GPU_CALL(deac_wait(stream));
+    return valid;
+}
+} // namespace
+
+int main() {
+    deac_stream_t stream;
+    TEST_GPU_CALL(deac_stream_create(stream));
+
+    const std::size_t below_block =
+            GPU_BLOCK_SIZE > 1 ? GPU_BLOCK_SIZE - 1 : 1;
+    const std::size_t above_block = GPU_BLOCK_SIZE + 17;
+    const bool below_valid = check_dimension(stream, below_block);
+    const bool above_valid = check_dimension(stream, above_block);
+
+    TEST_GPU_CALL(deac_stream_destroy(stream));
+    return below_valid && above_valid ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

- give CUDA, HIP, and SYCL reduced-chi-square kernels true overwrite semantics when `beta == 0.0`, avoiding reads from newly allocated fitness destinations
- preserve the exact existing nonzero-beta expression, reduction order, stream/queue ordering, and CPU path
- add a direct accelerator negative-control regression that poisons the destination, checks zero-beta overwrite, chains the scalar penalty, preserves nonzero-beta accumulation, and covers dimensions below and above the reduction block boundary
- add a test-only full-solver seam that observes both production fitness buffers as NaN immediately after allocation and proves finite initial and evolved scoring before rejection can mask the defect
- reuse #50's shared status path for the full-solver seam while intentionally keeping the standalone A/B harness independent of base `GPU_ASSERT`
- attach the new fitness target to #51's shared hipBLAS contract and extend its fixture/graph assertions from three to four consumers

## Stack and exact change

This PR is intentionally stacked on draft PR #51, which is itself stacked on #50.

- parent: `bd6a4c3af2e20732a7e5ea595fa55ade2b14718a` (#51)
- commit: `f6a6b65756fb9e53d4ef5e519b4a32a5bb5714dc`
- binary commit diff: 22,040 bytes
- binary commit-diff SHA-256: `a96ed3329803e5d26caa1c9179f5bfe583496cfe1838c1064252b9309dd54a6f`
- independent exact review: `PUBLISH`

## Required negative control

The exact final committed regression source was compiled unchanged against clean base `16ce1ec80933fa3e54329ede7c2f09de4949c5fb` with IntelLLVM 2026.1 Release SYCL flags. Two Level Zero runs both failed for the intended mechanism:

- zero-beta fitness remained NaN at row 0 for dimensions 255 and 273
- the chained scalar result consequently remained NaN
- the nonzero-beta control emitted no mismatch
- all test setup, poison, copy, wait, readback, and cleanup operations remained independently evaluated under `NDEBUG`

The final candidate direct test passes on the same hardware and configuration.

## Validation at the clean stacked commit

- Spack GCC 14.3.0 Release CPU: **71/71 CTests passed**
- GCC 14.3.0 Debug with ASan+UBSan, leak detection, and halt-on-error: **71/71 passed**
- IntelLLVM 2026.1 Release CPU, standard: **71/71 passed**
- IntelLLVM 2026.1 Release CPU, detailed balance: **71/71 passed**
- explicit Ninja 1.13.2 hipBLAS contract fixture: **7/7 passed**, proving exactly four consumer edges and one provider edge
- IntelLLVM 2026.1 Level Zero SYCL standard on Intel Data Center GPU Max 1550: **74/74 passed**
- IntelLLVM 2026.1 Level Zero SYCL detailed balance: **74/74 passed**
- both SYCL matrices include direct poisoned fitness, the full-solver old/new poison-to-finite seam, all #50 status tests, all #51 hipBLAS tests, and candidate-matched CPU parity
- CPU, production SYCL, and forced-helper binaries report exact source SHA `f6a6b65756fb9e53d4ef5e519b4a32a5bb5714dc` with `source_state=clean`

## Fixed-seed artifact A/B

Fresh explicit-Ninja base/final SYCL builds ran the same standard and detailed fixed-seed parity protocol on one Max 1550 device. All **35/35 binary frequency, spectrum, and statistics pairs were byte-identical**. All **42/42 saved artifact pairs** matched after canonicalizing only the expected `/reference/` versus `/candidate/` output-directory strings in seven logs; generation, minimum fitness, and every numerical line were byte-identical.

## Outstanding accelerator gates

This node has no CUDA or ROCm compiler/runtime/device. Source-equivalent CUDA/HIP branches and compile-oriented contract coverage are present, but real CUDA/HIP Release compile, device smoke, and parity remain **outstanding**, not passing. HIP+BLAS verbose-link/build-receipt evidence must be attached when #42 lands. This PR remains draft while those external gates and the parent stack are reviewed.

Refs #47.
