### PR TITLE
feat: embed effective build receipts

### DIFF
--- a/BUILD_RECEIPT.md
+++ b/BUILD_RECEIPT.md
@@ -1,0 +1,131 @@
+# DEAC build receipts
+
+`deac.e --build-identity` answers which source state was embedded. The
+separate `deac.e --build-receipt` endpoint answers how that executable target
+was configured to be built. It emits one newline-terminated, canonical JSON
+document. Schema 1 has this top-level shape:
+
+```json
+{"schema_version":1,"receipt_sha256":"<64 lowercase hex digits>","receipt":{}}
+```
+
+`receipt_sha256` is SHA-256 over the compact canonical JSON bytes of the
+nested `receipt` object. Consumers must reject unknown schema versions,
+noncanonical encodings, a digest mismatch, and disagreement between
+`receipt.source_identity` and `--build-identity`.
+
+## Recorded configuration
+
+The schema-1 payload records:
+
+- the selected backend and a sorted, explicit list of material CMake cache
+  entries;
+- generator, configuration, and the CMake executable version, resolved path,
+  and SHA-256;
+- effective File API compile command fragments, definitions, includes,
+  frameworks, language standard, precompiled headers, sources, and sysroot for
+  the executable target;
+- effective final-link fragments, language, LTO state, and sysroot;
+- every expected direct build-target dependency, including its compile groups
+  and any archive or link information; and
+- each used compiler driver's configured and resolved path, ID, version,
+  target, SHA-256, and implicit include/link inputs.
+
+The generated receipt translation unit is itself present in the target's
+recorded compile group. Its path and compile configuration are recorded, but
+its contents are not hashed into its own payload, avoiding a recursive digest.
+The separately compiled build-identity object is recorded as a direct target
+dependency. The final-link fragments and dependency record together cover the
+known final target inputs; linked imported libraries remain represented in the
+link fragments. The aggregate target fingerprint also binds the exact
+compiler-first compile and final-link rule templates and the direct archive
+templates accepted at configure time. It is propagated to every compile-capable
+direct dependency, so a compiler-byte or accepted-rule change followed by
+reconfiguration invalidates those objects as well as the executable's objects.
+
+The current CPU and SYCL configurations use the same schema. CUDA and HIP
+values are representable, but native CMake CUDA/HIP languages currently fail
+closed during receipt configuration because their intermediate device-link
+rules are not yet represented. DEAC's HIP mode remains a CXX-driver
+configuration. This document does not claim either GPU backend has passed real
+compiler and device gates.
+
+## Generation and freshness
+
+Build receipts require CMake 3.27 or newer. CMake 3.27 introduced
+`cmake_file_api(QUERY)`, which lets the project request codemodel 2.6, cache 2,
+and toolchains 1 replies for the current configure/generate invocation. Before
+3.27, a query file has to exist before configuration begins; creating it from
+the project is too late and would require an externally coordinated query or a
+two-pass configure. Raising the minimum is therefore required to make a
+single normal configure safe rather than an incidental syntax update.
+
+The requested replies are written at generation time. At build time, DEAC
+selects the current File API index, follows that index's reply references, and
+checks its source root, build root, configuration, target, backend, expected
+direct dependencies, CMake executable, and compiler metadata. The generated
+receipt source is symbolic, so an ordinary build regenerates it and relinks
+the executable. CMake's normal regeneration step refreshes the File API first
+when project configuration changes.
+
+Single-config generators use their configured build type. Multi-config
+generators create a distinct generated source, refresh edge, and adjacent
+receipt under a `$<CONFIG>` directory. Building one configuration schedules
+only that configuration's receipt edge; it does not touch another
+configuration's generated source or receipt.
+
+## Compiler replacement boundary
+
+At configure time DEAC resolves and hashes each enabled compiler driver and
+the CMake executable, and fingerprints the accepted CMake compile, final-link,
+and archive rule templates. An aggregate fingerprint is added as a private
+compile definition to every compile-capable recorded target. If compiler or
+CMake bytes change, receipt generation fails until CMake is rerun; after
+reconfiguration, the changed definition invalidates previously compiled
+target and direct-dependency objects even if the compiler pathname stayed the
+same. The identity dependency is independently rebuilt on every ordinary
+build.
+
+Receipt generation checks the current tool bytes before its translation unit
+is compiled. A pre-link check repeats the comparison after object compilation
+and rejects persistent replacement before a successful final link. Ordinary
+CMake cannot prove against a hostile process that swaps a compiler between
+individual process launches and restores it before verification. The receipt
+also identifies and hashes the invoked compiler driver, not every transitive
+program that driver may execute. Compiler and linker launchers, `RULE_LAUNCH`
+hooks, code-analysis hooks, link-what-you-use, interprocedural optimization,
+and `CMAKE_<LANG>_COMPILER_ARG1` are rejected because those indirections would
+exceed this attribution boundary. The exact archive rule is fingerprinted,
+but schema 1 does not independently hash `ar`/`ranlib` bytes.
+
+## Supported rule boundary
+
+Schema 1 accepts only the direct, single-command, compiler-first CXX rules and
+direct archive templates validated by the receipt module. It fails closed for
+legacy static-library rules, multi-command or launcher-prefixed templates, and
+native CMake CUDA/HIP languages. Custom toolchain files, user/project include
+hooks, cached module paths, and cached CXX/CUDA/HIP compile, link, archive, or
+CUDA device-link rule-template overrides are rejected because CMake does not
+provide reliable provenance for all mutations through those routes. This
+intentionally excludes generators/platforms such as MSVC whose normal rules
+do not satisfy that boundary; support requires a platform-specific configure
+and fixture gate rather than silently weakening attribution.
+
+## Paths and copies
+
+Structured source- and build-tree paths are canonicalized to `<SOURCE_ROOT>`
+and `<BUILD_ROOT>`. This makes receipts independent of relocatable working
+directories and avoids exposing those private paths. Absolute paths outside
+the two roots—including installed compilers, CMake, SDKs, and libraries—are
+retained because they are material attribution and may reveal local install
+topology. Command fragments are retained verbatim and can also contain
+user-supplied paths. Review a receipt before publishing it from a private
+system.
+
+CMake writes the same canonical bytes to
+`build/deac/receipt/<CONFIG>/deac-build-receipt.json`, and the regression test
+requires byte-for-byte equality with `--build-receipt`. This adjacent copy is
+only a build-tree diagnostic and can be replaced independently after the
+build. Verification and benchmark adapters must query the installed
+executable's embedded endpoint as the authority; they may compare, but must
+never trust, the adjacent file on its own.

--- a/BUILD_RECEIPT.md
+++ b/BUILD_RECEIPT.md
@@ -27,7 +27,9 @@ The schema-1 payload records:
   the executable target;
 - effective final-link fragments, language, LTO state, and sysroot;
 - every expected direct build-target dependency, including its compile groups
-  and any archive or link information; and
+  and any archive or link information;
+- the expanded `CMAKE_AR` and `CMAKE_RANLIB` executable paths, resolved paths,
+  and SHA-256 digests; and
 - each used compiler driver's configured and resolved path, ID, version,
   target, SHA-256, and implicit include/link inputs.
 
@@ -39,8 +41,9 @@ dependency. The final-link fragments and dependency record together cover the
 known final target inputs; linked imported libraries remain represented in the
 link fragments. The aggregate target fingerprint also binds the exact
 compiler-first compile and final-link rule templates and the direct archive
-templates accepted at configure time. It is propagated to every compile-capable
-direct dependency, so a compiler-byte or accepted-rule change followed by
+templates accepted at configure time, plus the expanded archive-tool
+identities. It is propagated to every compile-capable direct dependency, so a
+compiler-byte, archive-tool-byte, or accepted-rule change followed by
 reconfiguration invalidates those objects as well as the executable's objects.
 
 The current CPU and SYCL configurations use the same schema. CUDA and HIP
@@ -63,10 +66,15 @@ single normal configure safe rather than an incidental syntax update.
 The requested replies are written at generation time. At build time, DEAC
 selects the current File API index, follows that index's reply references, and
 checks its source root, build root, configuration, target, backend, expected
-direct dependencies, CMake executable, and compiler metadata. The generated
-receipt source is symbolic, so an ordinary build regenerates it and relinks
-the executable. CMake's normal regeneration step refreshes the File API first
-when project configuration changes.
+direct dependencies, CMake executable, compiler metadata, and configured
+archive-tool bytes. Symbolic refresh and rebuild tokens make every ordinary
+build regenerate the receipt source, compile that source, and relink the
+executable. Makefile graphs attach the always-missing rebuild token directly
+to the receipt object and link. Ninja graphs explicitly touch the generated
+source; on a coarse-timestamp filesystem they first wait for the clock to
+advance beyond a marker written after the previous receipt-object compile.
+CMake's normal regeneration step refreshes the File API first when project
+configuration changes.
 
 Single-config generators use their configured build type. Multi-config
 generators create a distinct generated source, refresh edge, and adjacent
@@ -74,42 +82,46 @@ receipt under a `$<CONFIG>` directory. Building one configuration schedules
 only that configuration's receipt edge; it does not touch another
 configuration's generated source or receipt.
 
-## Compiler replacement boundary
+## Tool replacement boundary
 
 At configure time DEAC resolves and hashes each enabled compiler driver and
-the CMake executable, and fingerprints the accepted CMake compile, final-link,
-and archive rule templates. An aggregate fingerprint is added as a private
-compile definition to every compile-capable recorded target. If compiler or
-CMake bytes change, receipt generation fails until CMake is rerun; after
-reconfiguration, the changed definition invalidates previously compiled
-target and direct-dependency objects even if the compiler pathname stayed the
+the expanded `CMAKE_AR` and `CMAKE_RANLIB` executables as well as the CMake
+executable, and fingerprints the accepted CMake compile, final-link, and
+archive rule templates. An aggregate fingerprint is added as a private compile
+definition to every compile-capable recorded target. If compiler, archive
+tool, or CMake bytes change, receipt generation fails until CMake is rerun;
+after reconfiguration, the changed definition invalidates previously compiled
+target and direct-dependency objects even if the tool pathname stayed the
 same. The identity dependency is independently rebuilt on every ordinary
 build.
 
 Receipt generation checks the current tool bytes before its translation unit
 is compiled. A pre-link check repeats the comparison after object compilation
 and rejects persistent replacement before a successful final link. Ordinary
-CMake cannot prove against a hostile process that swaps a compiler between
+CMake cannot prove against a hostile process that swaps a tool between
 individual process launches and restores it before verification. The receipt
-also identifies and hashes the invoked compiler driver, not every transitive
-program that driver may execute. Compiler and linker launchers, `RULE_LAUNCH`
-hooks, code-analysis hooks, link-what-you-use, interprocedural optimization,
-and `CMAKE_<LANG>_COMPILER_ARG1` are rejected because those indirections would
-exceed this attribution boundary. The exact archive rule is fingerprinted,
-but schema 1 does not independently hash `ar`/`ranlib` bytes.
+identifies and hashes the invoked compiler driver and expanded archive tools,
+not every transitive program those tools may execute. Compiler and linker
+launchers, `RULE_LAUNCH` hooks, code-analysis hooks, link-what-you-use, generic
+or configuration-specific interprocedural optimization, and
+`CMAKE_<LANG>_COMPILER_ARG1` are rejected because those indirections would
+exceed this attribution boundary.
 
 ## Supported rule boundary
 
 Schema 1 accepts only the direct, single-command, compiler-first CXX rules and
 direct archive templates validated by the receipt module. It fails closed for
 legacy static-library rules, multi-command or launcher-prefixed templates, and
-native CMake CUDA/HIP languages. Custom toolchain files, user/project include
-hooks, cached module paths, and cached CXX/CUDA/HIP compile, link, archive, or
-CUDA device-link rule-template overrides are rejected because CMake does not
-provide reliable provenance for all mutations through those routes. This
-intentionally excludes generators/platforms such as MSVC whose normal rules
-do not satisfy that boundary; support requires a platform-specific configure
-and fixture gate rather than silently weakening attribution.
+native CMake CUDA/HIP languages. Unquoted shell control and compound-command
+syntax (including `;`, `&&`, `||`, `|`, backticks, and `$()` substitution) is
+rejected; quoted or escaped literal operator characters remain valid. Custom
+toolchain files, user/project include hooks, cached module paths, and cached
+CXX/CUDA/HIP compile, link, archive, or CUDA device-link rule-template
+overrides are rejected because CMake does not provide reliable provenance for
+all mutations through those routes. This intentionally excludes
+generators/platforms such as MSVC whose normal rules do not satisfy that
+boundary; support requires a platform-specific configure and fixture gate
+rather than silently weakening attribution.
 
 ## Paths and copies
 

--- a/BUILD_RECEIPT.md
+++ b/BUILD_RECEIPT.md
@@ -13,6 +13,11 @@ document. Schema 1 has this top-level shape:
 nested `receipt` object. Consumers must reject unknown schema versions,
 noncanonical encodings, a digest mismatch, and disagreement between
 `receipt.source_identity` and `--build-identity`.
+JSON never contains a raw C0 control character. CMake truncates decoded strings
+at a semantic NUL, so schema 1 rejects both a raw NUL byte and a JSON `\u0000`
+escape before parsing. Backspace, tab, newline, form feed, and carriage return
+use their short JSON escapes; every other representable value from U+0001
+through U+001F uses a lowercase `\u00xx` escape.
 
 ## Recorded configuration
 
@@ -37,14 +42,43 @@ The generated receipt translation unit is itself present in the target's
 recorded compile group. Its path and compile configuration are recorded, but
 its contents are not hashed into its own payload, avoiding a recursive digest.
 The separately compiled build-identity object is recorded as a direct target
-dependency. The final-link fragments and dependency record together cover the
-known final target inputs; linked imported libraries remain represented in the
-link fragments. The aggregate target fingerprint also binds the exact
-compiler-first compile and final-link rule templates and the direct archive
-templates accepted at configure time, plus the expanded archive-tool
-identities. It is propagated to every compile-capable direct dependency, so a
-compiler-byte, archive-tool-byte, or accepted-rule change followed by
-reconfiguration invalidates those objects as well as the executable's objects.
+dependency. CMake's File API omits interface-only targets from its target and
+dependency lists, so DEAC emits each declared direct interface contract
+explicitly, with its name and `INTERFACE_LIBRARY` type but no invented compile,
+archive, or link record. A deferred seal at the end of top-level generation
+rechecks the final direct interface graph and the supported rule, launcher,
+analysis, IPO, and link-hook boundary. A mutation after receipt registration
+therefore fails the configure/generate step instead of escaping the earlier
+snapshot. A required imported provider is resolved without a target-file
+generator expression and must then appear as exactly one resolved
+`libraries`-role fragment in the build-time File API reply. Required provider
+artifacts are unique in every selected configuration, not merely as their
+unevaluated multi-config expressions. These checks avoid adding a new
+consumer-to-provider build-graph edge while still failing closed if the final
+contract or provider link changes.
+
+The final-link fragments and dependency record together cover the known final
+target inputs. For HIP with BLAS enabled, the material cache entries include
+`CMAKE_DISABLE_FIND_PACKAGE_hipblas`, `HIP_RUNTIME_INCLUDE_DIR`,
+`DEAC_HIPBLAS_INCLUDE_DIR`, `DEAC_HIPBLAS_LIBRARY`, `hipblas_DIR`, and
+`hipblas_ROOT`, including absent values, so both supported package discovery
+and compatibility-fallback routes remain attributable. The aggregate target
+fingerprint binds the exact compiler-first compile and final-link rule
+templates and the direct archive templates in the receipt registration
+directory, plus the expanded compiler and archive-tool identities. Every
+buildable target's CMake source-directory scope must expose identical supported
+rule templates and resolve to the same configured compiler, `CMAKE_AR`, and
+`CMAKE_RANLIB` path, real path, and digest. The fingerprint is propagated to
+every compile-capable direct dependency, so a compiler-byte,
+archive-tool-byte, or accepted-rule change followed by reconfiguration
+invalidates those objects as well as the executable objects.
+Receipt generation requires every compile group of the executable and every
+compile-capable recorded dependency to contain exactly one matching reserved
+fingerprint definition and no duplicate or conflicting definition with that
+identifier. Compile command fragments may not define or undefine that reserved
+identifier outside the structured definitions array. Removing or shadowing the
+injected definition is therefore a hard error rather than an apparently
+attributable stale object.
 
 The current CPU and SYCL configurations use the same schema. CUDA and HIP
 values are representable, but native CMake CUDA/HIP languages currently fail
@@ -76,24 +110,49 @@ advance beyond a marker written after the previous receipt-object compile.
 CMake's normal regeneration step refreshes the File API first when project
 configuration changes.
 
-Single-config generators use their configured build type. Multi-config
-generators create a distinct generated source, refresh edge, and adjacent
-receipt under a `$<CONFIG>` directory. Building one configuration schedules
-only that configuration's receipt edge; it does not touch another
-configuration's generated source or receipt.
+`deac_target_add_build_receipt()` exports `DEAC_BUILD_RECEIPT_REFRESH` to its
+caller as the primary refresh output. A receipt-only convenience target may
+depend on that path without compiling or linking the consumer. Callers must not
+use the generated receipt source BYPRODUCT as the dependency: with Unix
+Makefiles, its rule remains owned by the consuming target's `build.make` and is
+not a portable cross-target refresh edge.
+
+The native-fragment decoder and literal-shell gate are currently supported and
+fixture-tested on POSIX hosts with Ninja, Ninja Multi-Config, and Unix
+Makefiles. Other host/generator shell dialects are not covered by schema 1 and
+must not be enabled by weakening the POSIX checks.
+
+Single-config generators require exactly one nonempty configured build type.
+Multi-config generators create a distinct generated source, refresh edge, and
+adjacent receipt under a `$<CONFIG>` directory. Building one configuration
+schedules only that configuration's receipt edge; it does not touch another
+configuration's generated source or receipt. Configuration names must be
+path-safe and unique ignoring ASCII case because CMake's `$<CONFIG:...>`
+comparison is case-insensitive. The exact generator name, single- versus
+multi-config mode, and ordered configuration list must agree in the top-level
+source and receipt-registration directories and are sealed again at the end of
+generation, so a late directory mutation cannot invalidate the File API/output
+mapping or leave stale cache evidence. The effective generator and active build
+type/configuration-list variables must also equal their cache entries when
+present, preventing a normal variable from shadowing contradictory material
+cache evidence. The adjacent receipt path accepts only one literal `$<CONFIG>`
+as a complete path component and rejects every other generator expression,
+preventing a hidden or conditional token from collapsing configurations onto
+one output.
 
 ## Tool replacement boundary
 
 At configure time DEAC resolves and hashes each enabled compiler driver and
 the expanded `CMAKE_AR` and `CMAKE_RANLIB` executables as well as the CMake
 executable, and fingerprints the accepted CMake compile, final-link, and
-archive rule templates. An aggregate fingerprint is added as a private compile
-definition to every compile-capable recorded target. If compiler, archive
-tool, or CMake bytes change, receipt generation fails until CMake is rerun;
-after reconfiguration, the changed definition invalidates previously compiled
-target and direct-dependency objects even if the tool pathname stayed the
-same. The identity dependency is independently rebuilt on every ordinary
-build.
+archive rule templates. The configured compiler-target triple's presence and
+value must exactly match the File API toolchain reply before it is published in
+the receipt. An aggregate fingerprint is added as a private compile definition
+to every compile-capable recorded target. If compiler, archive tool, or CMake
+bytes change, receipt generation fails until CMake is rerun; after
+reconfiguration, the changed definition invalidates previously compiled target
+and direct-dependency objects even if the tool pathname stayed the same. The
+identity dependency is independently rebuilt on every ordinary build.
 
 Receipt generation checks the current tool bytes before its translation unit
 is compiled. A pre-link check repeats the comparison after object compilation
@@ -112,27 +171,48 @@ exceed this attribution boundary.
 Schema 1 accepts only the direct, single-command, compiler-first CXX rules and
 direct archive templates validated by the receipt module. It fails closed for
 legacy static-library rules, multi-command or launcher-prefixed templates, and
-native CMake CUDA/HIP languages. Unquoted shell control and compound-command
-syntax (including `;`, `&&`, `||`, `|`, backticks, and `$()` substitution) is
-rejected; quoted or escaped literal operator characters remain valid. Custom
-toolchain files, user/project include hooks, cached module paths, and cached
-CXX/CUDA/HIP compile, link, archive, or CUDA device-link rule-template
+native CMake CUDA/HIP languages. Outside POSIX quotes or protection that
+survives CMake's generator, globbing, comments, redirection, command or process
+substitution, compound-command operators, and grouping syntax are rejected.
+Dollar signs are rejected in every quoting state because Make and Ninja can
+expand them before POSIX shell quoting applies. An unquoted semicolon is also
+rejected even when the input text contains a backslash, because CMake consumes
+that protection while materializing a rule. Backticks are rejected unless
+protected by POSIX single quotes; a backslash-escaped backtick is outside this
+schema. Only the explicitly allowed standalone CMake rule placeholders may
+occur, and generator expressions in recipe text are unsupported. The same
+literal-shell policy is applied to effective File API compile, archive, and
+link fragments, including material `CMAKE_CXX_FLAGS` and linker flags.
+
+Custom toolchain files, user/project include hooks, cached module paths, and
+cached CXX/CUDA/HIP compile, link, archive, or CUDA device-link rule-template
 overrides are rejected because CMake does not provide reliable provenance for
-all mutations through those routes. This intentionally excludes
-generators/platforms such as MSVC whose normal rules do not satisfy that
-boundary; support requires a platform-specific configure and fixture gate
-rather than silently weakening attribution.
+all mutations through those routes. The end-of-generation seal repeats these
+checks and rejects late generator/configuration-state changes,
+target/directory/global launcher hooks, IPO, `LINK_WHAT_YOU_USE`, and
+direct-interface mutations. This intentionally excludes generators/platforms
+such as MSVC whose normal rules do not satisfy that boundary; support requires
+a platform-specific configure and fixture gate rather than silently weakening
+attribution.
 
 ## Paths and copies
 
 Structured source- and build-tree paths are canonicalized to `<SOURCE_ROOT>`
-and `<BUILD_ROOT>`. This makes receipts independent of relocatable working
+and `<BUILD_ROOT>`. When roots overlap, the most-specific containing root wins;
+a build nested inside the source tree therefore still uses `<BUILD_ROOT>` for
+its generated files. This makes receipts independent of relocatable working
 directories and avoids exposing those private paths. Absolute paths outside
 the two roots—including installed compilers, CMake, SDKs, and libraries—are
 retained because they are material attribution and may reveal local install
-topology. Command fragments are retained verbatim and can also contain
-user-supplied paths. Review a receipt before publishing it from a private
-system.
+topology. Command fragments are retained verbatim after the literal-shell
+check and can also contain user-supplied paths. Review a receipt before
+publishing it from a private system.
+
+Generated sources, refresh markers, compile markers, and adjacent receipts must
+be normalized descendants of `CMAKE_BINARY_DIR`. A symlinked build root itself
+is supported, but every descendant component is checked for existing or
+dangling symlinks at configuration, deferred sealing, receipt generation, and
+pre-link validation so an output cannot be redirected outside the build tree.
 
 CMake writes the same canonical bytes to
 `build/deac/receipt/<CONFIG>/deac-build-receipt.json`, and the regression test

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ that same build without a manually repeated configure command. Git identity
 probes ignore inherited repository-redirection environment variables; archive
 builds therefore cannot be assigned metadata from an unrelated checkout.
 
+Build attribution is available separately through `deac.e --build-receipt`.
+It reports the embedded canonical schema-1 receipt for the effective CMake
+target, including source identity, backend and material cache inputs, target
+and direct-dependency compile groups, final-link fragments, generator and
+configuration, and compiler-driver identity and SHA-256. See
+[BUILD_RECEIPT.md](BUILD_RECEIPT.md) for the schema, CMake 3.27 requirement,
+path handling, verification behavior, and security boundary. The embedded
+response is authoritative; the matching build-tree JSON is diagnostic only.
+
 ### Zero-temperature mode
 
 `ZeroT` and `ZeroTDebug` restore the original zero-temperature problem: one

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18.0)
+cmake_minimum_required(VERSION 3.27.0)
 project(deac.e LANGUAGES CXX)
 
 # Must use GNUInstallDirs to install libraries into correct

--- a/src/cmake/DeacBuildReceipt.cmake
+++ b/src/cmake/DeacBuildReceipt.cmake
@@ -511,6 +511,25 @@ function(deac_target_add_build_receipt target_name)
     set(_rebuild
         "${_configuration_directory}/${_receipt_identifier}.rebuild")
 
+    # Source properties are keyed by the literal path passed to CMake.  A
+    # property attached to the $<CONFIG>-spelled source is therefore not
+    # applied to the concrete source path emitted by Makefile generators.
+    # Register each configured source explicitly, while exposing only the
+    # selected configuration to the target graph.
+    set(_configured_receipt_sources)
+    foreach(_configuration IN LISTS _receipt_configurations)
+        set(_configured_source
+            "${DEAC_RECEIPT_GENERATED_DIRECTORY}/${_configuration}/${_receipt_identifier}.cpp")
+        set(_configured_rebuild
+            "${DEAC_RECEIPT_GENERATED_DIRECTORY}/${_configuration}/${_receipt_identifier}.rebuild")
+        set_source_files_properties(
+            "${_configured_source}" PROPERTIES
+            GENERATED TRUE
+            OBJECT_DEPENDS "${_configured_rebuild}")
+        list(APPEND _configured_receipt_sources
+            "$<$<CONFIG:${_configuration}>:${_configured_source}>")
+    endforeach()
+
     add_custom_command(
         # The command deliberately never creates this symbolic primary output.
         # A single $<CONFIG>-qualified edge keeps Ninja Multi-Config graphs
@@ -559,14 +578,10 @@ function(deac_target_add_build_receipt target_name)
     set_source_files_properties(
         "${_refresh}" "${_rebuild}"
         PROPERTIES GENERATED TRUE SYMBOLIC TRUE)
-    set_source_files_properties(
-        "${_generated_source}" PROPERTIES
-        GENERATED TRUE
-        OBJECT_DEPENDS "${_rebuild}")
     set_property(TARGET "${target_name}" APPEND PROPERTY
         LINK_DEPENDS "${_rebuild}")
     target_sources("${target_name}" PRIVATE
-        "${_generated_source}" "${_rebuild}")
+        ${_configured_receipt_sources} "${_rebuild}")
     target_include_directories("${target_name}" PRIVATE
         "${_support_directory}")
 

--- a/src/cmake/DeacBuildReceipt.cmake
+++ b/src/cmake/DeacBuildReceipt.cmake
@@ -11,16 +11,277 @@ function(_deac_build_receipt_require_plain value label)
     endif()
 endfunction()
 
-function(_deac_build_receipt_require_single_command value label)
-    if("${value}" MATCHES "[\r\n]")
+function(_deac_build_receipt_require_safe_path_text value label)
+    if("${value}" STREQUAL "" OR "${value}" MATCHES ";")
+        message(FATAL_ERROR "build-receipt ${label} is not a safe path")
+    endif()
+    string(HEX "${value}" _value_hex)
+    string(LENGTH "${_value_hex}" _value_hex_length)
+    set(_hex_index 0)
+    while(_hex_index LESS _value_hex_length)
+        string(SUBSTRING "${_value_hex}" ${_hex_index} 2 _byte_hex)
+        if(_byte_hex MATCHES "^(0[0-9a-f]|1[0-9a-f]|7f)$")
+            message(FATAL_ERROR
+                "build-receipt ${label} contains a control byte")
+        endif()
+        math(EXPR _hex_index "${_hex_index} + 2")
+    endwhile()
+endfunction()
+
+function(_deac_build_receipt_require_build_tree_descendant
+        value build_root label)
+    set(_normalized_build_root "${build_root}")
+    cmake_path(NORMAL_PATH _normalized_build_root)
+    cmake_path(IS_PREFIX _normalized_build_root "${value}" NORMALIZE
+        _is_build_tree_path)
+    if(NOT _is_build_tree_path OR value STREQUAL _normalized_build_root)
         message(FATAL_ERROR
-            "build-receipt ${label} contains shell control syntax")
+            "build-receipt ${label} must be a descendant of CMAKE_BINARY_DIR")
+    endif()
+endfunction()
+
+function(_deac_build_receipt_reject_descendant_symlinks
+        value build_root label)
+    _deac_build_receipt_require_build_tree_descendant(
+        "${value}" "${build_root}" "${label}")
+    file(RELATIVE_PATH _relative_path "${build_root}" "${value}")
+    string(REPLACE "/" ";" _path_components "${_relative_path}")
+    set(_candidate_path "${build_root}")
+    foreach(_path_component IN LISTS _path_components)
+        if(_path_component STREQUAL "")
+            continue()
+        endif()
+        cmake_path(APPEND _candidate_path "${_path_component}")
+        if(IS_SYMLINK "${_candidate_path}")
+            message(FATAL_ERROR
+                "build-receipt ${label} must not contain a symlink "
+                "component below CMAKE_BINARY_DIR")
+        endif()
+    endforeach()
+endfunction()
+
+function(_deac_build_receipt_normalize_generated_directory
+        value build_root output)
+    _deac_build_receipt_require_safe_path_text(
+        "${value}" "GENERATED_DIRECTORY")
+    if("${value}" MATCHES "[<>]" OR "${value}" MATCHES "\\$<" OR
+            NOT IS_ABSOLUTE "${value}")
+        message(FATAL_ERROR
+            "build-receipt GENERATED_DIRECTORY must be an absolute "
+            "generator-expression-free path")
+    endif()
+    if("${value}" MATCHES "(^|/)\\.\\.?(/|$)")
+        message(FATAL_ERROR
+            "build-receipt GENERATED_DIRECTORY must not contain . or .. "
+            "path components")
+    endif()
+    set(_normalized "${value}")
+    cmake_path(NORMAL_PATH _normalized)
+    if(NOT _normalized STREQUAL "${value}")
+        message(FATAL_ERROR
+            "build-receipt GENERATED_DIRECTORY must be normalized")
+    endif()
+    _deac_build_receipt_require_build_tree_descendant(
+        "${_normalized}" "${build_root}" "GENERATED_DIRECTORY")
+    _deac_build_receipt_reject_descendant_symlinks(
+        "${_normalized}" "${build_root}" "GENERATED_DIRECTORY")
+    set(${output} "${_normalized}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_build_receipt_normalize_receipt_path
+        value require_config build_root output)
+    _deac_build_receipt_require_safe_path_text("${value}" "RECEIPT")
+    if(NOT IS_ABSOLUTE "${value}")
+        message(FATAL_ERROR
+            "build-receipt RECEIPT must be an absolute path")
     endif()
 
-    # Rule templates may quote or escape literal path characters.  Reject
-    # control operators and command substitution only when the shell would
-    # interpret them, while leaving CMake's <PLACEHOLDER> and $<GENEX>
-    # syntax untouched.
+    string(REGEX MATCHALL "\\$<CONFIG>" _config_tokens "${value}")
+    list(LENGTH _config_tokens _config_token_count)
+    if(require_config AND NOT _config_token_count EQUAL 1)
+        message(FATAL_ERROR
+            "build-receipt RECEIPT must contain exactly one literal "
+            "$<CONFIG> path component for multi-config generators")
+    elseif(_config_token_count GREATER 1)
+        message(FATAL_ERROR
+            "build-receipt RECEIPT contains more than one literal "
+            "$<CONFIG> token")
+    endif()
+    if(_config_token_count EQUAL 1 AND
+            NOT "${value}" MATCHES "(^|/)\\$<CONFIG>(/|$)")
+        message(FATAL_ERROR
+            "build-receipt RECEIPT requires $<CONFIG> as a complete path "
+            "component")
+    endif()
+
+    string(REPLACE "$<CONFIG>" "" _without_config "${value}")
+    if(_without_config MATCHES "\\$<" OR _without_config MATCHES "[<>]")
+        message(FATAL_ERROR
+            "build-receipt RECEIPT contains unsupported "
+            "generator-expression syntax")
+    endif()
+
+    string(REPLACE "$<CONFIG>" "DEAC_CONFIG_COMPONENT"
+        _normalization_path "${value}")
+    if(_normalization_path MATCHES "(^|/)\\.\\.?(/|$)")
+        message(FATAL_ERROR
+            "build-receipt RECEIPT must not contain . or .. path components")
+    endif()
+    set(_normalized_path "${_normalization_path}")
+    cmake_path(NORMAL_PATH _normalized_path)
+    if(NOT _normalized_path STREQUAL _normalization_path)
+        message(FATAL_ERROR "build-receipt RECEIPT must be normalized")
+    endif()
+    _deac_build_receipt_require_build_tree_descendant(
+        "${_normalized_path}" "${build_root}" "RECEIPT")
+    set(${output} "${value}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_build_receipt_normalize_link_library_artifact
+        artifact output)
+    set(_selected_artifacts_output "")
+    if(ARGC GREATER 2)
+        set(_selected_artifacts_output "${ARGV2}")
+    endif()
+    _deac_build_receipt_require_safe_path_text(
+        "${artifact}" "link-library artifact")
+    string(FIND "${artifact}" "$<" _generator_expression_position)
+    if(_generator_expression_position EQUAL -1)
+        if("${artifact}" MATCHES "[<>]" OR
+                NOT IS_ABSOLUTE "${artifact}" OR
+                NOT EXISTS "${artifact}" OR IS_DIRECTORY "${artifact}")
+            message(FATAL_ERROR
+                "build-receipt link-library artifact must be an absolute "
+                "regular file: ${artifact}")
+        endif()
+        set(_normalized_artifact "${artifact}")
+        cmake_path(NORMAL_PATH _normalized_artifact)
+        set(${output} "${_normalized_artifact}" PARENT_SCOPE)
+        if(NOT _selected_artifacts_output STREQUAL "")
+            set(_selected_artifacts)
+            get_property(_artifact_is_multi_config GLOBAL
+                PROPERTY GENERATOR_IS_MULTI_CONFIG)
+            if(_artifact_is_multi_config)
+                foreach(_configuration IN LISTS CMAKE_CONFIGURATION_TYPES)
+                    list(APPEND _selected_artifacts "${_normalized_artifact}")
+                endforeach()
+            else()
+                list(APPEND _selected_artifacts "${_normalized_artifact}")
+            endif()
+            set(${_selected_artifacts_output}
+                "${_selected_artifacts}" PARENT_SCOPE)
+        endif()
+        return()
+    endif()
+
+    # The provider is resolved at configure time.  Multi-config builds need
+    # only one target-free $<$<CONFIG:name>:absolute-file> segment per config.
+    get_property(_artifact_is_multi_config GLOBAL
+        PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(NOT _generator_expression_position EQUAL 0 OR
+            NOT _artifact_is_multi_config OR
+            "${CMAKE_CONFIGURATION_TYPES}" STREQUAL "")
+        message(FATAL_ERROR
+            "build-receipt link-library artifact uses an unsupported "
+            "generator expression: ${artifact}")
+    endif()
+    set(_remaining_artifact "${artifact}")
+    set(_normalized_artifact "")
+    set(_configuration_artifacts)
+    foreach(_configuration IN LISTS CMAKE_CONFIGURATION_TYPES)
+        if(NOT _configuration MATCHES "^[A-Za-z0-9_.+-]+$" OR
+                _configuration STREQUAL "." OR
+                _configuration STREQUAL "..")
+            message(FATAL_ERROR
+                "build-receipt configuration is not path-safe: "
+                "${_configuration}")
+        endif()
+        set(_segment_prefix "$<$<CONFIG:${_configuration}>:")
+        string(FIND "${_remaining_artifact}" "${_segment_prefix}"
+            _segment_prefix_position)
+        if(NOT _segment_prefix_position EQUAL 0)
+            message(FATAL_ERROR
+                "build-receipt link-library artifact must contain one "
+                "ordered config-only segment for ${_configuration}: "
+                "${artifact}")
+        endif()
+        string(LENGTH "${_segment_prefix}" _segment_prefix_length)
+        string(SUBSTRING "${_remaining_artifact}"
+            ${_segment_prefix_length} -1 _segment_tail)
+        string(FIND "${_segment_tail}" ">" _segment_end)
+        if(_segment_end EQUAL -1)
+            message(FATAL_ERROR
+                "build-receipt link-library artifact has an unterminated "
+                "config-only segment: ${artifact}")
+        endif()
+        string(SUBSTRING "${_segment_tail}" 0 ${_segment_end}
+            _configuration_artifact)
+        if("${_configuration_artifact}" MATCHES "[<>]")
+            message(FATAL_ERROR
+                "build-receipt config-only link-library artifact contains "
+                "nested or unsafe generator-expression syntax: ${artifact}")
+        endif()
+        _deac_build_receipt_normalize_link_library_artifact(
+            "${_configuration_artifact}" _configuration_artifact)
+        list(APPEND _configuration_artifacts
+            "${_configuration_artifact}")
+        string(APPEND _normalized_artifact
+            "$<$<CONFIG:${_configuration}>:${_configuration_artifact}>")
+        math(EXPR _next_segment "${_segment_end} + 1")
+        string(SUBSTRING "${_segment_tail}" ${_next_segment} -1
+            _remaining_artifact)
+    endforeach()
+    if(NOT _remaining_artifact STREQUAL "")
+        message(FATAL_ERROR
+            "build-receipt link-library artifact has trailing or unsupported "
+            "generator-expression content: ${artifact}")
+    endif()
+    set(_unique_configuration_artifacts ${_configuration_artifacts})
+    list(REMOVE_DUPLICATES _unique_configuration_artifacts)
+    list(LENGTH _unique_configuration_artifacts
+        _unique_configuration_artifact_count)
+    if(_unique_configuration_artifact_count LESS 2)
+        message(FATAL_ERROR
+            "build-receipt config-only link-library artifact is noncanonical; "
+            "use its common absolute path directly")
+    endif()
+    set(${output} "${_normalized_artifact}" PARENT_SCOPE)
+    if(NOT _selected_artifacts_output STREQUAL "")
+        set(${_selected_artifacts_output}
+            "${_configuration_artifacts}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(_deac_build_receipt_require_posix_shell_literal value label)
+    # This helper is also called from cmake -P, where no cmake_minimum_required
+    # policy initialization is guaranteed.
+    if(POLICY CMP0054)
+        cmake_policy(SET CMP0054 NEW)
+    endif()
+    set(_allowed_placeholders ${ARGN})
+    foreach(_placeholder IN LISTS _allowed_placeholders)
+        if(NOT _placeholder MATCHES "^[A-Z][A-Z0-9_]*$")
+            message(FATAL_ERROR
+                "build-receipt ${label} has an invalid allowed placeholder")
+        endif()
+    endforeach()
+    list(REMOVE_DUPLICATES _allowed_placeholders)
+
+    # Recipe text is security-sensitive input.  Reject every control byte;
+    # rule templates and File API fragments have no need for one, including
+    # horizontal tabs and embedded line breaks.
+    string(HEX "${value}" _value_hex)
+    string(LENGTH "${_value_hex}" _value_hex_length)
+    set(_hex_index 0)
+    while(_hex_index LESS _value_hex_length)
+        string(SUBSTRING "${_value_hex}" ${_hex_index} 2 _byte_hex)
+        if(_byte_hex MATCHES "^(0[0-9a-f]|1[0-9a-f]|7f)$")
+            message(FATAL_ERROR
+                "build-receipt ${label} contains a POSIX shell control byte")
+        endif()
+        math(EXPR _hex_index "${_hex_index} + 2")
+    endwhile()
+
     string(LENGTH "${value}" _length)
     set(_index 0)
     set(_quote "")
@@ -33,41 +294,98 @@ function(_deac_build_receipt_require_single_command value label)
             string(SUBSTRING "${value}" ${_next_index} 1 _next_character)
         endif()
 
-        set(_handled_cmake_semicolon false)
-        if(_quote STREQUAL "" AND _character STREQUAL "\\")
-            # A backslash protecting CMake's list-valued semicolon is consumed
-            # before the generated recipe reaches the shell.  Therefore the
-            # rule template needs an even, nonzero run here so the emitted
-            # command retains an odd (shell-escaping) run.
-            set(_scan_index ${_index})
-            set(_backslash_count 0)
-            set(_scan_character "\\")
-            while(_scan_index LESS _length AND
-                    _scan_character STREQUAL "\\")
-                math(EXPR _backslash_count "${_backslash_count} + 1")
-                math(EXPR _scan_index "${_scan_index} + 1")
-                set(_scan_character "")
-                if(_scan_index LESS _length)
-                    string(SUBSTRING
-                        "${value}" ${_scan_index} 1 _scan_character)
-                endif()
-            endwhile()
-            if(_scan_character STREQUAL ";")
-                math(EXPR _backslash_remainder
-                    "${_backslash_count} % 2")
-                if(_backslash_remainder EQUAL 1)
-                    message(FATAL_ERROR
-                        "build-receipt ${label} contains shell control syntax")
-                endif()
-                set(_index ${_scan_index})
-                set(_handled_cmake_semicolon true)
-            endif()
+        # A generator expression is evaluated before the recipe reaches the
+        # shell, even when it is written inside POSIX single quotes.
+        if(_character STREQUAL "$" AND _next_character STREQUAL "<")
+            message(FATAL_ERROR
+                "build-receipt ${label} contains unsupported "
+                "generator-expression syntax")
+        endif()
+        # Dollar expansion happens in Make/Ninja before POSIX shell quoting is
+        # applied, so even a single-quoted or backslash-protected dollar is not
+        # stable across the supported generators.  Backtick command
+        # substitution is supported only when POSIX single quotes protect it;
+        # a generator-preserved backslash form is outside this schema.  CMake
+        # likewise consumes an unquoted backslash-semicolon layer while
+        # materializing rule templates.  Reject these shapes instead of
+        # attributing recipe text that differs from the command eventually
+        # executed.
+        if(_character STREQUAL "$")
+            message(FATAL_ERROR
+                "build-receipt ${label} contains unsafe POSIX shell syntax")
+        endif()
+        if(_character STREQUAL "`" AND NOT _quote STREQUAL "'")
+            message(FATAL_ERROR
+                "build-receipt ${label} contains unsafe POSIX shell syntax")
+        endif()
+        if(_character STREQUAL ";" AND _quote STREQUAL "")
+            message(FATAL_ERROR
+                "build-receipt ${label} contains unsafe POSIX shell syntax")
         endif()
 
-        if(_handled_cmake_semicolon)
-            # The scan already consumed the safe escaped semicolon.
-        elseif(_escaped)
+        if(_escaped)
             set(_escaped false)
+        elseif(_character STREQUAL "<")
+            string(SUBSTRING "${value}" ${_index} -1 _placeholder_tail)
+            string(FIND "${_placeholder_tail}" ">" _placeholder_end)
+            set(_recognized_placeholder false)
+            if(NOT _placeholder_end EQUAL -1)
+                math(EXPR _placeholder_length "${_placeholder_end} + 1")
+                math(EXPR _placeholder_name_length
+                    "${_placeholder_end} - 1")
+                string(SUBSTRING "${_placeholder_tail}" 0
+                    ${_placeholder_length} _placeholder_token)
+                string(SUBSTRING "${_placeholder_tail}" 1
+                    ${_placeholder_name_length} _placeholder_name)
+                if(_placeholder_name MATCHES "^[A-Z][A-Z0-9_]*$")
+                    list(FIND _allowed_placeholders "${_placeholder_name}"
+                        _placeholder_index)
+                    if(_placeholder_index EQUAL -1)
+                        message(FATAL_ERROR
+                            "build-receipt ${label} uses unsupported "
+                            "placeholder ${_placeholder_token}")
+                    endif()
+                    set(_placeholder_has_left_boundary false)
+                    if(_index EQUAL 0)
+                        set(_placeholder_has_left_boundary true)
+                    else()
+                        math(EXPR _previous_index "${_index} - 1")
+                        string(SUBSTRING "${value}" ${_previous_index} 1
+                            _previous_character)
+                        if(_previous_character STREQUAL " ")
+                            set(_placeholder_has_left_boundary true)
+                        endif()
+                    endif()
+                    math(EXPR _after_placeholder
+                        "${_index} + ${_placeholder_length}")
+                    set(_placeholder_has_right_boundary false)
+                    if(_after_placeholder EQUAL _length)
+                        set(_placeholder_has_right_boundary true)
+                    elseif(_after_placeholder LESS _length)
+                        string(SUBSTRING "${value}" ${_after_placeholder} 1
+                            _after_placeholder_character)
+                        if(_after_placeholder_character STREQUAL " ")
+                            set(_placeholder_has_right_boundary true)
+                        endif()
+                    endif()
+                    if(NOT _quote STREQUAL "" OR
+                            NOT _placeholder_has_left_boundary OR
+                            NOT _placeholder_has_right_boundary)
+                        message(FATAL_ERROR
+                            "build-receipt ${label} uses placeholder "
+                            "${_placeholder_token} outside a standalone "
+                            "unquoted shell word")
+                    endif()
+                    set(_recognized_placeholder true)
+                    math(EXPR _index
+                        "${_index} + ${_placeholder_length} - 1")
+                endif()
+            endif()
+            if(NOT _recognized_placeholder AND _quote STREQUAL "")
+                message(FATAL_ERROR
+                    "build-receipt ${label} contains unsafe POSIX shell "
+                    "syntax")
+            endif()
         elseif(_quote STREQUAL "'")
             if(_character STREQUAL "'")
                 set(_quote "")
@@ -77,32 +395,37 @@ function(_deac_build_receipt_require_single_command value label)
                 set(_escaped true)
             elseif(_character STREQUAL "\"")
                 set(_quote "")
-            elseif(_character STREQUAL "`" OR
-                    (_character STREQUAL "$" AND
-                     _next_character STREQUAL "("))
+            elseif(_character STREQUAL "$" OR _character STREQUAL "`")
                 message(FATAL_ERROR
-                    "build-receipt ${label} contains shell control syntax")
+                    "build-receipt ${label} contains unsafe POSIX shell "
+                    "syntax")
             endif()
         elseif(_character STREQUAL "\\")
             set(_escaped true)
         elseif(_character STREQUAL "'" OR _character STREQUAL "\"")
             set(_quote "${_character}")
-        elseif(_character MATCHES "[;|&`]" OR
-                (_character STREQUAL "$" AND
-                 _next_character STREQUAL "("))
+        elseif(_character STREQUAL "$" OR _character STREQUAL "`" OR
+                _character STREQUAL "*" OR _character STREQUAL "?" OR
+                _character STREQUAL "[" OR _character STREQUAL "]" OR
+                _character STREQUAL ">" OR _character STREQUAL "~" OR
+                _character STREQUAL "#" OR _character STREQUAL ";" OR
+                _character STREQUAL "|" OR _character STREQUAL "&" OR
+                _character STREQUAL "(" OR _character STREQUAL ")" OR
+                _character STREQUAL "{" OR _character STREQUAL "}")
             message(FATAL_ERROR
-                "build-receipt ${label} contains shell control syntax")
+                "build-receipt ${label} contains unsafe POSIX shell syntax")
         endif()
         math(EXPR _index "${_index} + 1")
     endwhile()
     if(_escaped OR NOT _quote STREQUAL "")
         message(FATAL_ERROR
-            "build-receipt ${label} has incomplete shell quoting")
+            "build-receipt ${label} has incomplete POSIX shell quoting")
     endif()
 endfunction()
 
 function(_deac_build_receipt_snapshot_named_tool
-        variable output_arguments output_fingerprint_material)
+        variable output_arguments output_fingerprint_material
+        output_path output_real_path output_sha256)
     if(NOT DEFINED ${variable} OR "${${variable}}" STREQUAL "")
         message(FATAL_ERROR "build receipt requires ${variable}")
     endif()
@@ -141,6 +464,9 @@ function(_deac_build_receipt_snapshot_named_tool
     set(${output_arguments} "${_arguments}" PARENT_SCOPE)
     set(${output_fingerprint_material}
         "${_fingerprint_material}" PARENT_SCOPE)
+    set(${output_path} "${${variable}}" PARENT_SCOPE)
+    set(${output_real_path} "${_tool_real}" PARENT_SCOPE)
+    set(${output_sha256} "${_tool_sha256}" PARENT_SCOPE)
 endfunction()
 
 function(_deac_build_receipt_reject_unsupported_languages)
@@ -159,8 +485,79 @@ function(_deac_build_receipt_query_enabled_languages output)
     set(${output} "${_enabled_languages}" PARENT_SCOPE)
 endfunction()
 
+function(_deac_build_receipt_configuration_snapshot
+        directory output_generator output_mode output_configurations)
+    get_directory_property(_generator DIRECTORY "${directory}"
+        DEFINITION CMAKE_GENERATOR)
+    get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(_is_multi_config)
+        set(_mode "multi")
+        set(_active_configuration_variable CMAKE_CONFIGURATION_TYPES)
+        get_directory_property(_configurations DIRECTORY "${directory}"
+            DEFINITION CMAKE_CONFIGURATION_TYPES)
+        if("${_configurations}" STREQUAL "")
+            message(FATAL_ERROR
+                "build-receipt multi-config generator has no configurations")
+        endif()
+    else()
+        set(_mode "single")
+        set(_active_configuration_variable CMAKE_BUILD_TYPE)
+        get_directory_property(_configurations DIRECTORY "${directory}"
+            DEFINITION CMAKE_BUILD_TYPE)
+    endif()
+    foreach(_state_variable CMAKE_GENERATOR ${_active_configuration_variable})
+        if(_state_variable STREQUAL "CMAKE_GENERATOR")
+            set(_effective_value "${_generator}")
+        else()
+            set(_effective_value "${_configurations}")
+        endif()
+        get_property(_cache_value_is_set CACHE "${_state_variable}"
+            PROPERTY VALUE SET)
+        if(_cache_value_is_set)
+            get_property(_cache_value CACHE "${_state_variable}"
+                PROPERTY VALUE)
+            if(NOT "${_cache_value}" STREQUAL "${_effective_value}")
+                message(FATAL_ERROR
+                    "build-receipt ${_state_variable} cache value disagrees "
+                    "with effective directory state: ${directory}")
+            endif()
+        endif()
+    endforeach()
+    list(LENGTH _configurations _configuration_count)
+    if(_configuration_count EQUAL 0)
+        message(FATAL_ERROR
+            "build-receipt requires at least one configured build type")
+    endif()
+    if(_mode STREQUAL "single" AND NOT _configuration_count EQUAL 1)
+        message(FATAL_ERROR
+            "build-receipt single-config generator requires exactly one "
+            "configured build type")
+    endif()
+    set(_folded_configurations)
+    foreach(_configuration IN LISTS _configurations)
+        if(NOT _configuration MATCHES "^[A-Za-z0-9_.+-]+$" OR
+                _configuration STREQUAL "." OR
+                _configuration STREQUAL "..")
+            message(FATAL_ERROR
+                "build-receipt configuration is not path-safe: "
+                "${_configuration}")
+        endif()
+        string(TOUPPER "${_configuration}" _folded_configuration)
+        if(_folded_configuration IN_LIST _folded_configurations)
+            message(FATAL_ERROR
+                "build-receipt configurations must be unique ignoring "
+                "ASCII case: ${_configuration}")
+        endif()
+        list(APPEND _folded_configurations "${_folded_configuration}")
+    endforeach()
+    set(${output_generator} "${_generator}" PARENT_SCOPE)
+    set(${output_mode} "${_mode}" PARENT_SCOPE)
+    set(${output_configurations} "${_configurations}" PARENT_SCOPE)
+endfunction()
+
 function(_deac_build_receipt_snapshot_tool
-        language output_arguments output_fingerprint_material)
+        language output_arguments output_fingerprint_material
+        output_path output_real_path output_sha256)
     if(NOT DEFINED CMAKE_${language}_COMPILER OR
             "${CMAKE_${language}_COMPILER}" STREQUAL "")
         message(FATAL_ERROR
@@ -219,19 +616,25 @@ function(_deac_build_receipt_snapshot_tool
     set(${output_arguments} "${_arguments}" PARENT_SCOPE)
     set(${output_fingerprint_material}
         "${_fingerprint_material}" PARENT_SCOPE)
+    set(${output_path} "${CMAKE_${language}_COMPILER}" PARENT_SCOPE)
+    set(${output_real_path} "${_compiler_real}" PARENT_SCOPE)
+    set(${output_sha256} "${_compiler_sha256}" PARENT_SCOPE)
 endfunction()
 
-function(_deac_build_receipt_reject_launchers target_name)
+function(_deac_build_receipt_reject_launchers target_name directory)
     foreach(_language CXX CUDA)
         foreach(_suffix COMPILER_LAUNCHER LINKER_LAUNCHER)
             set(_variable "CMAKE_${_language}_${_suffix}")
-            if(DEFINED ${_variable} AND NOT "${${_variable}}" STREQUAL "")
+            get_directory_property(_launcher DIRECTORY "${directory}"
+                DEFINITION "${_variable}")
+            if(NOT "${_launcher}" STREQUAL "")
                 message(FATAL_ERROR
                     "build receipts do not yet support ${_variable}")
             endif()
             get_target_property(_launcher "${target_name}"
                 "${_language}_${_suffix}")
-            if(_launcher AND NOT _launcher MATCHES "-NOTFOUND$")
+            if(NOT "${_launcher}" STREQUAL "" AND
+                    NOT "${_launcher}" MATCHES "-NOTFOUND$")
                 message(FATAL_ERROR
                     "build receipts do not yet support target "
                     "${target_name} ${_language}_${_suffix}")
@@ -241,15 +644,17 @@ function(_deac_build_receipt_reject_launchers target_name)
                 CLANG_TIDY CPPCHECK CPPLINT INCLUDE_WHAT_YOU_USE)
             get_target_property(_launcher "${target_name}"
                 "${_language}_${_suffix}")
-            if(_launcher AND NOT _launcher MATCHES "-NOTFOUND$")
+            if(NOT "${_launcher}" STREQUAL "" AND
+                    NOT "${_launcher}" MATCHES "-NOTFOUND$")
                 message(FATAL_ERROR
                     "build receipts do not yet support target "
                     "${target_name} ${_language}_${_suffix}")
             endif()
         endforeach()
         set(_compiler_arg1 "CMAKE_${_language}_COMPILER_ARG1")
-        if(DEFINED ${_compiler_arg1} AND
-                NOT "${${_compiler_arg1}}" STREQUAL "")
+        get_directory_property(_compiler_arg1_value
+            DIRECTORY "${directory}" DEFINITION "${_compiler_arg1}")
+        if(NOT "${_compiler_arg1_value}" STREQUAL "")
             message(FATAL_ERROR
                 "build receipts do not yet support ${_compiler_arg1}")
         endif()
@@ -263,10 +668,14 @@ function(_deac_build_receipt_reject_launchers target_name)
     endif()
 
     set(_ipo_properties INTERPROCEDURAL_OPTIMIZATION)
-    if(CMAKE_CONFIGURATION_TYPES)
-        set(_ipo_configurations ${CMAKE_CONFIGURATION_TYPES})
+    get_directory_property(_configuration_types DIRECTORY "${directory}"
+        DEFINITION CMAKE_CONFIGURATION_TYPES)
+    get_directory_property(_build_type DIRECTORY "${directory}"
+        DEFINITION CMAKE_BUILD_TYPE)
+    if(NOT "${_configuration_types}" STREQUAL "")
+        set(_ipo_configurations ${_configuration_types})
     else()
-        set(_ipo_configurations "${CMAKE_BUILD_TYPE}")
+        set(_ipo_configurations "${_build_type}")
     endif()
     foreach(_configuration IN LISTS _ipo_configurations)
         string(TOUPPER "${_configuration}" _configuration_upper)
@@ -290,24 +699,30 @@ function(_deac_build_receipt_reject_launchers target_name)
             RULE_LAUNCH_COMPILE RULE_LAUNCH_CUSTOM RULE_LAUNCH_LINK)
         get_target_property(
             _launcher_value "${target_name}" "${_launcher_property}")
-        if(_launcher_value AND NOT _launcher_value MATCHES "-NOTFOUND$")
+        if(NOT "${_launcher_value}" STREQUAL "" AND
+                NOT "${_launcher_value}" MATCHES "-NOTFOUND$")
             message(FATAL_ERROR
                 "build receipts do not yet support target ${target_name} "
                 "${_launcher_property}")
         endif()
-        foreach(_scope GLOBAL DIRECTORY)
-            get_property(_launcher_value ${_scope}
-                PROPERTY "${_launcher_property}")
-            if(NOT "${_launcher_value}" STREQUAL "")
-                message(FATAL_ERROR
-                    "build receipts do not yet support ${_scope} "
-                    "${_launcher_property}")
-            endif()
-        endforeach()
+        get_property(_launcher_value GLOBAL
+            PROPERTY "${_launcher_property}")
+        if(NOT "${_launcher_value}" STREQUAL "")
+            message(FATAL_ERROR
+                "build receipts do not yet support GLOBAL "
+                "${_launcher_property}")
+        endif()
+        get_property(_launcher_value DIRECTORY "${directory}"
+            PROPERTY "${_launcher_property}")
+        if(NOT "${_launcher_value}" STREQUAL "")
+            message(FATAL_ERROR
+                "build receipts do not yet support DIRECTORY "
+                "${_launcher_property}")
+        endif()
     endforeach()
 endfunction()
 
-function(_deac_build_receipt_reject_rule_override_routes)
+function(_deac_build_receipt_reject_rule_override_routes directory)
     foreach(_variable
             CMAKE_TOOLCHAIN_FILE
             CMAKE_USER_MAKE_RULES_OVERRIDE
@@ -317,7 +732,9 @@ function(_deac_build_receipt_reject_rule_override_routes)
             CMAKE_PROJECT_INCLUDE
             CMAKE_PROJECT_INCLUDE_BEFORE
             CMAKE_PROJECT_TOP_LEVEL_INCLUDES)
-        if(DEFINED ${_variable} AND NOT "${${_variable}}" STREQUAL "")
+        get_directory_property(_variable_value DIRECTORY "${directory}"
+            DEFINITION "${_variable}")
+        if(NOT "${_variable_value}" STREQUAL "")
             message(FATAL_ERROR
                 "build receipts do not support rule-override route ${_variable}")
         endif()
@@ -328,9 +745,13 @@ function(_deac_build_receipt_reject_rule_override_routes)
         message(FATAL_ERROR
             "build receipts reject cached rule-override route CMAKE_MODULE_PATH")
     endif()
+    get_directory_property(_project_name DIRECTORY "${directory}"
+        DEFINITION PROJECT_NAME)
     foreach(_suffix INCLUDE INCLUDE_BEFORE)
-        set(_variable "CMAKE_PROJECT_${PROJECT_NAME}_${_suffix}")
-        if(DEFINED ${_variable} AND NOT "${${_variable}}" STREQUAL "")
+        set(_variable "CMAKE_PROJECT_${_project_name}_${_suffix}")
+        get_directory_property(_variable_value DIRECTORY "${directory}"
+            DEFINITION "${_variable}")
+        if(NOT "${_variable_value}" STREQUAL "")
             message(FATAL_ERROR
                 "build receipts do not support rule-override route ${_variable}")
         endif()
@@ -366,99 +787,87 @@ function(_deac_build_receipt_reject_rule_override_routes)
 endfunction()
 
 function(_deac_build_receipt_rule_fingerprint
-        language output_fingerprint_material)
+        language directory output_fingerprint_material)
+    if(NOT language STREQUAL "CXX")
+        message(FATAL_ERROR
+            "schema-1 build receipts only support CXX rule templates")
+    endif()
     set(_material "")
     foreach(_rule COMPILE_OBJECT LINK_EXECUTABLE)
         set(_variable "CMAKE_${language}_${_rule}")
-        if(NOT DEFINED ${_variable} OR "${${_variable}}" STREQUAL "")
+        get_directory_property(_template DIRECTORY "${directory}"
+            DEFINITION "${_variable}")
+        if("${_template}" STREQUAL "")
             message(FATAL_ERROR "build receipt requires ${_variable}")
         endif()
-        set(_template "${${_variable}}")
-        _deac_build_receipt_require_single_command(
-            "${_template}" "${_variable}")
         if(_rule STREQUAL "COMPILE_OBJECT")
-            set(_allowed_prefix "<CMAKE_${language}_COMPILER>")
-            foreach(_placeholder DEFINES INCLUDES SOURCE OBJECT FLAGS)
-                if(NOT _template MATCHES "<${_placeholder}>")
-                    message(FATAL_ERROR
-                        "build-receipt ${_variable} omits <${_placeholder}>")
-                endif()
-            endforeach()
-        elseif(language STREQUAL "CUDA")
-            if(_template MATCHES "^<CMAKE_CUDA_COMPILER>( |$)")
-                set(_allowed_prefix "<CMAKE_CUDA_COMPILER>")
-            elseif(_template MATCHES "^<CMAKE_CUDA_HOST_LINK_LAUNCHER>( |$)")
-                set(_allowed_prefix "<CMAKE_CUDA_HOST_LINK_LAUNCHER>")
-            else()
-                message(FATAL_ERROR
-                    "build-receipt ${_variable} has an unsupported launcher")
-            endif()
+            set(_allowed_placeholders
+                CMAKE_CXX_COMPILER DEFINES INCLUDES FLAGS OBJECT SOURCE)
+            set(_required_placeholders
+                DEFINES INCLUDES FLAGS OBJECT SOURCE)
         else()
-            set(_allowed_prefix "<CMAKE_${language}_COMPILER>")
+            set(_allowed_placeholders
+                CMAKE_CXX_COMPILER FLAGS CMAKE_CXX_LINK_FLAGS LINK_FLAGS
+                OBJECTS TARGET LINK_LIBRARIES)
+            set(_required_placeholders
+                FLAGS CMAKE_CXX_LINK_FLAGS LINK_FLAGS OBJECTS TARGET
+                LINK_LIBRARIES)
         endif()
+        _deac_build_receipt_require_posix_shell_literal(
+            "${_template}" "${_variable}" ${_allowed_placeholders})
+        set(_allowed_prefix "<CMAKE_CXX_COMPILER>")
         string(FIND "${_template}" "${_allowed_prefix}" _prefix_position)
         if(NOT _prefix_position EQUAL 0)
             message(FATAL_ERROR
                 "build-receipt ${_variable} has an unsupported launcher")
         endif()
-        if(_rule STREQUAL "LINK_EXECUTABLE")
-            foreach(_placeholder
-                    LINK_FLAGS LINK_LIBRARIES OBJECTS TARGET)
-                if(NOT _template MATCHES "<${_placeholder}>")
-                    message(FATAL_ERROR
-                        "build-receipt ${_variable} omits <${_placeholder}>")
-                endif()
-            endforeach()
-            if(language STREQUAL "CXX")
-                foreach(_placeholder FLAGS CMAKE_CXX_LINK_FLAGS)
-                    if(NOT _template MATCHES "<${_placeholder}>")
-                        message(FATAL_ERROR
-                            "build-receipt ${_variable} omits <${_placeholder}>")
-                    endif()
-                endforeach()
+        foreach(_placeholder IN LISTS _required_placeholders)
+            if(NOT _template MATCHES "<${_placeholder}>")
+                message(FATAL_ERROR
+                    "build-receipt ${_variable} omits <${_placeholder}>")
             endif()
-        endif()
+        endforeach()
         string(LENGTH "${_template}" _length)
         string(APPEND _material
             "${language}.${_rule}:${_length}:${_template}\n")
     endforeach()
 
     set(_legacy_archive "CMAKE_${language}_CREATE_STATIC_LIBRARY")
-    if(DEFINED ${_legacy_archive} AND NOT "${${_legacy_archive}}" STREQUAL "")
+    get_directory_property(_legacy_archive_value DIRECTORY "${directory}"
+        DEFINITION "${_legacy_archive}")
+    if(NOT "${_legacy_archive_value}" STREQUAL "")
         message(FATAL_ERROR
             "build receipts do not support ${_legacy_archive}")
     endif()
     foreach(_rule ARCHIVE_CREATE ARCHIVE_APPEND ARCHIVE_FINISH)
         set(_variable "CMAKE_${language}_${_rule}")
-        if(NOT DEFINED ${_variable} OR "${${_variable}}" STREQUAL "")
+        get_directory_property(_template DIRECTORY "${directory}"
+            DEFINITION "${_variable}")
+        if("${_template}" STREQUAL "")
             message(FATAL_ERROR "build receipt requires ${_variable}")
         endif()
-        set(_template "${${_variable}}")
-        _deac_build_receipt_require_single_command(
-            "${_template}" "${_variable}")
         if(_rule STREQUAL "ARCHIVE_FINISH")
             set(_allowed_prefix "<CMAKE_RANLIB>")
+            set(_allowed_placeholders CMAKE_RANLIB TARGET)
+            set(_required_placeholders TARGET)
         else()
             set(_allowed_prefix "<CMAKE_AR>")
+            set(_allowed_placeholders CMAKE_AR LINK_FLAGS OBJECTS TARGET)
+            set(_required_placeholders LINK_FLAGS OBJECTS TARGET)
         endif()
+        _deac_build_receipt_require_posix_shell_literal(
+            "${_template}" "${_variable}" ${_allowed_placeholders})
         string(FIND "${_template}" "${_allowed_prefix}" _prefix_position)
         if(NOT _prefix_position EQUAL 0)
             message(FATAL_ERROR
                 "build-receipt ${_variable} has an unsupported launcher")
         endif()
-        if(_rule STREQUAL "ARCHIVE_FINISH")
-            if(NOT _template MATCHES "<TARGET>")
+        foreach(_placeholder IN LISTS _required_placeholders)
+            if(NOT _template MATCHES "<${_placeholder}>")
                 message(FATAL_ERROR
-                    "build-receipt ${_variable} omits <TARGET>")
+                    "build-receipt ${_variable} omits <${_placeholder}>")
             endif()
-        else()
-            foreach(_placeholder LINK_FLAGS OBJECTS TARGET)
-                if(NOT _template MATCHES "<${_placeholder}>")
-                    message(FATAL_ERROR
-                        "build-receipt ${_variable} omits <${_placeholder}>")
-                endif()
-            endforeach()
-        endif()
+        endforeach()
         string(LENGTH "${_template}" _length)
         string(APPEND _material
             "${language}.${_rule}:${_length}:${_template}\n")
@@ -466,10 +875,404 @@ function(_deac_build_receipt_rule_fingerprint
     set(${output_fingerprint_material} "${_material}" PARENT_SCOPE)
 endfunction()
 
+function(_deac_build_receipt_canonical_target target_name output)
+    if(NOT TARGET "${target_name}")
+        set(${output} "" PARENT_SCOPE)
+        return()
+    endif()
+    get_target_property(_aliased_target "${target_name}" ALIASED_TARGET)
+    if("${_aliased_target}" STREQUAL "" OR
+            "${_aliased_target}" STREQUAL "_aliased_target-NOTFOUND")
+        set(_aliased_target "${target_name}")
+    endif()
+    set(${output} "${_aliased_target}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_build_receipt_target_directory target_name output)
+    if(NOT TARGET "${target_name}")
+        message(FATAL_ERROR
+            "build-receipt validated target no longer exists: ${target_name}")
+    endif()
+    get_target_property(_target_directory "${target_name}" SOURCE_DIR)
+    if("${_target_directory}" STREQUAL "" OR
+            "${_target_directory}" STREQUAL "_target_directory-NOTFOUND" OR
+            NOT IS_ABSOLUTE "${_target_directory}")
+        message(FATAL_ERROR
+            "build-receipt target has no absolute SOURCE_DIR: ${target_name}")
+    endif()
+    set(${output} "${_target_directory}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_build_receipt_validate_target_scopes
+        receipt_target registration_directory)
+    set(_validated_targets ${ARGN})
+    _deac_build_receipt_reject_rule_override_routes(
+        "${registration_directory}")
+    _deac_build_receipt_reject_launchers(
+        "${receipt_target}" "${registration_directory}")
+    foreach(_validated_target IN LISTS _validated_targets)
+        _deac_build_receipt_target_directory(
+            "${_validated_target}" _target_directory)
+        _deac_build_receipt_reject_rule_override_routes(
+            "${_target_directory}")
+        _deac_build_receipt_reject_launchers(
+            "${_validated_target}" "${_target_directory}")
+    endforeach()
+endfunction()
+
+function(_deac_build_receipt_target_rule_fingerprint
+        language registration_directory output_fingerprint_material)
+    set(_validated_targets ${ARGN})
+    list(SORT _validated_targets)
+    _deac_build_receipt_rule_fingerprint(
+        "${language}" "${registration_directory}" _registration_rule_material)
+    set(_material
+        "deac-build-target-rules-v2\n${_registration_rule_material}")
+    set(_rule_target_types
+        EXECUTABLE STATIC_LIBRARY SHARED_LIBRARY MODULE_LIBRARY OBJECT_LIBRARY)
+    foreach(_validated_target IN LISTS _validated_targets)
+        get_target_property(_validated_target_type
+            "${_validated_target}" TYPE)
+        if(_validated_target_type IN_LIST _rule_target_types)
+            _deac_build_receipt_target_directory(
+                "${_validated_target}" _target_directory)
+            _deac_build_receipt_rule_fingerprint(
+                "${language}" "${_target_directory}" _target_rule_material)
+            if(NOT _target_rule_material STREQUAL
+                    _registration_rule_material)
+                message(FATAL_ERROR
+                    "build-receipt ${language} rule templates for target "
+                    "${_validated_target} differ from the receipt "
+                    "registration directory")
+            endif()
+        endif()
+    endforeach()
+    set(${output_fingerprint_material} "${_material}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_build_receipt_validate_named_tool_in_directory
+        variable directory expected_path expected_real_path expected_sha256)
+    get_directory_property(_tool_path DIRECTORY "${directory}"
+        DEFINITION "${variable}")
+    _deac_build_receipt_require_plain(
+        "${_tool_path}" "${variable} executable identity")
+    if(NOT "${_tool_path}" STREQUAL "${expected_path}" OR
+            NOT IS_ABSOLUTE "${_tool_path}")
+        message(FATAL_ERROR
+            "build-receipt ${variable} changed after registration")
+    endif()
+    get_filename_component(_tool_real_path "${_tool_path}" REALPATH)
+    if(NOT EXISTS "${_tool_real_path}" OR IS_DIRECTORY "${_tool_real_path}")
+        message(FATAL_ERROR
+            "build-receipt ${variable} is no longer a regular file")
+    endif()
+    file(SHA256 "${_tool_real_path}" _tool_sha256)
+    if(NOT "${_tool_real_path}" STREQUAL "${expected_real_path}" OR
+            NOT "${_tool_sha256}" STREQUAL "${expected_sha256}")
+        message(FATAL_ERROR
+            "build-receipt ${variable} changed after registration")
+    endif()
+endfunction()
+
+function(_deac_build_receipt_validate_interface_dependencies target_name)
+    get_target_property(_expected_interface_targets "${target_name}"
+        DEAC_BUILD_RECEIPT_INTERFACE_DEPENDENCIES)
+    if("${_expected_interface_targets}" STREQUAL
+            "_expected_interface_targets-NOTFOUND")
+        message(FATAL_ERROR
+            "build-receipt interface dependency seal is missing for "
+            "${target_name}")
+    endif()
+
+    get_target_property(_direct_links "${target_name}" LINK_LIBRARIES)
+    if("${_direct_links}" STREQUAL "_direct_links-NOTFOUND")
+        set(_direct_links)
+    endif()
+    set(_observed_interface_targets)
+    foreach(_direct_link IN LISTS _direct_links)
+        set(_linked_target "")
+        if(TARGET "${_direct_link}")
+            _deac_build_receipt_canonical_target(
+                "${_direct_link}" _linked_target)
+        elseif(_direct_link MATCHES "^\\$<LINK_ONLY:([^$<>]+)>$")
+            set(_link_only_item "${CMAKE_MATCH_1}")
+            if(TARGET "${_link_only_item}")
+                _deac_build_receipt_canonical_target(
+                    "${_link_only_item}" _linked_target)
+            endif()
+        elseif(_direct_link MATCHES "\\$<")
+            message(FATAL_ERROR
+                "has an unsupported generator-expression link item for "
+                "build-receipt target ${target_name}")
+        endif()
+        if(NOT "${_linked_target}" STREQUAL "")
+            get_target_property(_linked_target_type
+                "${_linked_target}" TYPE)
+            if(_linked_target_type STREQUAL "INTERFACE_LIBRARY")
+                list(APPEND _observed_interface_targets "${_linked_target}")
+            endif()
+        endif()
+    endforeach()
+    list(SORT _observed_interface_targets)
+    if(NOT "${_observed_interface_targets}" STREQUAL
+            "${_expected_interface_targets}")
+        message(FATAL_ERROR
+            "build-receipt interface dependencies changed after "
+            "registration for ${target_name}: expected "
+            "[${_expected_interface_targets}], got "
+            "[${_observed_interface_targets}]")
+    endif()
+endfunction()
+
+function(_deac_build_receipt_validate_interface_link_items
+        target_name property)
+    get_target_property(_link_items "${target_name}" "${property}")
+    if("${_link_items}" STREQUAL "_link_items-NOTFOUND")
+        return()
+    endif()
+    foreach(_link_item IN LISTS _link_items)
+        if(_link_item MATCHES "\\$<" AND
+                NOT _link_item MATCHES "^\\$<LINK_ONLY:[^$<>]+>$")
+            message(FATAL_ERROR
+                "build-receipt interface target ${target_name} property "
+                "${property} has an unsupported generator-expression "
+                "link item")
+        endif()
+    endforeach()
+endfunction()
+
+function(_deac_build_receipt_interface_fingerprint output)
+    set(_interface_targets ${ARGN})
+    list(SORT _interface_targets)
+    set(_material "deac-build-receipt-interface-v1\n")
+    set(_interface_properties
+        INTERFACE_COMPILE_DEFINITIONS
+        INTERFACE_COMPILE_FEATURES
+        INTERFACE_COMPILE_OPTIONS
+        INTERFACE_INCLUDE_DIRECTORIES
+        INTERFACE_LINK_DEPENDS
+        INTERFACE_LINK_DIRECTORIES
+        INTERFACE_LINK_LIBRARIES
+        INTERFACE_LINK_LIBRARIES_DIRECT
+        INTERFACE_LINK_LIBRARIES_DIRECT_EXCLUDE
+        INTERFACE_LINK_OPTIONS
+        INTERFACE_POSITION_INDEPENDENT_CODE
+        INTERFACE_PRECOMPILE_HEADERS
+        INTERFACE_SOURCES
+        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
+    foreach(_interface_target IN LISTS _interface_targets)
+        if(NOT TARGET "${_interface_target}")
+            message(FATAL_ERROR
+                "build-receipt sealed interface target no longer exists: "
+                "${_interface_target}")
+        endif()
+        get_target_property(_interface_type "${_interface_target}" TYPE)
+        if(NOT _interface_type STREQUAL "INTERFACE_LIBRARY")
+            message(FATAL_ERROR
+                "build-receipt sealed interface target changed type: "
+                "${_interface_target}")
+        endif()
+        string(LENGTH "${_interface_target}" _target_length)
+        string(APPEND _material
+            "target:${_target_length}:${_interface_target}\n")
+        foreach(_link_property
+                INTERFACE_LINK_LIBRARIES
+                INTERFACE_LINK_LIBRARIES_DIRECT
+                INTERFACE_LINK_LIBRARIES_DIRECT_EXCLUDE)
+            _deac_build_receipt_validate_interface_link_items(
+                "${_interface_target}" "${_link_property}")
+        endforeach()
+        foreach(_property IN LISTS _interface_properties)
+            get_target_property(_property_value
+                "${_interface_target}" "${_property}")
+            if("${_property_value}" STREQUAL
+                    "_property_value-NOTFOUND")
+                set(_property_value "")
+            endif()
+            string(LENGTH "${_property_value}" _property_length)
+            string(APPEND _material
+                "${_property}:${_property_length}:${_property_value}\n")
+        endforeach()
+    endforeach()
+    string(SHA256 _fingerprint "${_material}")
+    set(${output} "${_fingerprint}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_build_receipt_validate_seal target_name)
+    get_target_property(_registration_directory "${target_name}"
+        DEAC_BUILD_RECEIPT_REGISTRATION_DIRECTORY)
+    get_target_property(_validated_targets "${target_name}"
+        DEAC_BUILD_RECEIPT_VALIDATED_TARGETS)
+    get_target_property(_expected_rule_fingerprint "${target_name}"
+        DEAC_BUILD_RECEIPT_CXX_RULE_FINGERPRINT)
+    get_target_property(_expected_interface_fingerprint "${target_name}"
+        DEAC_BUILD_RECEIPT_INTERFACE_FINGERPRINT)
+    get_target_property(_build_root "${target_name}"
+        DEAC_BUILD_RECEIPT_BUILD_ROOT)
+    get_target_property(_output_paths "${target_name}"
+        DEAC_BUILD_RECEIPT_OUTPUT_PATHS)
+    get_target_property(_expected_generator "${target_name}"
+        DEAC_BUILD_RECEIPT_GENERATOR)
+    get_target_property(_expected_configuration_mode "${target_name}"
+        DEAC_BUILD_RECEIPT_CONFIGURATION_MODE)
+    get_target_property(_expected_configurations "${target_name}"
+        DEAC_BUILD_RECEIPT_CONFIGURATIONS)
+    get_target_property(_top_level_source_directory "${target_name}"
+        DEAC_BUILD_RECEIPT_TOP_LEVEL_SOURCE_DIRECTORY)
+    foreach(_seal_property_value
+            _registration_directory
+            _validated_targets
+            _expected_rule_fingerprint
+            _expected_interface_fingerprint
+            _build_root
+            _output_paths
+            _expected_generator
+            _expected_configuration_mode
+            _expected_configurations
+            _top_level_source_directory)
+        if("${${_seal_property_value}}" STREQUAL
+                "${_seal_property_value}-NOTFOUND")
+            message(FATAL_ERROR
+                "build-receipt validation seal is incomplete for "
+                "${target_name}")
+        endif()
+    endforeach()
+
+    set(_configuration_directories
+        "${_top_level_source_directory}" "${_registration_directory}")
+    list(REMOVE_DUPLICATES _configuration_directories)
+    foreach(_configuration_directory IN LISTS _configuration_directories)
+        _deac_build_receipt_configuration_snapshot(
+            "${_configuration_directory}" _observed_generator
+            _observed_configuration_mode _observed_configurations)
+        if(NOT _observed_generator STREQUAL _expected_generator OR
+                NOT _observed_configuration_mode STREQUAL
+                    _expected_configuration_mode OR
+                NOT "${_observed_configurations}" STREQUAL
+                    "${_expected_configurations}")
+            message(FATAL_ERROR
+                "build-receipt generator configuration state changed after "
+                "registration or differs between the top-level and receipt "
+                "directories for "
+                "${target_name}: ${_configuration_directory}")
+        endif()
+    endforeach()
+
+    _deac_build_receipt_validate_target_scopes(
+        "${target_name}" "${_registration_directory}"
+        ${_validated_targets})
+    foreach(_output_path IN LISTS _output_paths)
+        _deac_build_receipt_reject_descendant_symlinks(
+            "${_output_path}" "${_build_root}" "output path")
+    endforeach()
+    _deac_build_receipt_validate_interface_dependencies("${target_name}")
+
+    get_target_property(_interface_targets "${target_name}"
+        DEAC_BUILD_RECEIPT_INTERFACE_DEPENDENCIES)
+    _deac_build_receipt_interface_fingerprint(
+        _observed_interface_fingerprint ${_interface_targets})
+    if(NOT _observed_interface_fingerprint STREQUAL
+            _expected_interface_fingerprint)
+        message(FATAL_ERROR
+            "build-receipt interface properties changed after registration "
+            "for ${target_name}")
+    endif()
+
+    _deac_build_receipt_target_rule_fingerprint(
+        CXX "${_registration_directory}" _observed_rule_material
+        ${_validated_targets})
+    string(SHA256 _observed_rule_fingerprint
+        "${_observed_rule_material}")
+    if(NOT _observed_rule_fingerprint STREQUAL
+            _expected_rule_fingerprint)
+        message(FATAL_ERROR
+            "build-receipt CXX rule templates changed after registration "
+            "for ${target_name}")
+    endif()
+
+    set(_tool_target_types
+        EXECUTABLE STATIC_LIBRARY SHARED_LIBRARY MODULE_LIBRARY OBJECT_LIBRARY)
+    foreach(_tool_variable
+            CMAKE_CXX_COMPILER CMAKE_AR CMAKE_RANLIB)
+        get_target_property(_expected_tool_path "${target_name}"
+            "DEAC_BUILD_RECEIPT_${_tool_variable}_PATH")
+        get_target_property(_expected_tool_real_path "${target_name}"
+            "DEAC_BUILD_RECEIPT_${_tool_variable}_REAL_PATH")
+        get_target_property(_expected_tool_sha256 "${target_name}"
+            "DEAC_BUILD_RECEIPT_${_tool_variable}_SHA256")
+        foreach(_expected_tool_value
+                _expected_tool_path
+                _expected_tool_real_path
+                _expected_tool_sha256)
+            if("${${_expected_tool_value}}" STREQUAL
+                    "${_expected_tool_value}-NOTFOUND")
+                message(FATAL_ERROR
+                    "build-receipt tool validation seal is incomplete for "
+                    "${target_name}")
+            endif()
+        endforeach()
+        foreach(_validated_target IN LISTS _validated_targets)
+            get_target_property(_validated_target_type
+                "${_validated_target}" TYPE)
+            if(_validated_target_type IN_LIST _tool_target_types)
+                _deac_build_receipt_target_directory(
+                    "${_validated_target}" _target_directory)
+                _deac_build_receipt_validate_named_tool_in_directory(
+                    "${_tool_variable}" "${_target_directory}"
+                    "${_expected_tool_path}" "${_expected_tool_real_path}"
+                    "${_expected_tool_sha256}")
+            endif()
+        endforeach()
+    endforeach()
+endfunction()
+
+function(_deac_build_receipt_validate_current_directory_seals)
+    cmake_language(DEFER GET_CALL_IDS _pending_deferred_calls)
+    list(REMOVE_ITEM _pending_deferred_calls
+        deac_build_receipt_directory_seal
+        deac_build_receipt_top_level_seal)
+    if(_pending_deferred_calls)
+        cmake_language(DEFER ID deac_build_receipt_directory_seal CALL
+            _deac_build_receipt_validate_current_directory_seals)
+        return()
+    endif()
+    get_property(_sealed_targets DIRECTORY
+        PROPERTY DEAC_BUILD_RECEIPT_SEALED_TARGETS)
+    foreach(_sealed_target IN LISTS _sealed_targets)
+        _deac_build_receipt_validate_seal("${_sealed_target}")
+    endforeach()
+endfunction()
+
+function(_deac_build_receipt_validate_top_level_seals)
+    cmake_language(DEFER GET_CALL_IDS _pending_deferred_calls)
+    list(REMOVE_ITEM _pending_deferred_calls
+        deac_build_receipt_directory_seal
+        deac_build_receipt_top_level_seal)
+    if(_pending_deferred_calls)
+        cmake_language(DEFER ID deac_build_receipt_top_level_seal CALL
+            _deac_build_receipt_validate_top_level_seals)
+        return()
+    endif()
+    get_property(_sealed_targets GLOBAL
+        PROPERTY DEAC_BUILD_RECEIPT_SEALED_TARGETS)
+    foreach(_sealed_target IN LISTS _sealed_targets)
+        _deac_build_receipt_validate_seal("${_sealed_target}")
+    endforeach()
+endfunction()
+
 function(deac_target_add_build_receipt target_name)
     if(CMAKE_VERSION VERSION_LESS 3.27)
         message(FATAL_ERROR
             "canonical DEAC build receipts require CMake 3.27 or newer")
+    endif()
+    set(_supported_receipt_generators
+        "Ninja" "Ninja Multi-Config" "Unix Makefiles")
+    list(FIND _supported_receipt_generators "${CMAKE_GENERATOR}"
+        _supported_generator_index)
+    if(NOT CMAKE_HOST_UNIX OR _supported_generator_index EQUAL -1)
+        message(FATAL_ERROR
+            "schema-1 build receipts require a POSIX host with Ninja, "
+            "Ninja Multi-Config, or Unix Makefiles")
     endif()
     if(NOT TARGET "${target_name}")
         message(FATAL_ERROR
@@ -480,13 +1283,42 @@ function(deac_target_add_build_receipt target_name)
         message(FATAL_ERROR
             "deac_target_add_build_receipt requires an executable target")
     endif()
+    _deac_build_receipt_canonical_target(
+        "${target_name}" _canonical_receipt_target)
+    if(NOT _canonical_receipt_target STREQUAL target_name)
+        message(FATAL_ERROR
+            "deac_target_add_build_receipt requires a non-alias target")
+    endif()
+    get_target_property(_target_is_imported "${target_name}" IMPORTED)
+    if(_target_is_imported)
+        message(FATAL_ERROR
+            "deac_target_add_build_receipt requires a buildable target")
+    endif()
+    if(NOT target_name MATCHES "^[A-Za-z0-9_.+-]+$")
+        message(FATAL_ERROR
+            "deac_target_add_build_receipt target name is not safely "
+            "representable")
+    endif()
+    get_target_property(_existing_receipt_registration "${target_name}"
+        DEAC_BUILD_RECEIPT_REGISTRATION_DIRECTORY)
+    if(NOT "${_existing_receipt_registration}" STREQUAL
+            "_existing_receipt_registration-NOTFOUND")
+        message(FATAL_ERROR
+            "deac_target_add_build_receipt target is already registered: "
+            "${target_name}")
+    endif()
 
     cmake_parse_arguments(
         PARSE_ARGV 1
         DEAC_RECEIPT
         ""
         "SOURCE_ROOT;GENERATED_DIRECTORY;IDENTITY_NAME;RECEIPT;BACKEND"
-        "CACHE_KEYS;DEPENDENCY_TARGETS")
+        "CACHE_KEYS;DEPENDENCY_TARGETS;REQUIRED_LINK_LIBRARY_NAMES;REQUIRED_LINK_LIBRARY_ARTIFACTS")
+    if(DEAC_RECEIPT_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR
+            "deac_target_add_build_receipt received unsupported arguments: "
+            "${DEAC_RECEIPT_UNPARSED_ARGUMENTS}")
+    endif()
     foreach(_required_argument
             SOURCE_ROOT
             GENERATED_DIRECTORY
@@ -520,39 +1352,185 @@ function(deac_target_add_build_receipt target_name)
     list(SORT DEAC_RECEIPT_CACHE_KEYS)
     string(JOIN "," _cache_keys_csv ${DEAC_RECEIPT_CACHE_KEYS})
 
-    list(REMOVE_DUPLICATES DEAC_RECEIPT_DEPENDENCY_TARGETS)
-    list(SORT DEAC_RECEIPT_DEPENDENCY_TARGETS)
+    set(_registration_directory "${CMAKE_CURRENT_SOURCE_DIR}")
+    _deac_build_receipt_configuration_snapshot(
+        "${_registration_directory}" _receipt_generator
+        _receipt_configuration_mode _receipt_configurations)
+    if(_receipt_configuration_mode STREQUAL "multi")
+        set(_receipt_requires_config true)
+    else()
+        set(_receipt_requires_config false)
+    endif()
+    list(LENGTH _receipt_configurations _receipt_configuration_count)
+    _deac_build_receipt_normalize_generated_directory(
+        "${DEAC_RECEIPT_GENERATED_DIRECTORY}" "${CMAKE_BINARY_DIR}"
+        DEAC_RECEIPT_GENERATED_DIRECTORY)
+    _deac_build_receipt_normalize_receipt_path(
+        "${DEAC_RECEIPT_RECEIPT}" "${_receipt_requires_config}"
+        "${CMAKE_BINARY_DIR}" DEAC_RECEIPT_RECEIPT)
+
+    set(_canonical_dependency_targets)
+    set(_supported_dependency_types
+        EXECUTABLE STATIC_LIBRARY SHARED_LIBRARY MODULE_LIBRARY
+        OBJECT_LIBRARY INTERFACE_LIBRARY)
     foreach(_dependency_target IN LISTS DEAC_RECEIPT_DEPENDENCY_TARGETS)
+        if(NOT _dependency_target MATCHES "^[A-Za-z0-9_.:+-]+$")
+            message(FATAL_ERROR
+                "build-receipt dependency target name is not safely "
+                "representable")
+        endif()
         if(NOT TARGET "${_dependency_target}")
             message(FATAL_ERROR
                 "build-receipt dependency target does not exist: "
                 "${_dependency_target}")
         endif()
-        _deac_build_receipt_require_plain(
-            "${_dependency_target}" "build-receipt dependency target")
+        _deac_build_receipt_canonical_target(
+            "${_dependency_target}" _dependency_target)
+        get_target_property(_dependency_is_imported
+            "${_dependency_target}" IMPORTED)
+        if(_dependency_is_imported)
+            message(FATAL_ERROR
+                "build-receipt dependency target must be buildable, not "
+                "imported: ${_dependency_target}")
+        endif()
+        get_target_property(_dependency_type "${_dependency_target}" TYPE)
+        list(FIND _supported_dependency_types "${_dependency_type}"
+            _dependency_type_index)
+        if(_dependency_type_index EQUAL -1)
+            message(FATAL_ERROR
+                "build-receipt dependency target has unsupported type "
+                "${_dependency_type}: ${_dependency_target}")
+        endif()
+        list(FIND _canonical_dependency_targets "${_dependency_target}"
+            _dependency_index)
+        if(NOT _dependency_index EQUAL -1)
+            message(FATAL_ERROR
+                "build-receipt dependency targets must be unique after "
+                "alias resolution: ${_dependency_target}")
+        endif()
+        list(APPEND _canonical_dependency_targets "${_dependency_target}")
     endforeach()
-    string(JOIN "," _dependency_targets_csv
-        ${DEAC_RECEIPT_DEPENDENCY_TARGETS})
+    set(DEAC_RECEIPT_DEPENDENCY_TARGETS
+        ${_canonical_dependency_targets})
+    list(SORT DEAC_RECEIPT_DEPENDENCY_TARGETS)
+    set(_codemodel_dependency_targets)
+    set(_interface_dependency_targets)
+    foreach(_dependency_target IN LISTS DEAC_RECEIPT_DEPENDENCY_TARGETS)
+        get_target_property(
+            _dependency_type "${_dependency_target}" TYPE)
+        if(_dependency_type STREQUAL "INTERFACE_LIBRARY")
+            # Interface libraries are real direct graph contracts but CMake's
+            # File API omits them from both the codemodel target list and the
+            # consumer dependency IDs.  Verify the final target property here,
+            # then carry an explicit name/type record into the build-time
+            # receipt while the resolved provider remains independently
+            # checked in the File API link fragments below.
+            list(APPEND _interface_dependency_targets
+                "${_dependency_target}")
+        else()
+            list(APPEND _codemodel_dependency_targets
+                "${_dependency_target}")
+        endif()
+    endforeach()
+    set_property(TARGET "${target_name}" PROPERTY
+        DEAC_BUILD_RECEIPT_INTERFACE_DEPENDENCIES
+        "${_interface_dependency_targets}")
+    _deac_build_receipt_validate_interface_dependencies("${target_name}")
+    string(JOIN "," _codemodel_dependency_targets_csv
+        ${_codemodel_dependency_targets})
+    string(JOIN "," _interface_dependency_targets_csv
+        ${_interface_dependency_targets})
 
-    if(CMAKE_CONFIGURATION_TYPES)
-        string(FIND "${DEAC_RECEIPT_RECEIPT}" "$<CONFIG>" _config_position)
-        if(_config_position EQUAL -1)
-            message(FATAL_ERROR
-                "multi-config build receipts require $<CONFIG> in RECEIPT")
-        endif()
-        set(_receipt_configurations ${CMAKE_CONFIGURATION_TYPES})
-    else()
-        set(_receipt_configurations "${CMAKE_BUILD_TYPE}")
+    list(LENGTH DEAC_RECEIPT_REQUIRED_LINK_LIBRARY_NAMES
+        _required_link_library_name_count)
+    list(LENGTH DEAC_RECEIPT_REQUIRED_LINK_LIBRARY_ARTIFACTS
+        _required_link_library_artifact_count)
+    if(NOT _required_link_library_name_count EQUAL
+            _required_link_library_artifact_count)
+        message(FATAL_ERROR
+            "build-receipt required link-library names and artifacts must "
+            "have equal lengths")
     endif()
-    foreach(_configuration IN LISTS _receipt_configurations)
-        if(NOT _configuration MATCHES "^[A-Za-z0-9_.+-]+$" OR
-                _configuration STREQUAL "." OR
-                _configuration STREQUAL "..")
-            message(FATAL_ERROR
-                "build-receipt configuration is not path-safe: "
-                "${_configuration}")
-        endif()
-    endforeach()
+    set(_required_link_library_count
+        ${_required_link_library_name_count})
+    set(_required_link_library_arguments
+        "-DDEAC_BUILD_RECEIPT_REQUIRED_LINK_LIBRARY_COUNT:STRING=${_required_link_library_count}")
+    set(_required_link_library_names)
+    set(_required_link_library_artifacts)
+    list(LENGTH _receipt_configurations _artifact_configuration_count)
+    if(_artifact_configuration_count GREATER 0)
+        math(EXPR _artifact_configuration_last
+            "${_artifact_configuration_count} - 1")
+        foreach(_artifact_configuration_index
+                RANGE 0 ${_artifact_configuration_last})
+            set(_selected_link_artifacts_${_artifact_configuration_index})
+        endforeach()
+    endif()
+    if(_required_link_library_count GREATER 0)
+        math(EXPR _required_link_library_last
+            "${_required_link_library_count} - 1")
+        foreach(_required_link_library_index
+                RANGE 0 ${_required_link_library_last})
+            list(GET DEAC_RECEIPT_REQUIRED_LINK_LIBRARY_NAMES
+                ${_required_link_library_index} _link_library_name)
+            list(GET DEAC_RECEIPT_REQUIRED_LINK_LIBRARY_ARTIFACTS
+                ${_required_link_library_index} _link_library_artifact)
+            if(NOT _link_library_name MATCHES "^[A-Za-z0-9_.:+-]+$")
+                message(FATAL_ERROR
+                    "build-receipt link-library name is not path-safe: "
+                    "${_link_library_name}")
+            endif()
+            if(_link_library_name IN_LIST _required_link_library_names)
+                message(FATAL_ERROR
+                    "build-receipt required link-library names must be unique: "
+                    "${_link_library_name}")
+            endif()
+            _deac_build_receipt_normalize_link_library_artifact(
+                "${_link_library_artifact}" _link_library_artifact
+                _selected_link_library_artifacts)
+            list(LENGTH _selected_link_library_artifacts
+                _selected_link_library_artifact_count)
+            if(NOT _selected_link_library_artifact_count EQUAL
+                    _artifact_configuration_count)
+                message(FATAL_ERROR
+                    "build-receipt link-library artifact selection count "
+                    "does not match configured build types")
+            endif()
+            foreach(_artifact_configuration_index
+                    RANGE 0 ${_artifact_configuration_last})
+                list(GET _selected_link_library_artifacts
+                    ${_artifact_configuration_index} _selected_artifact)
+                set(_selected_artifact_variable
+                    "_selected_link_artifacts_${_artifact_configuration_index}")
+                list(FIND ${_selected_artifact_variable}
+                    "${_selected_artifact}" _selected_artifact_index)
+                if(NOT _selected_artifact_index EQUAL -1)
+                    list(GET _receipt_configurations
+                        ${_artifact_configuration_index}
+                        _artifact_configuration)
+                    message(FATAL_ERROR
+                        "build-receipt required link-library artifacts must "
+                        "be unique in configuration "
+                        "${_artifact_configuration}: ${_selected_artifact}")
+                endif()
+                list(APPEND ${_selected_artifact_variable}
+                    "${_selected_artifact}")
+            endforeach()
+            if(_link_library_artifact IN_LIST
+                    _required_link_library_artifacts)
+                message(FATAL_ERROR
+                    "build-receipt required link-library artifacts must be "
+                    "unique: ${_link_library_artifact}")
+            endif()
+            list(APPEND _required_link_library_names
+                "${_link_library_name}")
+            list(APPEND _required_link_library_artifacts
+                "${_link_library_artifact}")
+            list(APPEND _required_link_library_arguments
+                "-DDEAC_BUILD_RECEIPT_REQUIRED_LINK_LIBRARY_NAME_${_required_link_library_index}:STRING=${_link_library_name}"
+                "-DDEAC_BUILD_RECEIPT_REQUIRED_LINK_LIBRARY_ARTIFACT_${_required_link_library_index}:FILEPATH=${_link_library_artifact}")
+        endforeach()
+    endif()
 
     get_filename_component(
         _source_root "${DEAC_RECEIPT_SOURCE_ROOT}" REALPATH)
@@ -568,12 +1546,11 @@ function(deac_target_add_build_receipt target_name)
         CACHE 2
         TOOLCHAINS 1)
 
-    _deac_build_receipt_reject_rule_override_routes()
-
-    foreach(_validated_target
-            "${target_name}" ${DEAC_RECEIPT_DEPENDENCY_TARGETS})
-        _deac_build_receipt_reject_launchers("${_validated_target}")
-    endforeach()
+    set(_validated_targets
+        "${target_name}" ${DEAC_RECEIPT_DEPENDENCY_TARGETS})
+    _deac_build_receipt_validate_target_scopes(
+        "${target_name}" "${_registration_directory}"
+        ${_validated_targets})
 
     _deac_build_receipt_query_enabled_languages(_enabled_languages)
     _deac_build_receipt_reject_unsupported_languages(${_enabled_languages})
@@ -583,15 +1560,33 @@ function(deac_target_add_build_receipt target_name)
     foreach(_language CXX CUDA)
         if(_language IN_LIST _enabled_languages)
             _deac_build_receipt_snapshot_tool(
-                "${_language}" _language_arguments _language_fingerprint)
+                "${_language}" _language_arguments _language_fingerprint
+                _language_tool_path _language_tool_real_path
+                _language_tool_sha256)
             list(APPEND _receipt_languages "${_language}")
             list(APPEND _tool_arguments ${_language_arguments})
             string(APPEND _toolchain_fingerprint_material
                 "${_language_fingerprint}")
-            _deac_build_receipt_rule_fingerprint(
-                "${_language}" _language_rule_fingerprint)
+            _deac_build_receipt_target_rule_fingerprint(
+                "${_language}" "${_registration_directory}"
+                _language_rule_fingerprint
+                ${_validated_targets})
+            if(_language STREQUAL "CXX")
+                string(SHA256 _cxx_rule_fingerprint
+                    "${_language_rule_fingerprint}")
+            endif()
             string(APPEND _toolchain_fingerprint_material
                 "${_language_rule_fingerprint}")
+            set(_compiler_variable "CMAKE_${_language}_COMPILER")
+            set_property(TARGET "${target_name}" PROPERTY
+                "DEAC_BUILD_RECEIPT_${_compiler_variable}_PATH"
+                "${_language_tool_path}")
+            set_property(TARGET "${target_name}" PROPERTY
+                "DEAC_BUILD_RECEIPT_${_compiler_variable}_REAL_PATH"
+                "${_language_tool_real_path}")
+            set_property(TARGET "${target_name}" PROPERTY
+                "DEAC_BUILD_RECEIPT_${_compiler_variable}_SHA256"
+                "${_language_tool_sha256}")
         endif()
     endforeach()
     if(NOT "CXX" IN_LIST _receipt_languages)
@@ -603,10 +1598,20 @@ function(deac_target_add_build_receipt target_name)
     foreach(_archive_tool IN LISTS _archive_tools)
         _deac_build_receipt_snapshot_named_tool(
             "${_archive_tool}" _archive_tool_arguments
-            _archive_tool_fingerprint)
+            _archive_tool_fingerprint _archive_tool_path
+            _archive_tool_real_path _archive_tool_sha256)
         list(APPEND _tool_arguments ${_archive_tool_arguments})
         string(APPEND _toolchain_fingerprint_material
             "${_archive_tool_fingerprint}")
+        set_property(TARGET "${target_name}" PROPERTY
+            "DEAC_BUILD_RECEIPT_${_archive_tool}_PATH"
+            "${_archive_tool_path}")
+        set_property(TARGET "${target_name}" PROPERTY
+            "DEAC_BUILD_RECEIPT_${_archive_tool}_REAL_PATH"
+            "${_archive_tool_real_path}")
+        set_property(TARGET "${target_name}" PROPERTY
+            "DEAC_BUILD_RECEIPT_${_archive_tool}_SHA256"
+            "${_archive_tool_sha256}")
     endforeach()
     string(JOIN "," _archive_tools_csv ${_archive_tools})
 
@@ -645,8 +1650,21 @@ function(deac_target_add_build_receipt target_name)
             "${_fingerprinted_target}" TYPE)
         if(_fingerprinted_type MATCHES
                 "^(EXECUTABLE|MODULE_LIBRARY|OBJECT_LIBRARY|SHARED_LIBRARY|STATIC_LIBRARY)$")
-            target_compile_definitions("${_fingerprinted_target}" PRIVATE
-                "DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256=${_toolchain_fingerprint}")
+            get_target_property(_injected_fingerprint
+                "${_fingerprinted_target}"
+                DEAC_BUILD_RECEIPT_INJECTED_TOOLCHAIN_FINGERPRINT_SHA256)
+            if(_injected_fingerprint MATCHES "-NOTFOUND$")
+                target_compile_definitions("${_fingerprinted_target}" PRIVATE
+                    "DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256=${_toolchain_fingerprint}")
+                set_property(TARGET "${_fingerprinted_target}" PROPERTY
+                    DEAC_BUILD_RECEIPT_INJECTED_TOOLCHAIN_FINGERPRINT_SHA256
+                    "${_toolchain_fingerprint}")
+            elseif(NOT _injected_fingerprint STREQUAL
+                    _toolchain_fingerprint)
+                message(FATAL_ERROR
+                    "build-receipt target ${_fingerprinted_target} is shared "
+                    "by incompatible toolchain fingerprints")
+            endif()
         endif()
     endforeach()
 
@@ -676,6 +1694,23 @@ function(deac_target_add_build_receipt target_name)
     set(_compiled_marker
         "${_configuration_directory}/${_receipt_identifier}.compiled")
 
+    set(_concrete_output_paths)
+    foreach(_configuration IN LISTS _receipt_configurations)
+        list(APPEND _concrete_output_paths
+            "${DEAC_RECEIPT_GENERATED_DIRECTORY}/${_configuration}/${_receipt_identifier}.cpp"
+            "${DEAC_RECEIPT_GENERATED_DIRECTORY}/${_configuration}/${_receipt_identifier}.refresh"
+            "${DEAC_RECEIPT_GENERATED_DIRECTORY}/${_configuration}/${_receipt_identifier}.rebuild"
+            "${DEAC_RECEIPT_GENERATED_DIRECTORY}/${_configuration}/${_receipt_identifier}.compiled")
+        string(REPLACE "$<CONFIG>" "${_configuration}"
+            _configured_receipt "${_receipt}")
+        list(APPEND _concrete_output_paths "${_configured_receipt}")
+    endforeach()
+    list(REMOVE_DUPLICATES _concrete_output_paths)
+    foreach(_concrete_output_path IN LISTS _concrete_output_paths)
+        _deac_build_receipt_reject_descendant_symlinks(
+            "${_concrete_output_path}" "${CMAKE_BINARY_DIR}" "output path")
+    endforeach()
+
     # Source properties are keyed by the literal path passed to CMake.  A
     # property attached to the $<CONFIG>-spelled source is therefore not
     # applied to the concrete source path emitted by Makefile generators.
@@ -703,6 +1738,16 @@ function(deac_target_add_build_receipt target_name)
         BYPRODUCTS "${_generated_source}" "${_receipt}"
         COMMAND
             "${CMAKE_COMMAND}"
+            "-DDEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_COUNT:STRING=5"
+            "-DDEAC_BUILD_RECEIPT_VALIDATE_BUILD_ROOT:PATH=${CMAKE_BINARY_DIR}"
+            "-DDEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_0:FILEPATH=${_generated_source}"
+            "-DDEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_1:FILEPATH=${_receipt}"
+            "-DDEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_2:FILEPATH=${_compiled_marker}"
+            "-DDEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_3:FILEPATH=${_refresh}"
+            "-DDEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_4:FILEPATH=${_rebuild}"
+            -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/DeacBuildReceipt.cmake"
+        COMMAND
+            "${CMAKE_COMMAND}"
             "-DDEAC_BUILD_RECEIPT_SOURCE_ROOT:PATH=${_source_root}"
             "-DDEAC_BUILD_RECEIPT_CMAKE_SOURCE_ROOT:PATH=${CMAKE_SOURCE_DIR}"
             "-DDEAC_BUILD_RECEIPT_BUILD_ROOT:PATH=${CMAKE_BINARY_DIR}"
@@ -711,7 +1756,8 @@ function(deac_target_add_build_receipt target_name)
             "-DDEAC_BUILD_RECEIPT_CONFIGURATION:STRING=$<CONFIG>"
             "-DDEAC_BUILD_RECEIPT_BACKEND:STRING=${DEAC_RECEIPT_BACKEND}"
             "-DDEAC_BUILD_RECEIPT_CACHE_KEYS:STRING=${_cache_keys_csv}"
-            "-DDEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS:STRING=${_dependency_targets_csv}"
+            "-DDEAC_BUILD_RECEIPT_CODEMODEL_DEPENDENCY_TARGETS:STRING=${_codemodel_dependency_targets_csv}"
+            "-DDEAC_BUILD_RECEIPT_INTERFACE_DEPENDENCY_TARGETS:STRING=${_interface_dependency_targets_csv}"
             "-DDEAC_BUILD_RECEIPT_LANGUAGES:STRING=${_receipt_languages_csv}"
             "-DDEAC_BUILD_RECEIPT_ARCHIVE_TOOLS:STRING=${_archive_tools_csv}"
             "-DDEAC_BUILD_RECEIPT_TOOLCHAIN_FINGERPRINT:STRING=${_toolchain_fingerprint}"
@@ -721,6 +1767,7 @@ function(deac_target_add_build_receipt target_name)
             "-DDEAC_BUILD_RECEIPT_OUTPUT_SOURCE:FILEPATH=${_generated_source}"
             "-DDEAC_BUILD_RECEIPT_OUTPUT_RECEIPT:FILEPATH=${_receipt}"
             "-DDEAC_BUILD_RECEIPT_PREVIOUS_COMPILE_MARKER:FILEPATH=${_compiled_marker}"
+            ${_required_link_library_arguments}
             ${_git_argument}
             ${_tool_arguments}
             -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/GenerateDeacBuildReceipt.cmake"
@@ -768,6 +1815,12 @@ function(deac_target_add_build_receipt target_name)
             "-DDEAC_BUILD_RECEIPT_CMAKE_SHA256:STRING=${_cmake_sha256}"
             ${_tool_arguments}
             -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/VerifyDeacBuildReceiptTools.cmake"
+        COMMAND
+            "${CMAKE_COMMAND}"
+            "-DDEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_COUNT:STRING=1"
+            "-DDEAC_BUILD_RECEIPT_VALIDATE_BUILD_ROOT:PATH=${CMAKE_BINARY_DIR}"
+            "-DDEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_0:FILEPATH=${_compiled_marker}"
+            -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/DeacBuildReceipt.cmake"
         COMMAND "${CMAKE_COMMAND}" -E touch "${_compiled_marker}"
         COMMENT "Verifying build-receipt tool bytes for ${target_name}"
         VERBATIM)
@@ -775,10 +1828,121 @@ function(deac_target_add_build_receipt target_name)
         ADDITIONAL_CLEAN_FILES
             "${_generated_source};${_receipt};${_compiled_marker}")
 
+    _deac_build_receipt_interface_fingerprint(
+        _interface_fingerprint ${_interface_dependency_targets})
+    set_property(TARGET "${target_name}" PROPERTY
+        DEAC_BUILD_RECEIPT_REGISTRATION_DIRECTORY
+        "${_registration_directory}")
+    set_property(TARGET "${target_name}" PROPERTY
+        DEAC_BUILD_RECEIPT_VALIDATED_TARGETS "${_validated_targets}")
+    set_property(TARGET "${target_name}" PROPERTY
+        DEAC_BUILD_RECEIPT_CXX_RULE_FINGERPRINT
+        "${_cxx_rule_fingerprint}")
+    set_property(TARGET "${target_name}" PROPERTY
+        DEAC_BUILD_RECEIPT_INTERFACE_FINGERPRINT
+        "${_interface_fingerprint}")
+    set_property(TARGET "${target_name}" PROPERTY
+        DEAC_BUILD_RECEIPT_BUILD_ROOT "${CMAKE_BINARY_DIR}")
+    set_property(TARGET "${target_name}" PROPERTY
+        DEAC_BUILD_RECEIPT_OUTPUT_PATHS "${_concrete_output_paths}")
+    set_property(TARGET "${target_name}" PROPERTY
+        DEAC_BUILD_RECEIPT_GENERATOR "${_receipt_generator}")
+    set_property(TARGET "${target_name}" PROPERTY
+        DEAC_BUILD_RECEIPT_CONFIGURATION_MODE
+        "${_receipt_configuration_mode}")
+    set_property(TARGET "${target_name}" PROPERTY
+        DEAC_BUILD_RECEIPT_CONFIGURATIONS "${_receipt_configurations}")
+    set_property(TARGET "${target_name}" PROPERTY
+        DEAC_BUILD_RECEIPT_TOP_LEVEL_SOURCE_DIRECTORY
+        "${CMAKE_SOURCE_DIR}")
+    _deac_build_receipt_validate_seal("${target_name}")
+
+    set_property(DIRECTORY APPEND PROPERTY
+        DEAC_BUILD_RECEIPT_SEALED_TARGETS "${target_name}")
+    get_property(_directory_seal_scheduled DIRECTORY
+        PROPERTY DEAC_BUILD_RECEIPT_SEAL_SCHEDULED)
+    if(NOT _directory_seal_scheduled)
+        set_property(DIRECTORY PROPERTY
+            DEAC_BUILD_RECEIPT_SEAL_SCHEDULED true)
+        cmake_language(DEFER ID deac_build_receipt_directory_seal CALL
+            _deac_build_receipt_validate_current_directory_seals)
+    endif()
+
+    set_property(GLOBAL APPEND PROPERTY
+        DEAC_BUILD_RECEIPT_SEALED_TARGETS "${target_name}")
+    get_property(_top_level_seal_scheduled GLOBAL
+        PROPERTY DEAC_BUILD_RECEIPT_TOP_LEVEL_SEAL_SCHEDULED)
+    if(NOT _top_level_seal_scheduled)
+        set_property(GLOBAL PROPERTY
+            DEAC_BUILD_RECEIPT_TOP_LEVEL_SEAL_SCHEDULED true)
+        cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}"
+            ID deac_build_receipt_top_level_seal CALL
+            _deac_build_receipt_validate_top_level_seals)
+    endif()
+
     set(DEAC_BUILD_RECEIPT "${_receipt}" PARENT_SCOPE)
     set(DEAC_BUILD_RECEIPT_GENERATED_SOURCE
         "${DEAC_RECEIPT_GENERATED_DIRECTORY}/$<CONFIG>/${_receipt_identifier}.cpp"
         PARENT_SCOPE)
+    # Expose the primary custom-command output for callers that need a
+    # receipt-only verification target.  Depending on the generated source
+    # BYPRODUCT directly is not portable with Unix Makefiles because its rule
+    # remains owned by the consuming target's build.make.
+    set(DEAC_BUILD_RECEIPT_REFRESH "${_refresh}" PARENT_SCOPE)
     set(DEAC_BUILD_RECEIPT_TOOLCHAIN_FINGERPRINT
         "${_toolchain_fingerprint}" PARENT_SCOPE)
 endfunction()
+
+if(CMAKE_SCRIPT_MODE_FILE STREQUAL CMAKE_CURRENT_LIST_FILE AND
+        DEFINED DEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_COUNT)
+    if(NOT DEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_COUNT MATCHES "^[1-9][0-9]*$")
+        message(FATAL_ERROR
+            "DEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_COUNT must be positive")
+    endif()
+    if(NOT DEFINED DEAC_BUILD_RECEIPT_VALIDATE_BUILD_ROOT OR
+            "${DEAC_BUILD_RECEIPT_VALIDATE_BUILD_ROOT}" STREQUAL "")
+        message(FATAL_ERROR
+            "DEAC_BUILD_RECEIPT_VALIDATE_BUILD_ROOT is required")
+    endif()
+    _deac_build_receipt_require_safe_path_text(
+        "${DEAC_BUILD_RECEIPT_VALIDATE_BUILD_ROOT}" "build root")
+    if(NOT IS_ABSOLUTE "${DEAC_BUILD_RECEIPT_VALIDATE_BUILD_ROOT}")
+        message(FATAL_ERROR "build-receipt build root must be absolute")
+    endif()
+    set(_validated_build_root
+        "${DEAC_BUILD_RECEIPT_VALIDATE_BUILD_ROOT}")
+    cmake_path(NORMAL_PATH _validated_build_root)
+    if(NOT _validated_build_root STREQUAL
+            DEAC_BUILD_RECEIPT_VALIDATE_BUILD_ROOT)
+        message(FATAL_ERROR "build-receipt build root must be normalized")
+    endif()
+
+    math(EXPR _validated_output_last
+        "${DEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_COUNT} - 1")
+    foreach(_validated_output_index RANGE 0 ${_validated_output_last})
+        set(_validated_output_variable
+            "DEAC_BUILD_RECEIPT_VALIDATE_OUTPUT_${_validated_output_index}")
+        if(NOT DEFINED ${_validated_output_variable} OR
+                "${${_validated_output_variable}}" STREQUAL "")
+            message(FATAL_ERROR
+                "${_validated_output_variable} is required")
+        endif()
+        set(_validated_output_path "${${_validated_output_variable}}")
+        _deac_build_receipt_require_safe_path_text(
+            "${_validated_output_path}" "output path")
+        if(NOT IS_ABSOLUTE "${_validated_output_path}" OR
+                "${_validated_output_path}" MATCHES "(^|/)\\.\\.?(/|$)")
+            message(FATAL_ERROR
+                "build-receipt output path must be absolute and normalized")
+        endif()
+        set(_normalized_output_path "${_validated_output_path}")
+        cmake_path(NORMAL_PATH _normalized_output_path)
+        if(NOT _normalized_output_path STREQUAL _validated_output_path)
+            message(FATAL_ERROR
+                "build-receipt output path must be normalized")
+        endif()
+        _deac_build_receipt_reject_descendant_symlinks(
+            "${_validated_output_path}" "${_validated_build_root}"
+            "output path")
+    endforeach()
+endif()

--- a/src/cmake/DeacBuildReceipt.cmake
+++ b/src/cmake/DeacBuildReceipt.cmake
@@ -11,6 +11,116 @@ function(_deac_build_receipt_require_plain value label)
     endif()
 endfunction()
 
+function(_deac_build_receipt_require_single_command value label)
+    if("${value}" MATCHES "[;\r\n]")
+        message(FATAL_ERROR
+            "build-receipt ${label} contains shell control syntax")
+    endif()
+
+    # Rule templates may quote or escape literal path characters.  Reject
+    # control operators and command substitution only when the shell would
+    # interpret them, while leaving CMake's <PLACEHOLDER> and $<GENEX>
+    # syntax untouched.
+    string(LENGTH "${value}" _length)
+    set(_index 0)
+    set(_quote "")
+    set(_escaped false)
+    while(_index LESS _length)
+        string(SUBSTRING "${value}" ${_index} 1 _character)
+        math(EXPR _next_index "${_index} + 1")
+        set(_next_character "")
+        if(_next_index LESS _length)
+            string(SUBSTRING "${value}" ${_next_index} 1 _next_character)
+        endif()
+
+        if(_escaped)
+            set(_escaped false)
+        elseif(_quote STREQUAL "'")
+            if(_character STREQUAL "'")
+                set(_quote "")
+            endif()
+        elseif(_quote STREQUAL "\"")
+            if(_character STREQUAL "\\")
+                set(_escaped true)
+            elseif(_character STREQUAL "\"")
+                set(_quote "")
+            elseif(_character STREQUAL "`" OR
+                    (_character STREQUAL "$" AND
+                     _next_character STREQUAL "("))
+                message(FATAL_ERROR
+                    "build-receipt ${label} contains shell control syntax")
+            endif()
+        elseif(_character STREQUAL "\\")
+            set(_escaped true)
+        elseif(_character STREQUAL "'" OR _character STREQUAL "\"")
+            set(_quote "${_character}")
+        elseif(_character MATCHES "[|&`]" OR
+                (_character STREQUAL "$" AND
+                 _next_character STREQUAL "("))
+            message(FATAL_ERROR
+                "build-receipt ${label} contains shell control syntax")
+        endif()
+        math(EXPR _index "${_index} + 1")
+    endwhile()
+    if(_escaped OR NOT _quote STREQUAL "")
+        message(FATAL_ERROR
+            "build-receipt ${label} has incomplete shell quoting")
+    endif()
+endfunction()
+
+function(_deac_build_receipt_snapshot_named_tool
+        variable output_arguments output_fingerprint_material)
+    if(NOT DEFINED ${variable} OR "${${variable}}" STREQUAL "")
+        message(FATAL_ERROR "build receipt requires ${variable}")
+    endif()
+    _deac_build_receipt_require_plain(
+        "${${variable}}" "${variable} executable identity")
+    if(NOT IS_ABSOLUTE "${${variable}}")
+        message(FATAL_ERROR
+            "build-receipt ${variable} must be an absolute executable path")
+    endif()
+    get_filename_component(_tool_real "${${variable}}" REALPATH)
+    if(NOT EXISTS "${_tool_real}" OR IS_DIRECTORY "${_tool_real}")
+        message(FATAL_ERROR
+            "build-receipt ${variable} is not a regular file: ${${variable}}")
+    endif()
+    file(SHA256 "${_tool_real}" _tool_sha256)
+    _deac_build_receipt_require_plain(
+        "${_tool_real}" "${variable} executable identity")
+
+    set(_arguments
+        "-DDEAC_BUILD_RECEIPT_CONFIGURED_${variable}_PATH:FILEPATH=${${variable}}"
+        "-DDEAC_BUILD_RECEIPT_CONFIGURED_${variable}_REAL_PATH:FILEPATH=${_tool_real}"
+        "-DDEAC_BUILD_RECEIPT_CONFIGURED_${variable}_SHA256:STRING=${_tool_sha256}")
+    set(_fingerprint_material "")
+    foreach(_field PATH REAL_PATH SHA256)
+        if(_field STREQUAL "PATH")
+            set(_value "${${variable}}")
+        elseif(_field STREQUAL "REAL_PATH")
+            set(_value "${_tool_real}")
+        else()
+            set(_value "${_tool_sha256}")
+        endif()
+        string(LENGTH "${_value}" _value_length)
+        string(APPEND _fingerprint_material
+            "${variable}.${_field}:${_value_length}:${_value}\n")
+    endforeach()
+    set(${output_arguments} "${_arguments}" PARENT_SCOPE)
+    set(${output_fingerprint_material}
+        "${_fingerprint_material}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_build_receipt_reject_unsupported_languages)
+    foreach(_unsupported_language CUDA HIP)
+        if(_unsupported_language IN_LIST ARGN)
+            message(FATAL_ERROR
+                "build receipts fail closed for the native CMake "
+                "${_unsupported_language} language until its intermediate "
+                "device-link rules are represented and compiler-gated")
+        endif()
+    endforeach()
+endfunction()
+
 function(_deac_build_receipt_snapshot_tool
         language output_arguments output_fingerprint_material)
     if(NOT DEFINED CMAKE_${language}_COMPILER OR
@@ -114,15 +224,29 @@ function(_deac_build_receipt_reject_launchers target_name)
             "LINK_WHAT_YOU_USE")
     endif()
 
-    get_target_property(
-        _interprocedural_optimization
-        "${target_name}" INTERPROCEDURAL_OPTIMIZATION)
-    if(_interprocedural_optimization AND
-            NOT _interprocedural_optimization MATCHES "-NOTFOUND$")
-        message(FATAL_ERROR
-            "build receipts do not yet support target ${target_name} "
-            "INTERPROCEDURAL_OPTIMIZATION")
+    set(_ipo_properties INTERPROCEDURAL_OPTIMIZATION)
+    if(CMAKE_CONFIGURATION_TYPES)
+        set(_ipo_configurations ${CMAKE_CONFIGURATION_TYPES})
+    else()
+        set(_ipo_configurations "${CMAKE_BUILD_TYPE}")
     endif()
+    foreach(_configuration IN LISTS _ipo_configurations)
+        string(TOUPPER "${_configuration}" _configuration_upper)
+        list(APPEND _ipo_properties
+            "INTERPROCEDURAL_OPTIMIZATION_${_configuration_upper}")
+    endforeach()
+    list(REMOVE_DUPLICATES _ipo_properties)
+    foreach(_ipo_property IN LISTS _ipo_properties)
+        get_target_property(
+            _interprocedural_optimization
+            "${target_name}" "${_ipo_property}")
+        if(_interprocedural_optimization AND
+                NOT _interprocedural_optimization MATCHES "-NOTFOUND$")
+            message(FATAL_ERROR
+                "build receipts do not yet support target ${target_name} "
+                "${_ipo_property}")
+        endif()
+    endforeach()
 
     foreach(_launcher_property
             RULE_LAUNCH_COMPILE RULE_LAUNCH_CUSTOM RULE_LAUNCH_LINK)
@@ -212,10 +336,8 @@ function(_deac_build_receipt_rule_fingerprint
             message(FATAL_ERROR "build receipt requires ${_variable}")
         endif()
         set(_template "${${_variable}}")
-        if(_template MATCHES "[;\r\n]")
-            message(FATAL_ERROR
-                "build receipt does not support multi-command ${_variable}")
-        endif()
+        _deac_build_receipt_require_single_command(
+            "${_template}" "${_variable}")
         if(_rule STREQUAL "COMPILE_OBJECT")
             set(_allowed_prefix "<CMAKE_${language}_COMPILER>")
             foreach(_placeholder DEFINES INCLUDES SOURCE OBJECT FLAGS)
@@ -274,10 +396,8 @@ function(_deac_build_receipt_rule_fingerprint
             message(FATAL_ERROR "build receipt requires ${_variable}")
         endif()
         set(_template "${${_variable}}")
-        if(_template MATCHES "[;\r\n]")
-            message(FATAL_ERROR
-                "build receipt does not support multi-command ${_variable}")
-        endif()
+        _deac_build_receipt_require_single_command(
+            "${_template}" "${_variable}")
         if(_rule STREQUAL "ARCHIVE_FINISH")
             set(_allowed_prefix "<CMAKE_RANLIB>")
         else()
@@ -418,17 +538,10 @@ function(deac_target_add_build_receipt target_name)
     endforeach()
 
     get_property(_enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
-    foreach(_unsupported_language CUDA HIP)
-        if(_unsupported_language IN_LIST _enabled_languages)
-            message(FATAL_ERROR
-                "build receipts fail closed for the native CMake "
-                "${_unsupported_language} language until its intermediate "
-                "device-link rules are represented and compiler-gated")
-        endif()
-    endforeach()
+    _deac_build_receipt_reject_unsupported_languages(${_enabled_languages})
     set(_receipt_languages)
     set(_tool_arguments)
-    set(_toolchain_fingerprint_material "deac-build-toolchain-v1\n")
+    set(_toolchain_fingerprint_material "deac-build-toolchain-v2\n")
     foreach(_language CXX CUDA)
         if(_language IN_LIST _enabled_languages)
             _deac_build_receipt_snapshot_tool(
@@ -447,6 +560,17 @@ function(deac_target_add_build_receipt target_name)
         message(FATAL_ERROR "build receipt requires the CXX language")
     endif()
     string(JOIN "," _receipt_languages_csv ${_receipt_languages})
+
+    set(_archive_tools CMAKE_AR CMAKE_RANLIB)
+    foreach(_archive_tool IN LISTS _archive_tools)
+        _deac_build_receipt_snapshot_named_tool(
+            "${_archive_tool}" _archive_tool_arguments
+            _archive_tool_fingerprint)
+        list(APPEND _tool_arguments ${_archive_tool_arguments})
+        string(APPEND _toolchain_fingerprint_material
+            "${_archive_tool_fingerprint}")
+    endforeach()
+    string(JOIN "," _archive_tools_csv ${_archive_tools})
 
     get_filename_component(_cmake_real "${CMAKE_COMMAND}" REALPATH)
     if(NOT EXISTS "${_cmake_real}" OR IS_DIRECTORY "${_cmake_real}")
@@ -472,8 +596,9 @@ function(deac_target_add_build_receipt target_name)
     string(SHA256 _toolchain_fingerprint
         "${_toolchain_fingerprint_material}")
 
-    # Changing compiler or CMake bytes followed by a required reconfigure must
-    # invalidate every object, even when the compiler pathname is unchanged.
+    # Changing compiler, archive-tool, or CMake bytes followed by a required
+    # reconfigure must invalidate every object, even when a tool pathname is
+    # unchanged.
     # The same definition is visible in the File API compile groups recorded
     # below, binding that invalidation key into the receipt itself.
     foreach(_fingerprinted_target
@@ -510,6 +635,8 @@ function(deac_target_add_build_receipt target_name)
         "${_configuration_directory}/${_receipt_identifier}.refresh")
     set(_rebuild
         "${_configuration_directory}/${_receipt_identifier}.rebuild")
+    set(_compiled_marker
+        "${_configuration_directory}/${_receipt_identifier}.compiled")
 
     # Source properties are keyed by the literal path passed to CMake.  A
     # property attached to the $<CONFIG>-spelled source is therefore not
@@ -548,12 +675,14 @@ function(deac_target_add_build_receipt target_name)
             "-DDEAC_BUILD_RECEIPT_CACHE_KEYS:STRING=${_cache_keys_csv}"
             "-DDEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS:STRING=${_dependency_targets_csv}"
             "-DDEAC_BUILD_RECEIPT_LANGUAGES:STRING=${_receipt_languages_csv}"
+            "-DDEAC_BUILD_RECEIPT_ARCHIVE_TOOLS:STRING=${_archive_tools_csv}"
             "-DDEAC_BUILD_RECEIPT_TOOLCHAIN_FINGERPRINT:STRING=${_toolchain_fingerprint}"
             "-DDEAC_BUILD_RECEIPT_CMAKE_PATH:FILEPATH=${CMAKE_COMMAND}"
             "-DDEAC_BUILD_RECEIPT_CMAKE_REAL_PATH:FILEPATH=${_cmake_real}"
             "-DDEAC_BUILD_RECEIPT_CMAKE_SHA256:STRING=${_cmake_sha256}"
             "-DDEAC_BUILD_RECEIPT_OUTPUT_SOURCE:FILEPATH=${_generated_source}"
             "-DDEAC_BUILD_RECEIPT_OUTPUT_RECEIPT:FILEPATH=${_receipt}"
+            "-DDEAC_BUILD_RECEIPT_PREVIOUS_COMPILE_MARKER:FILEPATH=${_compiled_marker}"
             ${_git_argument}
             ${_tool_arguments}
             -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/GenerateDeacBuildReceipt.cmake"
@@ -569,8 +698,10 @@ function(deac_target_add_build_receipt target_name)
     add_custom_command(
         # This symbolic output separates receipt generation from the normal
         # generated-source relationship that CMake otherwise treats as
-        # timestamp-only.  Object and link rules depend on the always-missing
-        # token, so coarse filesystem timestamps cannot suppress a rebuild.
+        # timestamp-only.  Make object and link rules depend on the
+        # always-missing token, so coarse filesystem timestamps cannot suppress
+        # a rebuild.  Ninja additionally observes the explicitly touched
+        # generated source from the refresh edge.
         OUTPUT "${_rebuild}"
         COMMAND "${CMAKE_COMMAND}" -E true
         DEPENDS "${_refresh}"
@@ -585,23 +716,26 @@ function(deac_target_add_build_receipt target_name)
     target_include_directories("${target_name}" PRIVATE
         "${_support_directory}")
 
-    # This catches persistent compiler/CMake replacement after receipt
-    # generation but before the final link.  As with any ordinary build graph,
-    # an adversarial swap-and-restore between process invocations is outside
-    # CMake's attestation boundary.
+    # This catches persistent compiler/archive-tool/CMake replacement after
+    # receipt generation but before the final link.  As with any ordinary
+    # build graph, an adversarial swap-and-restore between process invocations
+    # is outside CMake's attestation boundary.
     add_custom_command(TARGET "${target_name}" PRE_LINK
         COMMAND
             "${CMAKE_COMMAND}"
             "-DDEAC_BUILD_RECEIPT_LANGUAGES:STRING=${_receipt_languages_csv}"
+            "-DDEAC_BUILD_RECEIPT_ARCHIVE_TOOLS:STRING=${_archive_tools_csv}"
             "-DDEAC_BUILD_RECEIPT_CMAKE_PATH:FILEPATH=${CMAKE_COMMAND}"
             "-DDEAC_BUILD_RECEIPT_CMAKE_REAL_PATH:FILEPATH=${_cmake_real}"
             "-DDEAC_BUILD_RECEIPT_CMAKE_SHA256:STRING=${_cmake_sha256}"
             ${_tool_arguments}
             -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/VerifyDeacBuildReceiptTools.cmake"
+        COMMAND "${CMAKE_COMMAND}" -E touch "${_compiled_marker}"
         COMMENT "Verifying build-receipt tool bytes for ${target_name}"
         VERBATIM)
     set_property(TARGET "${target_name}" APPEND PROPERTY
-        ADDITIONAL_CLEAN_FILES "${_generated_source};${_receipt}")
+        ADDITIONAL_CLEAN_FILES
+            "${_generated_source};${_receipt};${_compiled_marker}")
 
     set(DEAC_BUILD_RECEIPT "${_receipt}" PARENT_SCOPE)
     set(DEAC_BUILD_RECEIPT_GENERATED_SOURCE

--- a/src/cmake/DeacBuildReceipt.cmake
+++ b/src/cmake/DeacBuildReceipt.cmake
@@ -12,7 +12,7 @@ function(_deac_build_receipt_require_plain value label)
 endfunction()
 
 function(_deac_build_receipt_require_single_command value label)
-    if("${value}" MATCHES "[;\r\n]")
+    if("${value}" MATCHES "[\r\n]")
         message(FATAL_ERROR
             "build-receipt ${label} contains shell control syntax")
     endif()
@@ -33,7 +33,40 @@ function(_deac_build_receipt_require_single_command value label)
             string(SUBSTRING "${value}" ${_next_index} 1 _next_character)
         endif()
 
-        if(_escaped)
+        set(_handled_cmake_semicolon false)
+        if(_quote STREQUAL "" AND _character STREQUAL "\\")
+            # A backslash protecting CMake's list-valued semicolon is consumed
+            # before the generated recipe reaches the shell.  Therefore the
+            # rule template needs an even, nonzero run here so the emitted
+            # command retains an odd (shell-escaping) run.
+            set(_scan_index ${_index})
+            set(_backslash_count 0)
+            set(_scan_character "\\")
+            while(_scan_index LESS _length AND
+                    _scan_character STREQUAL "\\")
+                math(EXPR _backslash_count "${_backslash_count} + 1")
+                math(EXPR _scan_index "${_scan_index} + 1")
+                set(_scan_character "")
+                if(_scan_index LESS _length)
+                    string(SUBSTRING
+                        "${value}" ${_scan_index} 1 _scan_character)
+                endif()
+            endwhile()
+            if(_scan_character STREQUAL ";")
+                math(EXPR _backslash_remainder
+                    "${_backslash_count} % 2")
+                if(_backslash_remainder EQUAL 1)
+                    message(FATAL_ERROR
+                        "build-receipt ${label} contains shell control syntax")
+                endif()
+                set(_index ${_scan_index})
+                set(_handled_cmake_semicolon true)
+            endif()
+        endif()
+
+        if(_handled_cmake_semicolon)
+            # The scan already consumed the safe escaped semicolon.
+        elseif(_escaped)
             set(_escaped false)
         elseif(_quote STREQUAL "'")
             if(_character STREQUAL "'")
@@ -54,7 +87,7 @@ function(_deac_build_receipt_require_single_command value label)
             set(_escaped true)
         elseif(_character STREQUAL "'" OR _character STREQUAL "\"")
             set(_quote "${_character}")
-        elseif(_character MATCHES "[|&`]" OR
+        elseif(_character MATCHES "[;|&`]" OR
                 (_character STREQUAL "$" AND
                  _next_character STREQUAL "("))
             message(FATAL_ERROR
@@ -119,6 +152,11 @@ function(_deac_build_receipt_reject_unsupported_languages)
                 "device-link rules are represented and compiler-gated")
         endif()
     endforeach()
+endfunction()
+
+function(_deac_build_receipt_query_enabled_languages output)
+    get_property(_enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+    set(${output} "${_enabled_languages}" PARENT_SCOPE)
 endfunction()
 
 function(_deac_build_receipt_snapshot_tool
@@ -537,7 +575,7 @@ function(deac_target_add_build_receipt target_name)
         _deac_build_receipt_reject_launchers("${_validated_target}")
     endforeach()
 
-    get_property(_enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+    _deac_build_receipt_query_enabled_languages(_enabled_languages)
     _deac_build_receipt_reject_unsupported_languages(${_enabled_languages})
     set(_receipt_languages)
     set(_tool_arguments)

--- a/src/cmake/DeacBuildReceipt.cmake
+++ b/src/cmake/DeacBuildReceipt.cmake
@@ -1,0 +1,597 @@
+include_guard(GLOBAL)
+
+include(CMakeParseArguments)
+find_package(Git QUIET)
+
+function(_deac_build_receipt_require_plain value label)
+    if("${value}" MATCHES "[;\r\n]")
+        message(FATAL_ERROR
+            "${label} contains a list separator or line break and cannot be "
+            "represented safely in the build-receipt command")
+    endif()
+endfunction()
+
+function(_deac_build_receipt_snapshot_tool
+        language output_arguments output_fingerprint_material)
+    if(NOT DEFINED CMAKE_${language}_COMPILER OR
+            "${CMAKE_${language}_COMPILER}" STREQUAL "")
+        message(FATAL_ERROR
+            "build receipt requires CMAKE_${language}_COMPILER")
+    endif()
+    get_filename_component(
+        _compiler_real "${CMAKE_${language}_COMPILER}" REALPATH)
+    if(NOT EXISTS "${_compiler_real}" OR IS_DIRECTORY "${_compiler_real}")
+        message(FATAL_ERROR
+            "build receipt compiler is not a regular file: "
+            "${CMAKE_${language}_COMPILER}")
+    endif()
+    file(SHA256 "${_compiler_real}" _compiler_sha256)
+    foreach(_value
+            "${CMAKE_${language}_COMPILER}"
+            "${_compiler_real}"
+            "${CMAKE_${language}_COMPILER_ID}"
+            "${CMAKE_${language}_COMPILER_VERSION}")
+        _deac_build_receipt_require_plain(
+            "${_value}" "${language} compiler identity")
+    endforeach()
+    set(_arguments
+        "-DDEAC_BUILD_RECEIPT_CONFIGURED_${language}_PATH:FILEPATH=${CMAKE_${language}_COMPILER}"
+        "-DDEAC_BUILD_RECEIPT_CONFIGURED_${language}_REAL_PATH:FILEPATH=${_compiler_real}"
+        "-DDEAC_BUILD_RECEIPT_CONFIGURED_${language}_SHA256:STRING=${_compiler_sha256}"
+        "-DDEAC_BUILD_RECEIPT_CONFIGURED_${language}_ID:STRING=${CMAKE_${language}_COMPILER_ID}"
+        "-DDEAC_BUILD_RECEIPT_CONFIGURED_${language}_VERSION:STRING=${CMAKE_${language}_COMPILER_VERSION}")
+    if(DEFINED CMAKE_${language}_COMPILER_TARGET)
+        _deac_build_receipt_require_plain(
+            "${CMAKE_${language}_COMPILER_TARGET}"
+            "${language} compiler target")
+        list(APPEND _arguments
+            "-DDEAC_BUILD_RECEIPT_CONFIGURED_${language}_TARGET:STRING=${CMAKE_${language}_COMPILER_TARGET}")
+    endif()
+    set(_fingerprint_material "")
+    foreach(_field PATH REAL_PATH SHA256 ID VERSION TARGET)
+        if(_field STREQUAL "PATH")
+            set(_value "${CMAKE_${language}_COMPILER}")
+        elseif(_field STREQUAL "REAL_PATH")
+            set(_value "${_compiler_real}")
+        elseif(_field STREQUAL "SHA256")
+            set(_value "${_compiler_sha256}")
+        elseif(_field STREQUAL "ID")
+            set(_value "${CMAKE_${language}_COMPILER_ID}")
+        elseif(_field STREQUAL "VERSION")
+            set(_value "${CMAKE_${language}_COMPILER_VERSION}")
+        elseif(DEFINED CMAKE_${language}_COMPILER_TARGET)
+            set(_value "${CMAKE_${language}_COMPILER_TARGET}")
+        else()
+            set(_value "")
+        endif()
+        string(LENGTH "${_value}" _length)
+        string(APPEND _fingerprint_material
+            "${language}.${_field}:${_length}:${_value}\n")
+    endforeach()
+    set(${output_arguments} "${_arguments}" PARENT_SCOPE)
+    set(${output_fingerprint_material}
+        "${_fingerprint_material}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_build_receipt_reject_launchers target_name)
+    foreach(_language CXX CUDA)
+        foreach(_suffix COMPILER_LAUNCHER LINKER_LAUNCHER)
+            set(_variable "CMAKE_${_language}_${_suffix}")
+            if(DEFINED ${_variable} AND NOT "${${_variable}}" STREQUAL "")
+                message(FATAL_ERROR
+                    "build receipts do not yet support ${_variable}")
+            endif()
+            get_target_property(_launcher "${target_name}"
+                "${_language}_${_suffix}")
+            if(_launcher AND NOT _launcher MATCHES "-NOTFOUND$")
+                message(FATAL_ERROR
+                    "build receipts do not yet support target "
+                    "${target_name} ${_language}_${_suffix}")
+            endif()
+        endforeach()
+        foreach(_suffix
+                CLANG_TIDY CPPCHECK CPPLINT INCLUDE_WHAT_YOU_USE)
+            get_target_property(_launcher "${target_name}"
+                "${_language}_${_suffix}")
+            if(_launcher AND NOT _launcher MATCHES "-NOTFOUND$")
+                message(FATAL_ERROR
+                    "build receipts do not yet support target "
+                    "${target_name} ${_language}_${_suffix}")
+            endif()
+        endforeach()
+        set(_compiler_arg1 "CMAKE_${_language}_COMPILER_ARG1")
+        if(DEFINED ${_compiler_arg1} AND
+                NOT "${${_compiler_arg1}}" STREQUAL "")
+            message(FATAL_ERROR
+                "build receipts do not yet support ${_compiler_arg1}")
+        endif()
+    endforeach()
+
+    get_target_property(_link_what_you_use "${target_name}" LINK_WHAT_YOU_USE)
+    if(_link_what_you_use AND NOT _link_what_you_use MATCHES "-NOTFOUND$")
+        message(FATAL_ERROR
+            "build receipts do not yet support target ${target_name} "
+            "LINK_WHAT_YOU_USE")
+    endif()
+
+    get_target_property(
+        _interprocedural_optimization
+        "${target_name}" INTERPROCEDURAL_OPTIMIZATION)
+    if(_interprocedural_optimization AND
+            NOT _interprocedural_optimization MATCHES "-NOTFOUND$")
+        message(FATAL_ERROR
+            "build receipts do not yet support target ${target_name} "
+            "INTERPROCEDURAL_OPTIMIZATION")
+    endif()
+
+    foreach(_launcher_property
+            RULE_LAUNCH_COMPILE RULE_LAUNCH_CUSTOM RULE_LAUNCH_LINK)
+        get_target_property(
+            _launcher_value "${target_name}" "${_launcher_property}")
+        if(_launcher_value AND NOT _launcher_value MATCHES "-NOTFOUND$")
+            message(FATAL_ERROR
+                "build receipts do not yet support target ${target_name} "
+                "${_launcher_property}")
+        endif()
+        foreach(_scope GLOBAL DIRECTORY)
+            get_property(_launcher_value ${_scope}
+                PROPERTY "${_launcher_property}")
+            if(NOT "${_launcher_value}" STREQUAL "")
+                message(FATAL_ERROR
+                    "build receipts do not yet support ${_scope} "
+                    "${_launcher_property}")
+            endif()
+        endforeach()
+    endforeach()
+endfunction()
+
+function(_deac_build_receipt_reject_rule_override_routes)
+    foreach(_variable
+            CMAKE_TOOLCHAIN_FILE
+            CMAKE_USER_MAKE_RULES_OVERRIDE
+            CMAKE_USER_MAKE_RULES_OVERRIDE_CXX
+            CMAKE_USER_MAKE_RULES_OVERRIDE_CUDA
+            CMAKE_USER_MAKE_RULES_OVERRIDE_HIP
+            CMAKE_PROJECT_INCLUDE
+            CMAKE_PROJECT_INCLUDE_BEFORE
+            CMAKE_PROJECT_TOP_LEVEL_INCLUDES)
+        if(DEFINED ${_variable} AND NOT "${${_variable}}" STREQUAL "")
+            message(FATAL_ERROR
+                "build receipts do not support rule-override route ${_variable}")
+        endif()
+    endforeach()
+    get_property(_module_path_is_cached
+        CACHE CMAKE_MODULE_PATH PROPERTY TYPE SET)
+    if(_module_path_is_cached)
+        message(FATAL_ERROR
+            "build receipts reject cached rule-override route CMAKE_MODULE_PATH")
+    endif()
+    foreach(_suffix INCLUDE INCLUDE_BEFORE)
+        set(_variable "CMAKE_PROJECT_${PROJECT_NAME}_${_suffix}")
+        if(DEFINED ${_variable} AND NOT "${${_variable}}" STREQUAL "")
+            message(FATAL_ERROR
+                "build receipts do not support rule-override route ${_variable}")
+        endif()
+    endforeach()
+
+    foreach(_language CXX CUDA HIP)
+        foreach(_rule
+                COMPILE_OBJECT
+                LINK_EXECUTABLE
+                CREATE_STATIC_LIBRARY
+                ARCHIVE_CREATE
+                ARCHIVE_APPEND
+                ARCHIVE_FINISH)
+            set(_variable "CMAKE_${_language}_${_rule}")
+            get_property(_is_cached CACHE "${_variable}" PROPERTY TYPE SET)
+            if(_is_cached)
+                message(FATAL_ERROR
+                    "build receipts reject cached rule-template override "
+                    "${_variable}")
+            endif()
+        endforeach()
+    endforeach()
+    foreach(_rule
+            DEVICE_LINK_COMPILE DEVICE_LINK_EXECUTABLE DEVICE_LINK_LIBRARY)
+        set(_variable "CMAKE_CUDA_${_rule}")
+        get_property(_is_cached CACHE "${_variable}" PROPERTY TYPE SET)
+        if(_is_cached)
+            message(FATAL_ERROR
+                "build receipts reject cached rule-template override "
+                "${_variable}")
+        endif()
+    endforeach()
+endfunction()
+
+function(_deac_build_receipt_rule_fingerprint
+        language output_fingerprint_material)
+    set(_material "")
+    foreach(_rule COMPILE_OBJECT LINK_EXECUTABLE)
+        set(_variable "CMAKE_${language}_${_rule}")
+        if(NOT DEFINED ${_variable} OR "${${_variable}}" STREQUAL "")
+            message(FATAL_ERROR "build receipt requires ${_variable}")
+        endif()
+        set(_template "${${_variable}}")
+        if(_template MATCHES "[;\r\n]")
+            message(FATAL_ERROR
+                "build receipt does not support multi-command ${_variable}")
+        endif()
+        if(_rule STREQUAL "COMPILE_OBJECT")
+            set(_allowed_prefix "<CMAKE_${language}_COMPILER>")
+            foreach(_placeholder DEFINES INCLUDES SOURCE OBJECT FLAGS)
+                if(NOT _template MATCHES "<${_placeholder}>")
+                    message(FATAL_ERROR
+                        "build-receipt ${_variable} omits <${_placeholder}>")
+                endif()
+            endforeach()
+        elseif(language STREQUAL "CUDA")
+            if(_template MATCHES "^<CMAKE_CUDA_COMPILER>( |$)")
+                set(_allowed_prefix "<CMAKE_CUDA_COMPILER>")
+            elseif(_template MATCHES "^<CMAKE_CUDA_HOST_LINK_LAUNCHER>( |$)")
+                set(_allowed_prefix "<CMAKE_CUDA_HOST_LINK_LAUNCHER>")
+            else()
+                message(FATAL_ERROR
+                    "build-receipt ${_variable} has an unsupported launcher")
+            endif()
+        else()
+            set(_allowed_prefix "<CMAKE_${language}_COMPILER>")
+        endif()
+        string(FIND "${_template}" "${_allowed_prefix}" _prefix_position)
+        if(NOT _prefix_position EQUAL 0)
+            message(FATAL_ERROR
+                "build-receipt ${_variable} has an unsupported launcher")
+        endif()
+        if(_rule STREQUAL "LINK_EXECUTABLE")
+            foreach(_placeholder
+                    LINK_FLAGS LINK_LIBRARIES OBJECTS TARGET)
+                if(NOT _template MATCHES "<${_placeholder}>")
+                    message(FATAL_ERROR
+                        "build-receipt ${_variable} omits <${_placeholder}>")
+                endif()
+            endforeach()
+            if(language STREQUAL "CXX")
+                foreach(_placeholder FLAGS CMAKE_CXX_LINK_FLAGS)
+                    if(NOT _template MATCHES "<${_placeholder}>")
+                        message(FATAL_ERROR
+                            "build-receipt ${_variable} omits <${_placeholder}>")
+                    endif()
+                endforeach()
+            endif()
+        endif()
+        string(LENGTH "${_template}" _length)
+        string(APPEND _material
+            "${language}.${_rule}:${_length}:${_template}\n")
+    endforeach()
+
+    set(_legacy_archive "CMAKE_${language}_CREATE_STATIC_LIBRARY")
+    if(DEFINED ${_legacy_archive} AND NOT "${${_legacy_archive}}" STREQUAL "")
+        message(FATAL_ERROR
+            "build receipts do not support ${_legacy_archive}")
+    endif()
+    foreach(_rule ARCHIVE_CREATE ARCHIVE_APPEND ARCHIVE_FINISH)
+        set(_variable "CMAKE_${language}_${_rule}")
+        if(NOT DEFINED ${_variable} OR "${${_variable}}" STREQUAL "")
+            message(FATAL_ERROR "build receipt requires ${_variable}")
+        endif()
+        set(_template "${${_variable}}")
+        if(_template MATCHES "[;\r\n]")
+            message(FATAL_ERROR
+                "build receipt does not support multi-command ${_variable}")
+        endif()
+        if(_rule STREQUAL "ARCHIVE_FINISH")
+            set(_allowed_prefix "<CMAKE_RANLIB>")
+        else()
+            set(_allowed_prefix "<CMAKE_AR>")
+        endif()
+        string(FIND "${_template}" "${_allowed_prefix}" _prefix_position)
+        if(NOT _prefix_position EQUAL 0)
+            message(FATAL_ERROR
+                "build-receipt ${_variable} has an unsupported launcher")
+        endif()
+        if(_rule STREQUAL "ARCHIVE_FINISH")
+            if(NOT _template MATCHES "<TARGET>")
+                message(FATAL_ERROR
+                    "build-receipt ${_variable} omits <TARGET>")
+            endif()
+        else()
+            foreach(_placeholder LINK_FLAGS OBJECTS TARGET)
+                if(NOT _template MATCHES "<${_placeholder}>")
+                    message(FATAL_ERROR
+                        "build-receipt ${_variable} omits <${_placeholder}>")
+                endif()
+            endforeach()
+        endif()
+        string(LENGTH "${_template}" _length)
+        string(APPEND _material
+            "${language}.${_rule}:${_length}:${_template}\n")
+    endforeach()
+    set(${output_fingerprint_material} "${_material}" PARENT_SCOPE)
+endfunction()
+
+function(deac_target_add_build_receipt target_name)
+    if(CMAKE_VERSION VERSION_LESS 3.27)
+        message(FATAL_ERROR
+            "canonical DEAC build receipts require CMake 3.27 or newer")
+    endif()
+    if(NOT TARGET "${target_name}")
+        message(FATAL_ERROR
+            "deac_target_add_build_receipt requires an existing target")
+    endif()
+    get_target_property(_target_type "${target_name}" TYPE)
+    if(NOT _target_type STREQUAL "EXECUTABLE")
+        message(FATAL_ERROR
+            "deac_target_add_build_receipt requires an executable target")
+    endif()
+
+    cmake_parse_arguments(
+        PARSE_ARGV 1
+        DEAC_RECEIPT
+        ""
+        "SOURCE_ROOT;GENERATED_DIRECTORY;IDENTITY_NAME;RECEIPT;BACKEND"
+        "CACHE_KEYS;DEPENDENCY_TARGETS")
+    foreach(_required_argument
+            SOURCE_ROOT
+            GENERATED_DIRECTORY
+            IDENTITY_NAME
+            RECEIPT
+            BACKEND)
+        if(NOT DEAC_RECEIPT_${_required_argument})
+            message(FATAL_ERROR
+                "deac_target_add_build_receipt requires ${_required_argument}")
+        endif()
+    endforeach()
+    if(NOT DEAC_RECEIPT_IDENTITY_NAME MATCHES "^[A-Za-z0-9_.-]+$")
+        message(FATAL_ERROR
+            "build-receipt IDENTITY_NAME must be path-safe")
+    endif()
+    if(NOT DEAC_RECEIPT_BACKEND MATCHES "^(none|sycl|cuda|hip)$")
+        message(FATAL_ERROR
+            "build-receipt BACKEND must be none, sycl, cuda, or hip")
+    endif()
+    if(NOT DEAC_RECEIPT_CACHE_KEYS)
+        message(FATAL_ERROR
+            "deac_target_add_build_receipt requires CACHE_KEYS")
+    endif()
+    list(REMOVE_DUPLICATES DEAC_RECEIPT_CACHE_KEYS)
+    foreach(_cache_key IN LISTS DEAC_RECEIPT_CACHE_KEYS)
+        if(NOT _cache_key MATCHES "^[A-Za-z_][A-Za-z0-9_]*$")
+            message(FATAL_ERROR
+                "invalid build-receipt cache key: ${_cache_key}")
+        endif()
+    endforeach()
+    list(SORT DEAC_RECEIPT_CACHE_KEYS)
+    string(JOIN "," _cache_keys_csv ${DEAC_RECEIPT_CACHE_KEYS})
+
+    list(REMOVE_DUPLICATES DEAC_RECEIPT_DEPENDENCY_TARGETS)
+    list(SORT DEAC_RECEIPT_DEPENDENCY_TARGETS)
+    foreach(_dependency_target IN LISTS DEAC_RECEIPT_DEPENDENCY_TARGETS)
+        if(NOT TARGET "${_dependency_target}")
+            message(FATAL_ERROR
+                "build-receipt dependency target does not exist: "
+                "${_dependency_target}")
+        endif()
+        _deac_build_receipt_require_plain(
+            "${_dependency_target}" "build-receipt dependency target")
+    endforeach()
+    string(JOIN "," _dependency_targets_csv
+        ${DEAC_RECEIPT_DEPENDENCY_TARGETS})
+
+    if(CMAKE_CONFIGURATION_TYPES)
+        string(FIND "${DEAC_RECEIPT_RECEIPT}" "$<CONFIG>" _config_position)
+        if(_config_position EQUAL -1)
+            message(FATAL_ERROR
+                "multi-config build receipts require $<CONFIG> in RECEIPT")
+        endif()
+        set(_receipt_configurations ${CMAKE_CONFIGURATION_TYPES})
+    else()
+        set(_receipt_configurations "${CMAKE_BUILD_TYPE}")
+    endif()
+    foreach(_configuration IN LISTS _receipt_configurations)
+        if(NOT _configuration MATCHES "^[A-Za-z0-9_.+-]+$" OR
+                _configuration STREQUAL "." OR
+                _configuration STREQUAL "..")
+            message(FATAL_ERROR
+                "build-receipt configuration is not path-safe: "
+                "${_configuration}")
+        endif()
+    endforeach()
+
+    get_filename_component(
+        _source_root "${DEAC_RECEIPT_SOURCE_ROOT}" REALPATH)
+    if(NOT EXISTS "${_source_root}/VERSION")
+        message(FATAL_ERROR
+            "build-receipt source root has no VERSION file: ${_source_root}")
+    endif()
+
+    cmake_file_api(
+        QUERY
+        API_VERSION 1
+        CODEMODEL 2.6
+        CACHE 2
+        TOOLCHAINS 1)
+
+    _deac_build_receipt_reject_rule_override_routes()
+
+    foreach(_validated_target
+            "${target_name}" ${DEAC_RECEIPT_DEPENDENCY_TARGETS})
+        _deac_build_receipt_reject_launchers("${_validated_target}")
+    endforeach()
+
+    get_property(_enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+    foreach(_unsupported_language CUDA HIP)
+        if(_unsupported_language IN_LIST _enabled_languages)
+            message(FATAL_ERROR
+                "build receipts fail closed for the native CMake "
+                "${_unsupported_language} language until its intermediate "
+                "device-link rules are represented and compiler-gated")
+        endif()
+    endforeach()
+    set(_receipt_languages)
+    set(_tool_arguments)
+    set(_toolchain_fingerprint_material "deac-build-toolchain-v1\n")
+    foreach(_language CXX CUDA)
+        if(_language IN_LIST _enabled_languages)
+            _deac_build_receipt_snapshot_tool(
+                "${_language}" _language_arguments _language_fingerprint)
+            list(APPEND _receipt_languages "${_language}")
+            list(APPEND _tool_arguments ${_language_arguments})
+            string(APPEND _toolchain_fingerprint_material
+                "${_language_fingerprint}")
+            _deac_build_receipt_rule_fingerprint(
+                "${_language}" _language_rule_fingerprint)
+            string(APPEND _toolchain_fingerprint_material
+                "${_language_rule_fingerprint}")
+        endif()
+    endforeach()
+    if(NOT "CXX" IN_LIST _receipt_languages)
+        message(FATAL_ERROR "build receipt requires the CXX language")
+    endif()
+    string(JOIN "," _receipt_languages_csv ${_receipt_languages})
+
+    get_filename_component(_cmake_real "${CMAKE_COMMAND}" REALPATH)
+    if(NOT EXISTS "${_cmake_real}" OR IS_DIRECTORY "${_cmake_real}")
+        message(FATAL_ERROR
+            "build-receipt CMake command is not a regular file: ${CMAKE_COMMAND}")
+    endif()
+    file(SHA256 "${_cmake_real}" _cmake_sha256)
+    foreach(_value "${CMAKE_COMMAND}" "${_cmake_real}")
+        _deac_build_receipt_require_plain("${_value}" "CMake identity")
+    endforeach()
+    foreach(_field PATH REAL_PATH SHA256)
+        if(_field STREQUAL "PATH")
+            set(_value "${CMAKE_COMMAND}")
+        elseif(_field STREQUAL "REAL_PATH")
+            set(_value "${_cmake_real}")
+        else()
+            set(_value "${_cmake_sha256}")
+        endif()
+        string(LENGTH "${_value}" _length)
+        string(APPEND _toolchain_fingerprint_material
+            "CMAKE.${_field}:${_length}:${_value}\n")
+    endforeach()
+    string(SHA256 _toolchain_fingerprint
+        "${_toolchain_fingerprint_material}")
+
+    # Changing compiler or CMake bytes followed by a required reconfigure must
+    # invalidate every object, even when the compiler pathname is unchanged.
+    # The same definition is visible in the File API compile groups recorded
+    # below, binding that invalidation key into the receipt itself.
+    foreach(_fingerprinted_target
+            "${target_name}" ${DEAC_RECEIPT_DEPENDENCY_TARGETS})
+        get_target_property(_fingerprinted_type
+            "${_fingerprinted_target}" TYPE)
+        if(_fingerprinted_type MATCHES
+                "^(EXECUTABLE|MODULE_LIBRARY|OBJECT_LIBRARY|SHARED_LIBRARY|STATIC_LIBRARY)$")
+            target_compile_definitions("${_fingerprinted_target}" PRIVATE
+                "DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256=${_toolchain_fingerprint}")
+        endif()
+    endforeach()
+
+    get_filename_component(
+        _support_directory
+        "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../deac/src"
+        REALPATH)
+    string(MAKE_C_IDENTIFIER
+        "${DEAC_RECEIPT_IDENTITY_NAME}_${target_name}_build_receipt"
+        _receipt_identifier)
+    set(_receipt "${DEAC_RECEIPT_RECEIPT}")
+
+    set(_git_argument)
+    if(Git_FOUND)
+        list(APPEND _git_argument
+            "-DGIT_EXECUTABLE:FILEPATH=${GIT_EXECUTABLE}")
+    endif()
+
+    set(_configuration_directory
+        "${DEAC_RECEIPT_GENERATED_DIRECTORY}/$<CONFIG>")
+    set(_generated_source
+        "${_configuration_directory}/${_receipt_identifier}.cpp")
+    set(_refresh
+        "${_configuration_directory}/${_receipt_identifier}.refresh")
+    set(_rebuild
+        "${_configuration_directory}/${_receipt_identifier}.rebuild")
+
+    add_custom_command(
+        # The command deliberately never creates this symbolic primary output.
+        # A single $<CONFIG>-qualified edge keeps Ninja Multi-Config graphs
+        # isolated while making every ordinary selected-config build refresh.
+        OUTPUT "${_refresh}"
+        BYPRODUCTS "${_generated_source}" "${_receipt}"
+        COMMAND
+            "${CMAKE_COMMAND}"
+            "-DDEAC_BUILD_RECEIPT_SOURCE_ROOT:PATH=${_source_root}"
+            "-DDEAC_BUILD_RECEIPT_CMAKE_SOURCE_ROOT:PATH=${CMAKE_SOURCE_DIR}"
+            "-DDEAC_BUILD_RECEIPT_BUILD_ROOT:PATH=${CMAKE_BINARY_DIR}"
+            "-DDEAC_BUILD_RECEIPT_REPLY_DIRECTORY:PATH=${CMAKE_BINARY_DIR}/.cmake/api/v1/reply"
+            "-DDEAC_BUILD_RECEIPT_TARGET:STRING=${target_name}"
+            "-DDEAC_BUILD_RECEIPT_CONFIGURATION:STRING=$<CONFIG>"
+            "-DDEAC_BUILD_RECEIPT_BACKEND:STRING=${DEAC_RECEIPT_BACKEND}"
+            "-DDEAC_BUILD_RECEIPT_CACHE_KEYS:STRING=${_cache_keys_csv}"
+            "-DDEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS:STRING=${_dependency_targets_csv}"
+            "-DDEAC_BUILD_RECEIPT_LANGUAGES:STRING=${_receipt_languages_csv}"
+            "-DDEAC_BUILD_RECEIPT_TOOLCHAIN_FINGERPRINT:STRING=${_toolchain_fingerprint}"
+            "-DDEAC_BUILD_RECEIPT_CMAKE_PATH:FILEPATH=${CMAKE_COMMAND}"
+            "-DDEAC_BUILD_RECEIPT_CMAKE_REAL_PATH:FILEPATH=${_cmake_real}"
+            "-DDEAC_BUILD_RECEIPT_CMAKE_SHA256:STRING=${_cmake_sha256}"
+            "-DDEAC_BUILD_RECEIPT_OUTPUT_SOURCE:FILEPATH=${_generated_source}"
+            "-DDEAC_BUILD_RECEIPT_OUTPUT_RECEIPT:FILEPATH=${_receipt}"
+            ${_git_argument}
+            ${_tool_arguments}
+            -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/GenerateDeacBuildReceipt.cmake"
+        DEPENDS
+            "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/DeacBuildIdentity.cmake"
+            "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/DeacBuildReceipt.cmake"
+            "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/GenerateDeacBuildReceipt.cmake"
+            "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/VerifyDeacBuildReceiptTools.cmake"
+            "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/deac_build_receipt_data.cpp.in"
+            "${_source_root}/VERSION"
+        COMMENT "Embedding effective build receipt for ${target_name} ($<CONFIG>)"
+        VERBATIM)
+    add_custom_command(
+        # This symbolic output separates receipt generation from the normal
+        # generated-source relationship that CMake otherwise treats as
+        # timestamp-only.  Object and link rules depend on the always-missing
+        # token, so coarse filesystem timestamps cannot suppress a rebuild.
+        OUTPUT "${_rebuild}"
+        COMMAND "${CMAKE_COMMAND}" -E true
+        DEPENDS "${_refresh}"
+        VERBATIM)
+    set_source_files_properties(
+        "${_refresh}" "${_rebuild}"
+        PROPERTIES GENERATED TRUE SYMBOLIC TRUE)
+    set_source_files_properties(
+        "${_generated_source}" PROPERTIES
+        GENERATED TRUE
+        OBJECT_DEPENDS "${_rebuild}")
+    set_property(TARGET "${target_name}" APPEND PROPERTY
+        LINK_DEPENDS "${_rebuild}")
+    target_sources("${target_name}" PRIVATE
+        "${_generated_source}" "${_rebuild}")
+    target_include_directories("${target_name}" PRIVATE
+        "${_support_directory}")
+
+    # This catches persistent compiler/CMake replacement after receipt
+    # generation but before the final link.  As with any ordinary build graph,
+    # an adversarial swap-and-restore between process invocations is outside
+    # CMake's attestation boundary.
+    add_custom_command(TARGET "${target_name}" PRE_LINK
+        COMMAND
+            "${CMAKE_COMMAND}"
+            "-DDEAC_BUILD_RECEIPT_LANGUAGES:STRING=${_receipt_languages_csv}"
+            "-DDEAC_BUILD_RECEIPT_CMAKE_PATH:FILEPATH=${CMAKE_COMMAND}"
+            "-DDEAC_BUILD_RECEIPT_CMAKE_REAL_PATH:FILEPATH=${_cmake_real}"
+            "-DDEAC_BUILD_RECEIPT_CMAKE_SHA256:STRING=${_cmake_sha256}"
+            ${_tool_arguments}
+            -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/VerifyDeacBuildReceiptTools.cmake"
+        COMMENT "Verifying build-receipt tool bytes for ${target_name}"
+        VERBATIM)
+    set_property(TARGET "${target_name}" APPEND PROPERTY
+        ADDITIONAL_CLEAN_FILES "${_generated_source};${_receipt}")
+
+    set(DEAC_BUILD_RECEIPT "${_receipt}" PARENT_SCOPE)
+    set(DEAC_BUILD_RECEIPT_GENERATED_SOURCE
+        "${DEAC_RECEIPT_GENERATED_DIRECTORY}/$<CONFIG>/${_receipt_identifier}.cpp"
+        PARENT_SCOPE)
+    set(DEAC_BUILD_RECEIPT_TOOLCHAIN_FINGERPRINT
+        "${_toolchain_fingerprint}" PARENT_SCOPE)
+endfunction()

--- a/src/cmake/DeacHipblas.cmake
+++ b/src/cmake/DeacHipblas.cmake
@@ -1,7 +1,190 @@
 include_guard(GLOBAL)
 
+function(_deac_hipblas_canonical_provider target_name output)
+    if(NOT TARGET "${target_name}")
+        message(FATAL_ERROR
+            "The hipBLAS provider target does not exist: ${target_name}.")
+    endif()
+
+    set(_deac_provider "${target_name}")
+    while(TRUE)
+        get_target_property(_deac_aliased_target
+            "${_deac_provider}" ALIASED_TARGET)
+        if(NOT _deac_aliased_target OR
+                _deac_aliased_target MATCHES "-NOTFOUND$")
+            break()
+        endif()
+        set(_deac_provider "${_deac_aliased_target}")
+    endwhile()
+
+    get_target_property(_deac_imported "${_deac_provider}" IMPORTED)
+    get_target_property(_deac_provider_type "${_deac_provider}" TYPE)
+    set(_deac_supported_provider_types
+        STATIC_LIBRARY SHARED_LIBRARY UNKNOWN_LIBRARY)
+    if(NOT _deac_imported OR NOT _deac_provider_type IN_LIST
+            _deac_supported_provider_types)
+        message(FATAL_ERROR
+            "The hipBLAS provider must resolve to an imported STATIC, SHARED, "
+            "or UNKNOWN library target: ${target_name} (resolved to "
+            "${_deac_provider}, type ${_deac_provider_type}).")
+    endif()
+    set(${output} "${_deac_provider}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_hipblas_location_property target_name property_name output)
+    get_target_property(_deac_location "${target_name}" "${property_name}")
+    if(NOT _deac_location OR _deac_location MATCHES "-NOTFOUND$")
+        set(_deac_location "")
+    endif()
+    set(${output} "${_deac_location}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_hipblas_imported_location target_name configuration output)
+    _deac_hipblas_canonical_provider("${target_name}" _deac_provider)
+
+    set(_deac_location "")
+    if(NOT "${configuration}" STREQUAL "")
+        string(TOUPPER "${configuration}" _deac_configuration_upper)
+        set(_deac_map_property
+            "MAP_IMPORTED_CONFIG_${_deac_configuration_upper}")
+        get_property(_deac_map_is_set TARGET "${_deac_provider}"
+            PROPERTY "${_deac_map_property}" SET)
+        if(_deac_map_is_set)
+            get_target_property(_deac_candidate_configurations
+                "${_deac_provider}" "${_deac_map_property}")
+            if("${_deac_candidate_configurations}" STREQUAL "")
+                set(_deac_candidate_configurations "<CONFIGLESS>")
+            endif()
+        else()
+            set(_deac_candidate_configurations
+                "${_deac_configuration_upper}" "<CONFIGLESS>")
+        endif()
+    else()
+        set(_deac_candidate_configurations "<CONFIGLESS>")
+    endif()
+
+    foreach(_deac_candidate IN LISTS _deac_candidate_configurations)
+        if("${_deac_candidate}" STREQUAL "" OR
+                _deac_candidate STREQUAL "<CONFIGLESS>")
+            set(_deac_location_property IMPORTED_LOCATION)
+        else()
+            string(TOUPPER "${_deac_candidate}" _deac_candidate_upper)
+            set(_deac_location_property
+                "IMPORTED_LOCATION_${_deac_candidate_upper}")
+        endif()
+        _deac_hipblas_location_property(
+            "${_deac_provider}" "${_deac_location_property}"
+            _deac_candidate_location)
+        if(NOT "${_deac_candidate_location}" STREQUAL "")
+            set(_deac_location "${_deac_candidate_location}")
+            break()
+        endif()
+    endforeach()
+
+    if(_deac_location STREQUAL "" AND NOT _deac_map_is_set)
+        get_target_property(_deac_imported_configurations
+            "${_deac_provider}" IMPORTED_CONFIGURATIONS)
+        foreach(_deac_candidate IN LISTS _deac_imported_configurations)
+            string(TOUPPER "${_deac_candidate}" _deac_candidate_upper)
+            _deac_hipblas_location_property(
+                "${_deac_provider}"
+                "IMPORTED_LOCATION_${_deac_candidate_upper}"
+                _deac_candidate_location)
+            if(NOT "${_deac_candidate_location}" STREQUAL "")
+                set(_deac_location "${_deac_candidate_location}")
+                break()
+            endif()
+        endforeach()
+    endif()
+
+    if(_deac_location STREQUAL "" OR
+            _deac_location MATCHES "[;<>\r\n]" OR
+            _deac_location MATCHES "\\$<" OR
+            NOT IS_ABSOLUTE "${_deac_location}" OR
+            NOT EXISTS "${_deac_location}" OR
+            IS_DIRECTORY "${_deac_location}")
+        message(FATAL_ERROR
+            "The hipBLAS provider ${_deac_provider} has no receipt-safe regular "
+            "imported artifact for configuration '${configuration}'.")
+    endif()
+    set(${output} "${_deac_location}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_hipblas_provider_artifact target_name output)
+    _deac_hipblas_canonical_provider("${target_name}" _deac_provider)
+    if(CMAKE_CONFIGURATION_TYPES)
+        set(_deac_locations)
+        set(_deac_configuration_keys)
+        foreach(_deac_configuration IN LISTS CMAKE_CONFIGURATION_TYPES)
+            if("${_deac_configuration}" STREQUAL "" OR
+                    _deac_configuration MATCHES "[;<>,$\r\n]")
+                message(FATAL_ERROR
+                    "CMAKE_CONFIGURATION_TYPES contains a receipt-unsafe "
+                    "configuration name: '${_deac_configuration}'.")
+            endif()
+            string(TOUPPER "${_deac_configuration}"
+                _deac_configuration_key)
+            if(_deac_configuration_key IN_LIST _deac_configuration_keys)
+                message(FATAL_ERROR
+                    "CMAKE_CONFIGURATION_TYPES contains duplicate "
+                    "case-insensitive configuration '${_deac_configuration}'.")
+            endif()
+            list(APPEND _deac_configuration_keys
+                "${_deac_configuration_key}")
+            _deac_hipblas_imported_location(
+                "${_deac_provider}" "${_deac_configuration}" _deac_location)
+            list(APPEND _deac_locations "${_deac_location}")
+        endforeach()
+        set(_deac_unique_locations ${_deac_locations})
+        list(REMOVE_DUPLICATES _deac_unique_locations)
+        list(LENGTH _deac_unique_locations _deac_unique_location_count)
+        if(_deac_unique_location_count EQUAL 1)
+            list(GET _deac_unique_locations 0 _deac_artifact)
+        else()
+            set(_deac_artifact "")
+            set(_deac_index 0)
+            foreach(_deac_configuration IN LISTS CMAKE_CONFIGURATION_TYPES)
+                list(GET _deac_locations ${_deac_index} _deac_location)
+                string(APPEND _deac_artifact
+                    "$<$<CONFIG:${_deac_configuration}>:${_deac_location}>")
+                math(EXPR _deac_index "${_deac_index} + 1")
+            endforeach()
+        endif()
+    else()
+        _deac_hipblas_imported_location(
+            "${_deac_provider}" "${CMAKE_BUILD_TYPE}" _deac_artifact)
+    endif()
+    set(${output} "${_deac_artifact}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_hipblas_validate_link_contract target_name)
+    get_target_property(_deac_provider "${target_name}"
+        DEAC_HIPBLAS_PROVIDER_TARGET)
+    _deac_hipblas_canonical_provider("${_deac_provider}"
+        _deac_canonical_provider)
+    get_target_property(_deac_links "${target_name}"
+        INTERFACE_LINK_LIBRARIES)
+    if(NOT "${_deac_provider}" STREQUAL "${_deac_canonical_provider}" OR
+            NOT "${_deac_links}" STREQUAL "${_deac_canonical_provider}")
+        message(FATAL_ERROR
+            "The hipBLAS link contract must contain exactly its canonical "
+            "provider once; provider=${_deac_provider}, links=${_deac_links}.")
+    endif()
+    _deac_hipblas_provider_artifact(
+        "${_deac_canonical_provider}" _deac_expected_artifact)
+    get_target_property(_deac_recorded_artifact "${target_name}"
+        DEAC_HIPBLAS_PROVIDER_ARTIFACT)
+    if(NOT "${_deac_recorded_artifact}" STREQUAL
+            "${_deac_expected_artifact}")
+        message(FATAL_ERROR
+            "The hipBLAS link contract's recorded provider artifact drifted "
+            "from its canonical provider.")
+    endif()
+endfunction()
+
 function(_deac_define_hipblas_link_contract)
     if(TARGET deac_hipblas_link_contract)
+        _deac_hipblas_validate_link_contract(deac_hipblas_link_contract)
         return()
     endif()
 
@@ -88,9 +271,19 @@ function(_deac_define_hipblas_link_contract)
         set(_deac_hipblas_provider deac_hipblas_compat)
     endif()
 
+    _deac_hipblas_canonical_provider(
+        "${_deac_hipblas_provider}" _deac_hipblas_provider)
+    _deac_hipblas_provider_artifact(
+        "${_deac_hipblas_provider}" _deac_hipblas_provider_artifact)
     add_library(deac_hipblas_link_contract INTERFACE)
     target_link_libraries(deac_hipblas_link_contract INTERFACE
         "${_deac_hipblas_provider}")
+    set_property(TARGET deac_hipblas_link_contract PROPERTY
+        DEAC_HIPBLAS_PROVIDER_TARGET "${_deac_hipblas_provider}")
+    set_property(TARGET deac_hipblas_link_contract PROPERTY
+        DEAC_HIPBLAS_PROVIDER_ARTIFACT
+        "${_deac_hipblas_provider_artifact}")
+    _deac_hipblas_validate_link_contract(deac_hipblas_link_contract)
     add_library(deac::hipblas ALIAS deac_hipblas_link_contract)
 endfunction()
 

--- a/src/cmake/GenerateDeacBuildReceipt.cmake
+++ b/src/cmake/GenerateDeacBuildReceipt.cmake
@@ -10,12 +10,14 @@ foreach(_required_variable
         DEAC_BUILD_RECEIPT_BACKEND
         DEAC_BUILD_RECEIPT_CACHE_KEYS
         DEAC_BUILD_RECEIPT_LANGUAGES
+        DEAC_BUILD_RECEIPT_ARCHIVE_TOOLS
         DEAC_BUILD_RECEIPT_TOOLCHAIN_FINGERPRINT
         DEAC_BUILD_RECEIPT_CMAKE_PATH
         DEAC_BUILD_RECEIPT_CMAKE_REAL_PATH
         DEAC_BUILD_RECEIPT_CMAKE_SHA256
         DEAC_BUILD_RECEIPT_OUTPUT_SOURCE
-        DEAC_BUILD_RECEIPT_OUTPUT_RECEIPT)
+        DEAC_BUILD_RECEIPT_OUTPUT_RECEIPT
+        DEAC_BUILD_RECEIPT_PREVIOUS_COMPILE_MARKER)
     if(NOT DEFINED ${_required_variable} OR
             "${${_required_variable}}" STREQUAL "")
         message(FATAL_ERROR "${_required_variable} is required")
@@ -215,6 +217,50 @@ function(_deac_receipt_normalize_path output value)
         endif()
     endforeach()
     set(${output} "${_path}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_configured_tool_json output tool)
+    if(NOT tool MATCHES "^CMAKE_[A-Z0-9_]+$")
+        message(FATAL_ERROR "invalid build-receipt archive tool: ${tool}")
+    endif()
+    set(_path_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${tool}_PATH")
+    set(_real_path_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${tool}_REAL_PATH")
+    set(_sha256_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${tool}_SHA256")
+    foreach(_variable
+            ${_path_variable} ${_real_path_variable} ${_sha256_variable})
+        if(NOT DEFINED ${_variable} OR "${${_variable}}" STREQUAL "")
+            message(FATAL_ERROR "build-receipt missing ${_variable}")
+        endif()
+    endforeach()
+
+    get_filename_component(_real_path "${${_path_variable}}" REALPATH)
+    if(NOT EXISTS "${_real_path}" OR IS_DIRECTORY "${_real_path}")
+        message(FATAL_ERROR
+            "build-receipt ${tool} is no longer a regular file")
+    endif()
+    file(SHA256 "${_real_path}" _sha256)
+    if(NOT _real_path STREQUAL "${${_real_path_variable}}" OR
+            NOT _sha256 STREQUAL "${${_sha256_variable}}")
+        message(FATAL_ERROR
+            "build-receipt ${tool} executable changed after configuration; "
+            "rerun CMake before building")
+    endif()
+
+    _deac_receipt_normalize_path(_path_json_value "${${_path_variable}}")
+    _deac_receipt_normalize_path(_real_path_json_value "${_real_path}")
+    _deac_receipt_json_quote(_name_json "${tool}")
+    _deac_receipt_json_quote(_path_json "${_path_json_value}")
+    _deac_receipt_json_quote(_real_path_json "${_real_path_json_value}")
+    _deac_receipt_json_quote(_sha256_json "${_sha256}")
+    string(CONCAT _tool_json
+        "{\"name\":" "${_name_json}" ","
+        "\"path\":" "${_path_json}" ","
+        "\"real_path\":" "${_real_path_json}" ","
+        "\"sha256\":" "${_sha256_json}" "}")
+    set(${output} "${_tool_json}" PARENT_SCOPE)
 endfunction()
 
 function(_deac_receipt_normalize_path_list output value)
@@ -1032,6 +1078,26 @@ foreach(_language IN LISTS _used_languages)
 endforeach()
 string(APPEND _toolchains_json "]")
 
+string(REPLACE "," ";" _archive_tools
+    "${DEAC_BUILD_RECEIPT_ARCHIVE_TOOLS}")
+set(_archive_tools_sorted ${_archive_tools})
+list(REMOVE_DUPLICATES _archive_tools_sorted)
+list(SORT _archive_tools_sorted)
+if(NOT "${_archive_tools}" STREQUAL "${_archive_tools_sorted}")
+    message(FATAL_ERROR
+        "build-receipt archive tools must be unique and sorted")
+endif()
+set(_archive_tools_json "[")
+set(_archive_tool_separator "")
+foreach(_archive_tool IN LISTS _archive_tools)
+    _deac_receipt_configured_tool_json(
+        _archive_tool_json "${_archive_tool}")
+    string(APPEND _archive_tools_json
+        "${_archive_tool_separator}${_archive_tool_json}")
+    set(_archive_tool_separator ",")
+endforeach()
+string(APPEND _archive_tools_json "]")
+
 get_filename_component(_cmake_real "${DEAC_BUILD_RECEIPT_CMAKE_PATH}" REALPATH)
 if(NOT EXISTS "${_cmake_real}" OR IS_DIRECTORY "${_cmake_real}")
     message(FATAL_ERROR "build-receipt CMake executable is unavailable")
@@ -1091,7 +1157,8 @@ _deac_receipt_json_quote(
     _toolchain_fingerprint_json
     "${DEAC_BUILD_RECEIPT_TOOLCHAIN_FINGERPRINT}")
 string(CONCAT _payload
-    "{\"backend\":" "${_backend_json}" ","
+    "{\"archive_tools\":" "${_archive_tools_json}" ","
+    "\"backend\":" "${_backend_json}" ","
     "\"build_system\":" "${_build_system_json}" ","
     "\"cache_entries\":" "${_cache_json}" ","
     "\"compile_groups\":" "${_compile_groups_json}" ","
@@ -1127,4 +1194,35 @@ configure_file(
     "${CMAKE_CURRENT_LIST_DIR}/deac_build_receipt_data.cpp.in"
     "${DEAC_BUILD_RECEIPT_OUTPUT_SOURCE}"
     @ONLY)
+# Ninja's custom-command `restat` suppresses dependent compile and link edges
+# when canonical receipt bytes are unchanged.  Refresh the generated source's
+# timestamp explicitly so an ordinary selected-config Ninja build still
+# recompiles and relinks the authoritative embedded receipt.  On a coarse
+# filesystem, wait until the clock is newer than the marker written after the
+# previous receipt-object compilation.  The separate symbolic dependency
+# protects Makefile generators without this wait.
+if(_generator_name MATCHES "^Ninja" AND
+        EXISTS "${DEAC_BUILD_RECEIPT_PREVIOUS_COMPILE_MARKER}")
+    file(TIMESTAMP
+        "${DEAC_BUILD_RECEIPT_PREVIOUS_COMPILE_MARKER}"
+        _previous_compile_epoch "%s" UTC)
+    string(TIMESTAMP _current_epoch "%s" UTC)
+    set(_clock_wait_attempts 0)
+    while(_current_epoch LESS_EQUAL _previous_compile_epoch)
+        if(_clock_wait_attempts GREATER_EQUAL 5)
+            message(FATAL_ERROR
+                "build-receipt clock did not advance beyond the previous compile")
+        endif()
+        execute_process(
+            COMMAND "${CMAKE_COMMAND}" -E sleep 1
+            RESULT_VARIABLE _sleep_result)
+        if(NOT _sleep_result EQUAL 0)
+            message(FATAL_ERROR
+                "build-receipt could not wait for timestamp advancement")
+        endif()
+        math(EXPR _clock_wait_attempts "${_clock_wait_attempts} + 1")
+        string(TIMESTAMP _current_epoch "%s" UTC)
+    endwhile()
+endif()
+file(TOUCH "${DEAC_BUILD_RECEIPT_OUTPUT_SOURCE}")
 file(WRITE "${DEAC_BUILD_RECEIPT_OUTPUT_RECEIPT}" "${_canonical_json}\n")

--- a/src/cmake/GenerateDeacBuildReceipt.cmake
+++ b/src/cmake/GenerateDeacBuildReceipt.cmake
@@ -274,7 +274,7 @@ function(_deac_receipt_normalize_path output value)
         file(RELATIVE_PATH _relative "${_root}" "${_path}")
         if((_relative STREQUAL "" OR
                 (NOT IS_ABSOLUTE "${_relative}" AND
-                 NOT _relative MATCHES "^\.\.(/|$)")))
+                 NOT _relative MATCHES "^[.][.](/|$)")))
             string(LENGTH "${_root}" _root_length)
             if(_root_length GREATER _best_root_length)
                 set(_best_root_length ${_root_length})

--- a/src/cmake/GenerateDeacBuildReceipt.cmake
+++ b/src/cmake/GenerateDeacBuildReceipt.cmake
@@ -448,15 +448,151 @@ function(_deac_receipt_fragment_array
                 "${document}" ${ARGN} ${_index} fragment)
             _deac_build_receipt_require_posix_shell_literal(
                 "${_fragment}" "${label}[${_index}] fragment")
-            if(fingerprint_policy STREQUAL "REJECT_FINGERPRINT")
-                # The structured File API defines array is the only accepted
-                # source of the reserved fingerprint macro.  Decode first so
-                # attached or separate -D or /D operands, quoting, escaping, and
-                # compiler-driver forwarding spellings cannot hide another
-                # effective definition (or undefinition) in a flags fragment.
-                separate_arguments(
-                    _fragment_arguments UNIX_COMMAND "${_fragment}")
-                foreach(_fragment_argument IN LISTS _fragment_arguments)
+            separate_arguments(
+                _fragment_arguments UNIX_COMMAND "${_fragment}")
+            foreach(_fragment_argument IN LISTS _fragment_arguments)
+                if("${_fragment_argument}" MATCHES "^@" OR
+                        "${_fragment_argument}" MATCHES "^-Wa,.*@" OR
+                        "${_fragment_argument}" MATCHES "^-Wl,.*@" OR
+                        "${_fragment_argument}" MATCHES
+                        "^-Xlinker=?@")
+                    message(FATAL_ERROR
+                        "build-receipt ${label}[${_index}] uses an "
+                        "unsupported unbound build input route "
+                        "(response file)")
+                endif()
+                if(fingerprint_policy STREQUAL "REJECT_FINGERPRINT")
+                    # The structured File API defines array is the only
+                    # accepted source of the reserved fingerprint macro.
+                    # Decode first so attached or separate -D or /D operands,
+                    # quoting, escaping, and compiler-driver forwarding
+                    # spellings cannot hide another effective definition (or
+                    # undefinition) in a flags fragment.
+                    string(TOLOWER
+                        "${_fragment_argument}" _fragment_argument_lower)
+                    set(_unbound_compile_input_route "")
+                    if("${_fragment_argument_lower}" MATCHES "^-include" OR
+                            "${_fragment_argument_lower}" MATCHES
+                            "^--include")
+                        set(_unbound_compile_input_route
+                            "forced include or precompiled header")
+                    elseif("${_fragment_argument_lower}" MATCHES "^-imacros" OR
+                            "${_fragment_argument_lower}" MATCHES
+                            "^--imacros")
+                        set(_unbound_compile_input_route "macro include")
+                    elseif("${_fragment_argument}" MATCHES "^[-/]FI")
+                        set(_unbound_compile_input_route "forced include")
+                    elseif("${_fragment_argument}" MATCHES
+                            "^[-/](Yu|Yc|Fp|FU)")
+                        set(_unbound_compile_input_route
+                            "clang-cl precompiled header or module")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^[-/](headerunit:|ifcsearchdir|reference)")
+                        set(_unbound_compile_input_route
+                            "MSVC module input or search path")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^--(define|undefine)-macro")
+                        set(_unbound_compile_input_route
+                            "compiler macro definition forwarding")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-wp($|,|=)")
+                        set(_unbound_compile_input_route
+                            "preprocessor option forwarding")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-qoption,")
+                        set(_unbound_compile_input_route
+                            "Intel component option forwarding")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-xpreprocessor")
+                        set(_unbound_compile_input_route
+                            "preprocessor option forwarding")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-xclang")
+                        set(_unbound_compile_input_route
+                            "Clang option forwarding")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-xarch_")
+                        set(_unbound_compile_input_route
+                            "accelerator option forwarding")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-xoffload-compiler" OR
+                            "${_fragment_argument_lower}" MATCHES
+                            "^-xopenmp-target" OR
+                            "${_fragment_argument_lower}" MATCHES
+                            "^-xsycl-target-")
+                        set(_unbound_compile_input_route
+                            "accelerator toolchain option forwarding")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-fsycl-host-compiler")
+                        set(_unbound_compile_input_route
+                            "SYCL host compiler or option forwarding")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^[-/]clang:")
+                        set(_unbound_compile_input_route
+                            "Clang option forwarding")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^--config")
+                        set(_unbound_compile_input_route
+                            "Clang configuration file or directory")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-multi-lib-config")
+                        set(_unbound_compile_input_route
+                            "compiler multilib configuration")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-ivfsoverlay" OR
+                            "${_fragment_argument_lower}" MATCHES
+                            "^-vfsoverlay")
+                        set(_unbound_compile_input_route
+                            "virtual filesystem overlay")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-fplugin")
+                        set(_unbound_compile_input_route "compiler plugin")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-fpass-plugin")
+                        set(_unbound_compile_input_route
+                            "compiler pass plugin")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-pch-use")
+                        set(_unbound_compile_input_route
+                            "Intel precompiled header")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-fpch-preprocess")
+                        set(_unbound_compile_input_route
+                            "GCC precompiled header")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-fmodule-file" OR
+                            "${_fragment_argument_lower}" MATCHES
+                            "^-fmodule-map-file" OR
+                            "${_fragment_argument_lower}" MATCHES
+                            "^-fmodule-mapper" OR
+                            "${_fragment_argument_lower}" MATCHES
+                            "^-fprebuilt-module-path" OR
+                            "${_fragment_argument_lower}" MATCHES
+                            "^-fmodules-cache-path")
+                        set(_unbound_compile_input_route
+                            "Clang module input or cache")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^--icx" OR
+                            "${_fragment_argument}" MATCHES "^-B" OR
+                            "${_fragment_argument_lower}" MATCHES
+                            "^-wrapper" OR
+                            "${_fragment_argument_lower}" MATCHES
+                            "^--?gcc-toolchain")
+                        set(_unbound_compile_input_route
+                            "compiler tool redirect")
+                    elseif("${_fragment_argument_lower}" MATCHES
+                            "^-specs" OR
+                            "${_fragment_argument_lower}" MATCHES
+                            "^--specs")
+                        set(_unbound_compile_input_route
+                            "GCC specs file")
+                    endif()
+                    if(NOT _unbound_compile_input_route STREQUAL "")
+                        message(FATAL_ERROR
+                            "build-receipt ${label}[${_index}] uses an "
+                            "unsupported unbound compile input route "
+                            "(${_unbound_compile_input_route})")
+                    endif()
                     if("${_fragment_argument}" MATCHES
                             "${_fingerprint_identifier_pattern}")
                         message(FATAL_ERROR
@@ -467,8 +603,8 @@ function(_deac_receipt_fragment_array
                             "definition; the reserved identifier appears "
                             "outside the structured definitions array")
                     endif()
-                endforeach()
-            endif()
+                endif()
+            endforeach()
             _deac_receipt_json_quote(_fragment_json "${_fragment}")
             _deac_receipt_optional_string(
                 _role_json "${label}[${_index}].role"
@@ -636,6 +772,22 @@ function(_deac_receipt_compile_groups
             _deac_receipt_json_quote(_language_json "${_language}")
             _deac_receipt_source_array(
                 _sources_json ${_group} "${target_document}")
+            _deac_receipt_json_type(
+                _pch_type _pch_exists
+                "${label} compile group precompiled headers"
+                "${target_document}"
+                compileGroups ${_group} precompileHeaders)
+            if(_pch_exists AND _pch_type STREQUAL "ARRAY")
+                _deac_receipt_json_length(
+                    _pch_count "${label} compile group precompiled headers"
+                    "${target_document}"
+                    compileGroups ${_group} precompileHeaders)
+                if(_pch_count GREATER 0)
+                    message(FATAL_ERROR
+                        "build-receipt ${label} compile group uses "
+                        "unsupported nonempty structured precompiled headers")
+                endif()
+            endif()
             _deac_receipt_fragment_array(
                 _fragments_json "${label} compile group fragments"
                 REJECT_FINGERPRINT

--- a/src/cmake/GenerateDeacBuildReceipt.cmake
+++ b/src/cmake/GenerateDeacBuildReceipt.cmake
@@ -1,0 +1,1130 @@
+cmake_minimum_required(VERSION 3.27)
+
+foreach(_required_variable
+        DEAC_BUILD_RECEIPT_SOURCE_ROOT
+        DEAC_BUILD_RECEIPT_CMAKE_SOURCE_ROOT
+        DEAC_BUILD_RECEIPT_BUILD_ROOT
+        DEAC_BUILD_RECEIPT_REPLY_DIRECTORY
+        DEAC_BUILD_RECEIPT_TARGET
+        DEAC_BUILD_RECEIPT_CONFIGURATION
+        DEAC_BUILD_RECEIPT_BACKEND
+        DEAC_BUILD_RECEIPT_CACHE_KEYS
+        DEAC_BUILD_RECEIPT_LANGUAGES
+        DEAC_BUILD_RECEIPT_TOOLCHAIN_FINGERPRINT
+        DEAC_BUILD_RECEIPT_CMAKE_PATH
+        DEAC_BUILD_RECEIPT_CMAKE_REAL_PATH
+        DEAC_BUILD_RECEIPT_CMAKE_SHA256
+        DEAC_BUILD_RECEIPT_OUTPUT_SOURCE
+        DEAC_BUILD_RECEIPT_OUTPUT_RECEIPT)
+    if(NOT DEFINED ${_required_variable} OR
+            "${${_required_variable}}" STREQUAL "")
+        message(FATAL_ERROR "${_required_variable} is required")
+    endif()
+endforeach()
+if(NOT DEFINED DEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS)
+    message(FATAL_ERROR "DEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS is required")
+endif()
+
+function(_deac_receipt_json_quote output value)
+    set(_value "${value}")
+    string(REPLACE "\\" "\\\\" _value "${_value}")
+    string(REPLACE "\"" "\\\"" _value "${_value}")
+    string(ASCII 8 _backspace)
+    string(ASCII 12 _form_feed)
+    string(REPLACE "${_backspace}" "\\b" _value "${_value}")
+    string(REPLACE "${_form_feed}" "\\f" _value "${_value}")
+    string(REPLACE "\n" "\\n" _value "${_value}")
+    string(REPLACE "\r" "\\r" _value "${_value}")
+    string(REPLACE "\t" "\\t" _value "${_value}")
+    set(${output} "\"${_value}\"" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_json_get output label document)
+    string(JSON _value ERROR_VARIABLE _error GET "${document}" ${ARGN})
+    if(NOT _error STREQUAL "NOTFOUND")
+        message(FATAL_ERROR
+            "build-receipt ${label} is missing or invalid: ${_error}")
+    endif()
+    set(${output} "${_value}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_json_length output label document)
+    string(JSON _value ERROR_VARIABLE _error LENGTH "${document}" ${ARGN})
+    if(NOT _error STREQUAL "NOTFOUND")
+        message(FATAL_ERROR
+            "build-receipt ${label} is missing or invalid: ${_error}")
+    endif()
+    set(${output} "${_value}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_json_type output exists label document)
+    string(JSON _value ERROR_VARIABLE _error TYPE "${document}" ${ARGN})
+    if(_error STREQUAL "NOTFOUND")
+        set(${output} "${_value}" PARENT_SCOPE)
+        set(${exists} true PARENT_SCOPE)
+    else()
+        set(${output} "" PARENT_SCOPE)
+        set(${exists} false PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(_deac_receipt_optional_string output label document)
+    _deac_receipt_json_type(
+        _type _exists "${label}" "${document}" ${ARGN})
+    if(NOT _exists)
+        set(${output} "null" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT _type STREQUAL "STRING")
+        message(FATAL_ERROR "build-receipt ${label} must be a string")
+    endif()
+    _deac_receipt_json_get(_value "${label}" "${document}" ${ARGN})
+    _deac_receipt_json_quote(_quoted "${_value}")
+    set(${output} "${_quoted}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_optional_path output label document)
+    _deac_receipt_json_type(
+        _type _exists "${label}" "${document}" ${ARGN})
+    if(NOT _exists)
+        set(${output} "null" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT _type STREQUAL "STRING")
+        message(FATAL_ERROR "build-receipt ${label} must be a string")
+    endif()
+    _deac_receipt_json_get(_value "${label}" "${document}" ${ARGN})
+    _deac_receipt_normalize_path(_value "${_value}")
+    _deac_receipt_json_quote(_quoted "${_value}")
+    set(${output} "${_quoted}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_optional_boolean output label document)
+    _deac_receipt_json_type(
+        _type _exists "${label}" "${document}" ${ARGN})
+    if(NOT _exists)
+        set(${output} "false" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT _type STREQUAL "BOOLEAN")
+        message(FATAL_ERROR "build-receipt ${label} must be a boolean")
+    endif()
+    _deac_receipt_json_get(_value "${label}" "${document}" ${ARGN})
+    if(_value)
+        set(${output} "true" PARENT_SCOPE)
+    else()
+        set(${output} "false" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(_deac_receipt_latest_index output reply_directory)
+    file(GLOB _matches LIST_DIRECTORIES false
+        "${reply_directory}/index-*.json")
+    list(LENGTH _matches _count)
+    if(_count LESS 1)
+        message(FATAL_ERROR "build-receipt File API index is unavailable")
+    endif()
+    # The File API specifies the lexicographically greatest index as current
+    # during the brief interval in which two generation indexes coexist.
+    list(SORT _matches)
+    list(GET _matches -1 _match)
+    set(${output} "${_match}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_reply_file
+        output label reply_key expected_kind expected_major index_document)
+    _deac_receipt_json_get(
+        _json_file "${label} JSON file" "${index_document}"
+        reply "${reply_key}" jsonFile)
+    _deac_receipt_json_get(
+        _kind "${label} kind" "${index_document}"
+        reply "${reply_key}" kind)
+    _deac_receipt_json_get(
+        _major "${label} major version" "${index_document}"
+        reply "${reply_key}" version major)
+    if(NOT _kind STREQUAL "${expected_kind}" OR
+            NOT _major EQUAL expected_major)
+        message(FATAL_ERROR
+            "build-receipt ${label} reply has an unsupported kind/version")
+    endif()
+    if(NOT _json_file MATCHES "^[A-Za-z0-9_.-]+\\.json$")
+        message(FATAL_ERROR
+            "build-receipt ${label} reply has an unsafe filename")
+    endif()
+    set(${output}
+        "${DEAC_BUILD_RECEIPT_REPLY_DIRECTORY}/${_json_file}"
+        PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_one_file output label pattern)
+    file(GLOB _matches LIST_DIRECTORIES false "${pattern}")
+    list(LENGTH _matches _count)
+    if(NOT _count EQUAL 1)
+        message(FATAL_ERROR
+            "build-receipt expected one ${label}, found ${_count}")
+    endif()
+    list(GET _matches 0 _match)
+    set(${output} "${_match}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_read_json output label path)
+    if(NOT EXISTS "${path}" OR IS_DIRECTORY "${path}")
+        message(FATAL_ERROR "build-receipt ${label} is unavailable: ${path}")
+    endif()
+    file(SIZE "${path}" _size)
+    if(_size GREATER 8388608)
+        message(FATAL_ERROR "build-receipt ${label} exceeds 8 MiB")
+    endif()
+    file(READ "${path}" _document)
+    string(JSON _type ERROR_VARIABLE _error TYPE "${_document}")
+    if(NOT _error STREQUAL "NOTFOUND" OR NOT _type STREQUAL "OBJECT")
+        message(FATAL_ERROR "build-receipt ${label} is not a JSON object")
+    endif()
+    set(${output} "${_document}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_normalize_path output value)
+    set(_path "${value}")
+    if(NOT IS_ABSOLUTE "${_path}")
+        cmake_path(
+            ABSOLUTE_PATH _path
+            BASE_DIRECTORY "${DEAC_BUILD_RECEIPT_CMAKE_SOURCE_ROOT}"
+            NORMALIZE
+            OUTPUT_VARIABLE _path)
+    else()
+        cmake_path(NORMAL_PATH _path OUTPUT_VARIABLE _path)
+    endif()
+    foreach(_root_kind SOURCE BUILD)
+        if(_root_kind STREQUAL "SOURCE")
+            set(_root "${DEAC_BUILD_RECEIPT_CMAKE_SOURCE_ROOT}")
+            set(_token "<SOURCE_ROOT>")
+        else()
+            set(_root "${DEAC_BUILD_RECEIPT_BUILD_ROOT}")
+            set(_token "<BUILD_ROOT>")
+        endif()
+        cmake_path(NORMAL_PATH _root OUTPUT_VARIABLE _root)
+        file(RELATIVE_PATH _relative "${_root}" "${_path}")
+        if(_relative STREQUAL "")
+            set(${output} "${_token}" PARENT_SCOPE)
+            return()
+        endif()
+        if(NOT IS_ABSOLUTE "${_relative}" AND
+                NOT _relative MATCHES "^\.\.(/|$)")
+            set(${output} "${_token}/${_relative}" PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+    set(${output} "${_path}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_normalize_path_list output value)
+    set(_normalized "")
+    set(_separator "")
+    foreach(_element IN LISTS value)
+        if(_element STREQUAL "")
+            set(_normalized_element "")
+        else()
+            _deac_receipt_normalize_path(
+                _normalized_element "${_element}")
+        endif()
+        string(APPEND _normalized
+            "${_separator}${_normalized_element}")
+        set(_separator ";")
+    endforeach()
+    set(${output} "${_normalized}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_string_array output label document)
+    _deac_receipt_json_type(
+        _type _exists "${label}" "${document}" ${ARGN})
+    if(NOT _exists)
+        set(${output} "[]" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT _type STREQUAL "ARRAY")
+        message(FATAL_ERROR "build-receipt ${label} must be an array")
+    endif()
+    _deac_receipt_json_length(_length "${label}" "${document}" ${ARGN})
+    set(_json "[")
+    set(_separator "")
+    if(_length GREATER 0)
+        math(EXPR _last "${_length} - 1")
+        foreach(_index RANGE 0 ${_last})
+            _deac_receipt_json_get(
+                _value "${label}[${_index}]" "${document}" ${ARGN} ${_index})
+            _deac_receipt_json_quote(_quoted "${_value}")
+            string(APPEND _json "${_separator}${_quoted}")
+            set(_separator ",")
+        endforeach()
+    endif()
+    string(APPEND _json "]")
+    set(${output} "${_json}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_path_array output label document)
+    _deac_receipt_json_type(
+        _type _exists "${label}" "${document}" ${ARGN})
+    if(NOT _exists)
+        set(${output} "[]" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT _type STREQUAL "ARRAY")
+        message(FATAL_ERROR "build-receipt ${label} must be an array")
+    endif()
+    _deac_receipt_json_length(_length "${label}" "${document}" ${ARGN})
+    set(_json "[")
+    set(_separator "")
+    if(_length GREATER 0)
+        math(EXPR _last "${_length} - 1")
+        foreach(_index RANGE 0 ${_last})
+            _deac_receipt_json_get(
+                _value "${label}[${_index}]" "${document}" ${ARGN} ${_index})
+            _deac_receipt_normalize_path(_normalized "${_value}")
+            _deac_receipt_json_quote(_quoted "${_normalized}")
+            string(APPEND _json "${_separator}${_quoted}")
+            set(_separator ",")
+        endforeach()
+    endif()
+    string(APPEND _json "]")
+    set(${output} "${_json}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_fragment_array output label document)
+    _deac_receipt_json_type(
+        _type _exists "${label}" "${document}" ${ARGN})
+    if(NOT _exists)
+        set(${output} "[]" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT _type STREQUAL "ARRAY")
+        message(FATAL_ERROR "build-receipt ${label} must be an array")
+    endif()
+    _deac_receipt_json_length(_length "${label}" "${document}" ${ARGN})
+    set(_json "[")
+    set(_separator "")
+    if(_length GREATER 0)
+        math(EXPR _last "${_length} - 1")
+        foreach(_index RANGE 0 ${_last})
+            _deac_receipt_json_get(
+                _fragment "${label}[${_index}].fragment"
+                "${document}" ${ARGN} ${_index} fragment)
+            _deac_receipt_json_quote(_fragment_json "${_fragment}")
+            _deac_receipt_optional_string(
+                _role_json "${label}[${_index}].role"
+                "${document}" ${ARGN} ${_index} role)
+            string(APPEND _json
+                "${_separator}{\"fragment\":${_fragment_json},\"role\":${_role_json}}")
+            set(_separator ",")
+        endforeach()
+    endif()
+    string(APPEND _json "]")
+    set(${output} "${_json}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_named_array output label field document)
+    _deac_receipt_json_type(
+        _type _exists "${label}" "${document}" ${ARGN})
+    if(NOT _exists)
+        set(${output} "[]" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT _type STREQUAL "ARRAY")
+        message(FATAL_ERROR "build-receipt ${label} must be an array")
+    endif()
+    _deac_receipt_json_length(_length "${label}" "${document}" ${ARGN})
+    set(_json "[")
+    set(_separator "")
+    if(_length GREATER 0)
+        math(EXPR _last "${_length} - 1")
+        foreach(_index RANGE 0 ${_last})
+            _deac_receipt_json_get(
+                _value "${label}[${_index}].${field}"
+                "${document}" ${ARGN} ${_index} "${field}")
+            _deac_receipt_json_quote(_quoted "${_value}")
+            string(APPEND _json "${_separator}${_quoted}")
+            set(_separator ",")
+        endforeach()
+    endif()
+    string(APPEND _json "]")
+    set(${output} "${_json}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_named_path_array output label field document)
+    _deac_receipt_json_type(
+        _type _exists "${label}" "${document}" ${ARGN})
+    if(NOT _exists)
+        set(${output} "[]" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT _type STREQUAL "ARRAY")
+        message(FATAL_ERROR "build-receipt ${label} must be an array")
+    endif()
+    _deac_receipt_json_length(_length "${label}" "${document}" ${ARGN})
+    set(_json "[")
+    set(_separator "")
+    if(_length GREATER 0)
+        math(EXPR _last "${_length} - 1")
+        foreach(_index RANGE 0 ${_last})
+            _deac_receipt_json_get(
+                _value "${label}[${_index}].${field}"
+                "${document}" ${ARGN} ${_index} "${field}")
+            _deac_receipt_normalize_path(_value "${_value}")
+            _deac_receipt_json_quote(_quoted "${_value}")
+            string(APPEND _json "${_separator}${_quoted}")
+            set(_separator ",")
+        endforeach()
+    endif()
+    string(APPEND _json "]")
+    set(${output} "${_json}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_include_array output label document)
+    _deac_receipt_json_type(
+        _type _exists "${label}" "${document}" ${ARGN})
+    if(NOT _exists)
+        set(${output} "[]" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT _type STREQUAL "ARRAY")
+        message(FATAL_ERROR "build-receipt ${label} must be an array")
+    endif()
+    _deac_receipt_json_length(_length "${label}" "${document}" ${ARGN})
+    set(_json "[")
+    set(_separator "")
+    if(_length GREATER 0)
+        math(EXPR _last "${_length} - 1")
+        foreach(_index RANGE 0 ${_last})
+            _deac_receipt_json_get(
+                _path "${label}[${_index}].path"
+                "${document}" ${ARGN} ${_index} path)
+            _deac_receipt_normalize_path(_path "${_path}")
+            _deac_receipt_json_quote(_path_json "${_path}")
+            _deac_receipt_optional_boolean(
+                _system_json "${label}[${_index}].isSystem"
+                "${document}" ${ARGN} ${_index} isSystem)
+            string(APPEND _json
+                "${_separator}{\"path\":${_path_json},\"system\":${_system_json}}")
+            set(_separator ",")
+        endforeach()
+    endif()
+    string(APPEND _json "]")
+    set(${output} "${_json}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_source_array output group_index target_document)
+    _deac_receipt_json_length(
+        _length "compile group ${group_index} source indexes"
+        "${target_document}" compileGroups ${group_index} sourceIndexes)
+    set(_json "[")
+    set(_separator "")
+    if(_length GREATER 0)
+        math(EXPR _last "${_length} - 1")
+        foreach(_index RANGE 0 ${_last})
+            _deac_receipt_json_get(
+                _source_index "compile group source index"
+                "${target_document}"
+                compileGroups ${group_index} sourceIndexes ${_index})
+            _deac_receipt_json_get(
+                _path "compile group source path"
+                "${target_document}" sources ${_source_index} path)
+            _deac_receipt_normalize_path(_path "${_path}")
+            _deac_receipt_json_quote(_path_json "${_path}")
+            string(APPEND _json "${_separator}${_path_json}")
+            set(_separator ",")
+        endforeach()
+    endif()
+    string(APPEND _json "]")
+    set(${output} "${_json}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_compile_groups
+        output languages_output label target_document require_fingerprint)
+    _deac_receipt_json_type(
+        _type _exists "${label} compile groups"
+        "${target_document}" compileGroups)
+    if(NOT _exists)
+        set(${output} "[]" PARENT_SCOPE)
+        set(${languages_output} "" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT _type STREQUAL "ARRAY")
+        message(FATAL_ERROR
+            "build-receipt ${label} compile groups must be an array")
+    endif()
+    _deac_receipt_json_length(
+        _count "${label} compile groups" "${target_document}" compileGroups)
+    if(require_fingerprint AND _count LESS 1)
+        message(FATAL_ERROR
+            "build-receipt ${label} has no compile groups")
+    endif()
+
+    set(_json "[")
+    set(_separator "")
+    set(_languages)
+    if(_count GREATER 0)
+        math(EXPR _last "${_count} - 1")
+        foreach(_group RANGE 0 ${_last})
+            _deac_receipt_json_get(
+                _language "${label} compile group language"
+                "${target_document}" compileGroups ${_group} language)
+            list(APPEND _languages "${_language}")
+            _deac_receipt_json_quote(_language_json "${_language}")
+            _deac_receipt_source_array(
+                _sources_json ${_group} "${target_document}")
+            _deac_receipt_fragment_array(
+                _fragments_json "${label} compile group fragments"
+                "${target_document}"
+                compileGroups ${_group} compileCommandFragments)
+            _deac_receipt_named_array(
+                _defines_json "${label} compile group definitions" define
+                "${target_document}" compileGroups ${_group} defines)
+            _deac_receipt_include_array(
+                _includes_json "${label} compile group includes"
+                "${target_document}" compileGroups ${_group} includes)
+            _deac_receipt_include_array(
+                _frameworks_json "${label} compile group frameworks"
+                "${target_document}" compileGroups ${_group} frameworks)
+            _deac_receipt_named_path_array(
+                _pch_json "${label} compile group precompiled headers" header
+                "${target_document}"
+                compileGroups ${_group} precompileHeaders)
+            _deac_receipt_optional_string(
+                _standard_json "${label} compile group language standard"
+                "${target_document}"
+                compileGroups ${_group} languageStandard standard)
+            _deac_receipt_optional_path(
+                _sysroot_json "${label} compile group sysroot"
+                "${target_document}" compileGroups ${_group} sysroot path)
+
+            if(require_fingerprint)
+                set(_expected_definition
+                    "DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256=${DEAC_BUILD_RECEIPT_TOOLCHAIN_FINGERPRINT}")
+                _deac_receipt_json_type(
+                    _definitions_type _definitions_exist
+                    "${label} compile group definitions"
+                    "${target_document}" compileGroups ${_group} defines)
+                set(_fingerprint_matches 0)
+                if(_definitions_exist)
+                    _deac_receipt_json_length(
+                        _definition_count "${label} compile group definitions"
+                        "${target_document}" compileGroups ${_group} defines)
+                    if(_definition_count GREATER 0)
+                        math(EXPR _definition_last "${_definition_count} - 1")
+                        foreach(_definition_index RANGE 0 ${_definition_last})
+                            _deac_receipt_json_get(
+                                _definition "${label} compile definition"
+                                "${target_document}" compileGroups ${_group}
+                                defines ${_definition_index} define)
+                            if(_definition STREQUAL _expected_definition)
+                                math(EXPR _fingerprint_matches
+                                    "${_fingerprint_matches} + 1")
+                            endif()
+                        endforeach()
+                    endif()
+                endif()
+                if(NOT _fingerprint_matches EQUAL 1)
+                    message(FATAL_ERROR
+                        "build-receipt ${label} compile group does not contain "
+                        "exactly one configured toolchain fingerprint")
+                endif()
+            endif()
+
+            string(APPEND _json
+                "${_separator}{\"command_fragments\":${_fragments_json},"
+                "\"definitions\":${_defines_json},"
+                "\"frameworks\":${_frameworks_json},"
+                "\"includes\":${_includes_json},"
+                "\"language\":${_language_json},"
+                "\"language_standard\":${_standard_json},"
+                "\"precompiled_headers\":${_pch_json},"
+                "\"sources\":${_sources_json},"
+                "\"sysroot\":${_sysroot_json}}")
+            set(_separator ",")
+        endforeach()
+    endif()
+    string(APPEND _json "]")
+    list(REMOVE_DUPLICATES _languages)
+    list(SORT _languages)
+    set(${output} "${_json}" PARENT_SCOPE)
+    set(${languages_output} "${_languages}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_link output language_output label target_document required)
+    _deac_receipt_json_type(
+        _type _exists "${label} link" "${target_document}" link)
+    if(NOT _exists)
+        if(required)
+            message(FATAL_ERROR "build-receipt ${label} has no link object")
+        endif()
+        set(${output} "null" PARENT_SCOPE)
+        set(${language_output} "" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT _type STREQUAL "OBJECT")
+        message(FATAL_ERROR "build-receipt ${label} link must be an object")
+    endif()
+    _deac_receipt_json_get(
+        _language "${label} link language" "${target_document}" link language)
+    _deac_receipt_json_quote(_language_json "${_language}")
+    _deac_receipt_fragment_array(
+        _fragments_json "${label} link fragments"
+        "${target_document}" link commandFragments)
+    _deac_receipt_optional_boolean(
+        _lto_json "${label} link LTO" "${target_document}" link lto)
+    _deac_receipt_optional_path(
+        _sysroot_json "${label} link sysroot"
+        "${target_document}" link sysroot path)
+    string(CONCAT _json
+        "{\"command_fragments\":" "${_fragments_json}" ","
+        "\"language\":" "${_language_json}" ","
+        "\"lto\":" "${_lto_json}" ","
+        "\"sysroot\":" "${_sysroot_json}" "}")
+    set(${output} "${_json}" PARENT_SCOPE)
+    set(${language_output} "${_language}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_archive output label target_document)
+    _deac_receipt_json_type(
+        _type _exists "${label} archive" "${target_document}" archive)
+    if(NOT _exists)
+        set(${output} "null" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT _type STREQUAL "OBJECT")
+        message(FATAL_ERROR "build-receipt ${label} archive must be an object")
+    endif()
+    _deac_receipt_fragment_array(
+        _fragments_json "${label} archive fragments"
+        "${target_document}" archive commandFragments)
+    _deac_receipt_optional_boolean(
+        _lto_json "${label} archive LTO" "${target_document}" archive lto)
+    set(_json
+        "{\"command_fragments\":${_fragments_json},\"lto\":${_lto_json}}")
+    set(${output} "${_json}" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_cache_entry output found name cache_document)
+    _deac_receipt_json_length(_length "cache entries" "${cache_document}" entries)
+    set(_match_count 0)
+    if(_length GREATER 0)
+        math(EXPR _last "${_length} - 1")
+        foreach(_index RANGE 0 ${_last})
+            _deac_receipt_json_get(
+                _candidate "cache entry name"
+                "${cache_document}" entries ${_index} name)
+            if(_candidate STREQUAL "${name}")
+                math(EXPR _match_count "${_match_count} + 1")
+                _deac_receipt_json_get(
+                    _type "cache entry ${name} type"
+                    "${cache_document}" entries ${_index} type)
+                _deac_receipt_json_get(
+                    _value "cache entry ${name} value"
+                    "${cache_document}" entries ${_index} value)
+            endif()
+        endforeach()
+    endif()
+    if(_match_count GREATER 1)
+        message(FATAL_ERROR "build-receipt cache contains duplicate ${name}")
+    endif()
+    if(_match_count EQUAL 0)
+        set(${output}
+            "{\"name\":\"${name}\",\"type\":null,\"value\":null}"
+            PARENT_SCOPE)
+        set(${found} false PARENT_SCOPE)
+        return()
+    endif()
+    _deac_receipt_json_quote(_name_json "${name}")
+    _deac_receipt_json_quote(_type_json "${_type}")
+    set(_canonical_value "${_value}")
+    if(NOT _canonical_value STREQUAL "" AND
+            NOT _canonical_value MATCHES "-NOTFOUND$")
+        if(_type MATCHES "^(FILEPATH|PATH)$" OR
+                name STREQUAL "CMAKE_PREFIX_PATH")
+            _deac_receipt_normalize_path_list(
+                _canonical_value "${_canonical_value}")
+        elseif(name MATCHES
+                "^(CMAKE_GENERATOR_INSTANCE|CMAKE_HOME_DIRECTORY)$")
+            _deac_receipt_normalize_path(
+                _canonical_value "${_canonical_value}")
+        endif()
+    endif()
+    _deac_receipt_json_quote(_value_json "${_canonical_value}")
+    set(${output}
+        "{\"name\":${_name_json},\"type\":${_type_json},\"value\":${_value_json}}"
+        PARENT_SCOPE)
+    set(${found} true PARENT_SCOPE)
+    set(${name}_VALUE "${_value}" PARENT_SCOPE)
+endfunction()
+
+include("${CMAKE_CURRENT_LIST_DIR}/DeacBuildIdentity.cmake")
+_deac_compute_build_identity("${DEAC_BUILD_RECEIPT_SOURCE_ROOT}")
+
+foreach(_path_variable
+        DEAC_BUILD_RECEIPT_SOURCE_ROOT
+        DEAC_BUILD_RECEIPT_CMAKE_SOURCE_ROOT
+        DEAC_BUILD_RECEIPT_BUILD_ROOT
+        DEAC_BUILD_RECEIPT_REPLY_DIRECTORY)
+    cmake_path(NORMAL_PATH ${_path_variable})
+endforeach()
+
+_deac_receipt_latest_index(
+    _index_file "${DEAC_BUILD_RECEIPT_REPLY_DIRECTORY}")
+_deac_receipt_read_json(_index "File API index" "${_index_file}")
+_deac_receipt_reply_file(
+    _codemodel_file "codemodel" "codemodel-v2" "codemodel" 2 "${_index}")
+_deac_receipt_reply_file(
+    _toolchains_file "toolchains" "toolchains-v1" "toolchains" 1 "${_index}")
+_deac_receipt_reply_file(
+    _cache_file "cache" "cache-v2" "cache" 2 "${_index}")
+_deac_receipt_read_json(_codemodel "File API codemodel" "${_codemodel_file}")
+_deac_receipt_read_json(_toolchains "File API toolchains" "${_toolchains_file}")
+_deac_receipt_read_json(_cache "File API cache" "${_cache_file}")
+
+_deac_receipt_json_get(_codemodel_major "codemodel major" "${_codemodel}" version major)
+_deac_receipt_json_get(_codemodel_minor "codemodel minor" "${_codemodel}" version minor)
+if(NOT _codemodel_major EQUAL 2 OR _codemodel_minor LESS 6)
+    message(FATAL_ERROR
+        "build receipt requires File API codemodel 2.6 or newer")
+endif()
+_deac_receipt_json_get(_toolchains_major "toolchains major" "${_toolchains}" version major)
+if(NOT _toolchains_major EQUAL 1)
+    message(FATAL_ERROR "unsupported File API toolchains schema")
+endif()
+_deac_receipt_json_get(_cache_major "cache major" "${_cache}" version major)
+if(NOT _cache_major EQUAL 2)
+    message(FATAL_ERROR "unsupported File API cache schema")
+endif()
+
+_deac_receipt_json_get(_model_source "codemodel source root" "${_codemodel}" paths source)
+_deac_receipt_json_get(_model_build "codemodel build root" "${_codemodel}" paths build)
+cmake_path(NORMAL_PATH _model_source)
+cmake_path(NORMAL_PATH _model_build)
+if(NOT _model_source STREQUAL DEAC_BUILD_RECEIPT_CMAKE_SOURCE_ROOT OR
+        NOT _model_build STREQUAL DEAC_BUILD_RECEIPT_BUILD_ROOT)
+    message(FATAL_ERROR
+        "build-receipt File API roots disagree with the configured build")
+endif()
+
+_deac_receipt_json_length(
+    _configuration_count "codemodel configurations"
+    "${_codemodel}" configurations)
+set(_configuration_index "")
+set(_configuration_matches 0)
+if(_configuration_count GREATER 0)
+    math(EXPR _configuration_last "${_configuration_count} - 1")
+    foreach(_index RANGE 0 ${_configuration_last})
+        _deac_receipt_json_get(
+            _name "configuration name" "${_codemodel}" configurations ${_index} name)
+        if(_name STREQUAL DEAC_BUILD_RECEIPT_CONFIGURATION)
+            set(_configuration_index ${_index})
+            math(EXPR _configuration_matches "${_configuration_matches} + 1")
+        endif()
+    endforeach()
+endif()
+if(NOT _configuration_matches EQUAL 1)
+    message(FATAL_ERROR
+        "build-receipt configuration ${DEAC_BUILD_RECEIPT_CONFIGURATION} "
+        "matched ${_configuration_matches} File API configurations")
+endif()
+
+_deac_receipt_json_length(
+    _target_count "codemodel targets" "${_codemodel}"
+    configurations ${_configuration_index} targets)
+set(_target_json_file "")
+set(_target_matches 0)
+if(_target_count GREATER 0)
+    math(EXPR _target_last "${_target_count} - 1")
+    foreach(_index RANGE 0 ${_target_last})
+        _deac_receipt_json_get(
+            _name "target name" "${_codemodel}"
+            configurations ${_configuration_index} targets ${_index} name)
+        if(_name STREQUAL DEAC_BUILD_RECEIPT_TARGET)
+            _deac_receipt_json_get(
+                _target_json_file "target JSON file" "${_codemodel}"
+                configurations ${_configuration_index} targets ${_index} jsonFile)
+            math(EXPR _target_matches "${_target_matches} + 1")
+        endif()
+    endforeach()
+endif()
+if(NOT _target_matches EQUAL 1)
+    message(FATAL_ERROR
+        "build-receipt target ${DEAC_BUILD_RECEIPT_TARGET} matched "
+        "${_target_matches} File API targets")
+endif()
+_deac_receipt_read_json(
+    _target "target codemodel"
+    "${DEAC_BUILD_RECEIPT_REPLY_DIRECTORY}/${_target_json_file}")
+_deac_receipt_json_get(_target_type "target type" "${_target}" type)
+if(NOT _target_type STREQUAL "EXECUTABLE")
+    message(FATAL_ERROR "build-receipt target is not an executable")
+endif()
+_deac_receipt_json_get(_target_name "target name" "${_target}" name)
+_deac_receipt_json_get(_target_disk_name "target disk name" "${_target}" nameOnDisk)
+if(NOT _target_name STREQUAL DEAC_BUILD_RECEIPT_TARGET)
+    message(FATAL_ERROR "build-receipt target object name changed")
+endif()
+
+string(REPLACE "," ";" _cache_keys "${DEAC_BUILD_RECEIPT_CACHE_KEYS}")
+set(_cache_json "[")
+set(_separator "")
+foreach(_key IN LISTS _cache_keys)
+    _deac_receipt_cache_entry(_entry _found "${_key}" "${_cache}")
+    string(APPEND _cache_json "${_separator}${_entry}")
+    set(_separator ",")
+endforeach()
+string(APPEND _cache_json "]")
+if(NOT DEFINED GPU_BACKEND_VALUE OR
+        NOT GPU_BACKEND_VALUE STREQUAL DEAC_BUILD_RECEIPT_BACKEND)
+    message(FATAL_ERROR
+        "build-receipt backend disagrees with the generated CMake cache")
+endif()
+
+_deac_receipt_compile_groups(
+    _compile_groups_json _target_compile_languages
+    "target ${_target_name}" "${_target}" true)
+_deac_receipt_link(
+    _link_json _link_language "target ${_target_name}" "${_target}" true)
+set(_used_languages ${_target_compile_languages} "${_link_language}")
+
+_deac_receipt_json_type(
+    _dependencies_type _dependencies_exist
+    "target ${_target_name} dependencies" "${_target}" dependencies)
+set(_dependency_ids)
+if(_dependencies_exist)
+    if(NOT _dependencies_type STREQUAL "ARRAY")
+        message(FATAL_ERROR "build-receipt target dependencies must be an array")
+    endif()
+    _deac_receipt_json_length(
+        _dependency_count "target dependencies" "${_target}" dependencies)
+    if(_dependency_count GREATER 0)
+        math(EXPR _dependency_last "${_dependency_count} - 1")
+        foreach(_dependency_index RANGE 0 ${_dependency_last})
+            _deac_receipt_json_get(
+                _dependency_id "target dependency ID" "${_target}"
+                dependencies ${_dependency_index} id)
+            list(APPEND _dependency_ids "${_dependency_id}")
+        endforeach()
+    endif()
+endif()
+list(REMOVE_DUPLICATES _dependency_ids)
+
+set(_actual_dependency_names)
+foreach(_dependency_id IN LISTS _dependency_ids)
+    set(_dependency_matches 0)
+    if(_target_count GREATER 0)
+        foreach(_candidate_index RANGE 0 ${_target_last})
+            _deac_receipt_json_get(
+                _candidate_id "dependency candidate ID" "${_codemodel}"
+                configurations ${_configuration_index}
+                targets ${_candidate_index} id)
+            if(_candidate_id STREQUAL "${_dependency_id}")
+                _deac_receipt_json_get(
+                    _candidate_name "dependency candidate name" "${_codemodel}"
+                    configurations ${_configuration_index}
+                    targets ${_candidate_index} name)
+                list(APPEND _actual_dependency_names "${_candidate_name}")
+                math(EXPR _dependency_matches "${_dependency_matches} + 1")
+            endif()
+        endforeach()
+    endif()
+    if(NOT _dependency_matches EQUAL 1)
+        message(FATAL_ERROR
+            "build-receipt dependency ${_dependency_id} matched "
+            "${_dependency_matches} configuration targets")
+    endif()
+endforeach()
+list(SORT _actual_dependency_names)
+string(REPLACE "," ";" _expected_dependency_names
+    "${DEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS}")
+list(SORT _expected_dependency_names)
+if(NOT "${_actual_dependency_names}" STREQUAL
+        "${_expected_dependency_names}")
+    message(FATAL_ERROR
+        "build-receipt target dependencies changed: expected "
+        "[${_expected_dependency_names}], got [${_actual_dependency_names}]")
+endif()
+
+set(_dependencies_json "[")
+set(_dependency_separator "")
+foreach(_expected_name IN LISTS _expected_dependency_names)
+    set(_dependency_json_file "")
+    set(_dependency_matches 0)
+    if(_target_count GREATER 0)
+        foreach(_candidate_index RANGE 0 ${_target_last})
+            _deac_receipt_json_get(
+                _candidate_id "dependency candidate ID" "${_codemodel}"
+                configurations ${_configuration_index}
+                targets ${_candidate_index} id)
+            _deac_receipt_json_get(
+                _candidate_name "dependency candidate name" "${_codemodel}"
+                configurations ${_configuration_index}
+                targets ${_candidate_index} name)
+            if(_candidate_name STREQUAL "${_expected_name}" AND
+                    _candidate_id IN_LIST _dependency_ids)
+                _deac_receipt_json_get(
+                    _dependency_json_file "dependency target JSON file"
+                    "${_codemodel}" configurations ${_configuration_index}
+                    targets ${_candidate_index} jsonFile)
+                math(EXPR _dependency_matches "${_dependency_matches} + 1")
+            endif()
+        endforeach()
+    endif()
+    if(NOT _dependency_matches EQUAL 1)
+        message(FATAL_ERROR
+            "build-receipt dependency target ${_expected_name} matched "
+            "${_dependency_matches} File API targets")
+    endif()
+    _deac_receipt_read_json(
+        _dependency "dependency target ${_expected_name}"
+        "${DEAC_BUILD_RECEIPT_REPLY_DIRECTORY}/${_dependency_json_file}")
+    _deac_receipt_json_get(
+        _dependency_name "dependency target name" "${_dependency}" name)
+    _deac_receipt_json_get(
+        _dependency_type "dependency target type" "${_dependency}" type)
+    if(NOT _dependency_name STREQUAL "${_expected_name}")
+        message(FATAL_ERROR "build-receipt dependency target name changed")
+    endif()
+    _deac_receipt_compile_groups(
+        _dependency_compile_groups _dependency_languages
+        "dependency ${_dependency_name}" "${_dependency}" false)
+    _deac_receipt_link(
+        _dependency_link _dependency_link_language
+        "dependency ${_dependency_name}" "${_dependency}" false)
+    _deac_receipt_archive(
+        _dependency_archive "dependency ${_dependency_name}" "${_dependency}")
+    list(APPEND _used_languages
+        ${_dependency_languages} "${_dependency_link_language}")
+    _deac_receipt_json_quote(_dependency_name_json "${_dependency_name}")
+    _deac_receipt_json_quote(_dependency_type_json "${_dependency_type}")
+    string(APPEND _dependencies_json
+        "${_dependency_separator}{\"archive\":${_dependency_archive},"
+        "\"compile_groups\":${_dependency_compile_groups},"
+        "\"link\":${_dependency_link},"
+        "\"name\":${_dependency_name_json},"
+        "\"type\":${_dependency_type_json}}")
+    set(_dependency_separator ",")
+endforeach()
+string(APPEND _dependencies_json "]")
+
+list(FILTER _used_languages EXCLUDE REGEX "^$")
+list(REMOVE_DUPLICATES _used_languages)
+list(SORT _used_languages)
+
+string(REPLACE "," ";" _configured_languages "${DEAC_BUILD_RECEIPT_LANGUAGES}")
+foreach(_language IN LISTS _used_languages)
+    if(NOT _language IN_LIST _configured_languages)
+        message(FATAL_ERROR
+            "build-receipt target uses unbound toolchain language ${_language}")
+    endif()
+endforeach()
+
+_deac_receipt_json_length(
+    _toolchain_count "toolchains" "${_toolchains}" toolchains)
+set(_toolchains_json "[")
+set(_separator "")
+foreach(_language IN LISTS _used_languages)
+    set(_toolchain_index "")
+    set(_matches 0)
+    if(_toolchain_count GREATER 0)
+        math(EXPR _toolchain_last "${_toolchain_count} - 1")
+        foreach(_index RANGE 0 ${_toolchain_last})
+            _deac_receipt_json_get(
+                _candidate "toolchain language" "${_toolchains}"
+                toolchains ${_index} language)
+            if(_candidate STREQUAL "${_language}")
+                set(_toolchain_index ${_index})
+                math(EXPR _matches "${_matches} + 1")
+            endif()
+        endforeach()
+    endif()
+    if(NOT _matches EQUAL 1)
+        message(FATAL_ERROR
+            "build-receipt language ${_language} matched ${_matches} toolchains")
+    endif()
+    _deac_receipt_json_get(
+        _compiler_path "${_language} compiler path" "${_toolchains}"
+        toolchains ${_toolchain_index} compiler path)
+    _deac_receipt_json_get(
+        _compiler_id "${_language} compiler ID" "${_toolchains}"
+        toolchains ${_toolchain_index} compiler id)
+    _deac_receipt_json_get(
+        _compiler_version "${_language} compiler version" "${_toolchains}"
+        toolchains ${_toolchain_index} compiler version)
+    set(_configured_path_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${_language}_PATH")
+    set(_configured_real_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${_language}_REAL_PATH")
+    set(_configured_sha_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${_language}_SHA256")
+    set(_configured_id_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${_language}_ID")
+    set(_configured_version_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${_language}_VERSION")
+    foreach(_variable
+            ${_configured_path_variable}
+            ${_configured_real_variable}
+            ${_configured_sha_variable}
+            ${_configured_id_variable}
+            ${_configured_version_variable})
+        if(NOT DEFINED ${_variable})
+            message(FATAL_ERROR "build-receipt missing ${_variable}")
+        endif()
+    endforeach()
+    if(NOT _compiler_path STREQUAL "${${_configured_path_variable}}" OR
+            NOT _compiler_id STREQUAL "${${_configured_id_variable}}" OR
+            NOT _compiler_version STREQUAL "${${_configured_version_variable}}")
+        message(FATAL_ERROR
+            "build-receipt ${_language} toolchain disagrees with configure-time identity")
+    endif()
+    get_filename_component(_compiler_real "${_compiler_path}" REALPATH)
+    if(NOT EXISTS "${_compiler_real}" OR IS_DIRECTORY "${_compiler_real}")
+        message(FATAL_ERROR
+            "build-receipt ${_language} compiler is no longer a regular file")
+    endif()
+    file(SHA256 "${_compiler_real}" _compiler_sha256)
+    if(NOT _compiler_real STREQUAL "${${_configured_real_variable}}" OR
+            NOT _compiler_sha256 STREQUAL "${${_configured_sha_variable}}")
+        message(FATAL_ERROR
+            "build-receipt ${_language} compiler changed after configuration; "
+            "rerun CMake before building")
+    endif()
+    _deac_receipt_json_quote(_language_json "${_language}")
+    _deac_receipt_normalize_path(_compiler_path_json_value "${_compiler_path}")
+    _deac_receipt_normalize_path(_compiler_real_json_value "${_compiler_real}")
+    _deac_receipt_json_quote(_path_json "${_compiler_path_json_value}")
+    _deac_receipt_json_quote(_real_path_json "${_compiler_real_json_value}")
+    _deac_receipt_json_quote(_sha_json "${_compiler_sha256}")
+    _deac_receipt_json_quote(_id_json "${_compiler_id}")
+    _deac_receipt_json_quote(_version_json "${_compiler_version}")
+    _deac_receipt_optional_string(
+        _target_json "${_language} compiler target" "${_toolchains}"
+        toolchains ${_toolchain_index} compiler target)
+    _deac_receipt_path_array(
+        _implicit_includes "${_language} implicit include directories"
+        "${_toolchains}"
+        toolchains ${_toolchain_index} compiler implicit includeDirectories)
+    _deac_receipt_path_array(
+        _implicit_link_dirs "${_language} implicit link directories"
+        "${_toolchains}"
+        toolchains ${_toolchain_index} compiler implicit linkDirectories)
+    _deac_receipt_path_array(
+        _implicit_framework_dirs "${_language} implicit framework directories"
+        "${_toolchains}"
+        toolchains ${_toolchain_index} compiler implicit linkFrameworkDirectories)
+    _deac_receipt_string_array(
+        _implicit_libraries "${_language} implicit link libraries"
+        "${_toolchains}"
+        toolchains ${_toolchain_index} compiler implicit linkLibraries)
+    string(APPEND _toolchains_json
+        "${_separator}{\"compiler\":{"
+        "\"id\":${_id_json},"
+        "\"implicit_framework_directories\":${_implicit_framework_dirs},"
+        "\"implicit_include_directories\":${_implicit_includes},"
+        "\"implicit_link_directories\":${_implicit_link_dirs},"
+        "\"implicit_link_libraries\":${_implicit_libraries},"
+        "\"path\":${_path_json},"
+        "\"real_path\":${_real_path_json},"
+        "\"sha256\":${_sha_json},"
+        "\"target\":${_target_json},"
+        "\"version\":${_version_json}},"
+        "\"language\":${_language_json}}")
+    set(_separator ",")
+endforeach()
+string(APPEND _toolchains_json "]")
+
+get_filename_component(_cmake_real "${DEAC_BUILD_RECEIPT_CMAKE_PATH}" REALPATH)
+if(NOT EXISTS "${_cmake_real}" OR IS_DIRECTORY "${_cmake_real}")
+    message(FATAL_ERROR "build-receipt CMake executable is unavailable")
+endif()
+file(SHA256 "${_cmake_real}" _cmake_sha256)
+if(NOT _cmake_real STREQUAL DEAC_BUILD_RECEIPT_CMAKE_REAL_PATH OR
+        NOT _cmake_sha256 STREQUAL DEAC_BUILD_RECEIPT_CMAKE_SHA256)
+    message(FATAL_ERROR
+        "build-receipt CMake executable changed after configuration")
+endif()
+_deac_receipt_json_get(_index_cmake_path "index CMake path" "${_index}" cmake paths cmake)
+get_filename_component(_index_cmake_real "${_index_cmake_path}" REALPATH)
+if(NOT _index_cmake_real STREQUAL _cmake_real)
+    message(FATAL_ERROR "build-receipt File API was generated by another CMake")
+endif()
+_deac_receipt_json_get(
+    _cmake_version "index CMake version" "${_index}" cmake version string)
+_deac_receipt_json_get(
+    _generator_name "index generator" "${_index}" cmake generator name)
+_deac_receipt_json_get(
+    _generator_multi "index multi-config flag" "${_index}" cmake generator multiConfig)
+if(_generator_multi)
+    set(_generator_multi_json true)
+else()
+    set(_generator_multi_json false)
+endif()
+_deac_receipt_optional_string(
+    _generator_platform_json "index generator platform" "${_index}"
+    cmake generator platform)
+_deac_receipt_optional_string(
+    _generator_toolset_json "index generator toolset" "${_index}"
+    cmake generator toolset)
+_deac_receipt_normalize_path(
+    _cmake_path_json_value "${DEAC_BUILD_RECEIPT_CMAKE_PATH}")
+_deac_receipt_normalize_path(_cmake_real_json_value "${_cmake_real}")
+_deac_receipt_json_quote(_cmake_path_json "${_cmake_path_json_value}")
+_deac_receipt_json_quote(_cmake_real_json "${_cmake_real_json_value}")
+_deac_receipt_json_quote(_cmake_sha_json "${_cmake_sha256}")
+_deac_receipt_json_quote(_cmake_version_json "${_cmake_version}")
+_deac_receipt_json_quote(_generator_name_json "${_generator_name}")
+_deac_receipt_json_quote(_configuration_json "${DEAC_BUILD_RECEIPT_CONFIGURATION}")
+string(CONCAT _build_system_json
+    "{\"cmake\":{\"path\":" "${_cmake_path_json}" ","
+    "\"real_path\":" "${_cmake_real_json}" ","
+    "\"sha256\":" "${_cmake_sha_json}" ","
+    "\"version\":" "${_cmake_version_json}" "},"
+    "\"configuration\":" "${_configuration_json}" ","
+    "\"generator\":{\"multi_config\":" "${_generator_multi_json}" ","
+    "\"name\":" "${_generator_name_json}" ","
+    "\"platform\":" "${_generator_platform_json}" ","
+    "\"toolset\":" "${_generator_toolset_json}" "}}")
+
+_deac_receipt_json_quote(_backend_json "${DEAC_BUILD_RECEIPT_BACKEND}")
+_deac_receipt_json_quote(_target_name_json "${_target_name}")
+_deac_receipt_json_quote(_target_disk_json "${_target_disk_name}")
+_deac_receipt_json_quote(
+    _toolchain_fingerprint_json
+    "${DEAC_BUILD_RECEIPT_TOOLCHAIN_FINGERPRINT}")
+string(CONCAT _payload
+    "{\"backend\":" "${_backend_json}" ","
+    "\"build_system\":" "${_build_system_json}" ","
+    "\"cache_entries\":" "${_cache_json}" ","
+    "\"compile_groups\":" "${_compile_groups_json}" ","
+    "\"link\":" "${_link_json}" ","
+    "\"source_identity\":" "${DEAC_BUILD_IDENTITY_CANONICAL_JSON}" ","
+    "\"target\":{\"name\":" "${_target_name_json}" ","
+    "\"name_on_disk\":" "${_target_disk_json}" ","
+    "\"toolchain_fingerprint_sha256\":"
+    "${_toolchain_fingerprint_json}" ","
+    "\"type\":\"EXECUTABLE\"},"
+    "\"target_dependencies\":" "${_dependencies_json}" ","
+    "\"toolchains\":" "${_toolchains_json}" "}")
+string(SHA256 _payload_sha256 "${_payload}")
+string(CONCAT _canonical_json
+    "{\"schema_version\":1,\"receipt_sha256\":\""
+    "${_payload_sha256}" "\",\"receipt\":" "${_payload}" "}")
+string(LENGTH "${_canonical_json}" _receipt_length)
+if(_receipt_length GREATER 1048576)
+    message(FATAL_ERROR "canonical build receipt exceeds 1 MiB")
+endif()
+
+set(DEAC_BUILD_RECEIPT_CXX_JSON "${_canonical_json}")
+string(REPLACE "\\" "\\\\" DEAC_BUILD_RECEIPT_CXX_JSON
+    "${DEAC_BUILD_RECEIPT_CXX_JSON}")
+string(REPLACE "\"" "\\\"" DEAC_BUILD_RECEIPT_CXX_JSON
+    "${DEAC_BUILD_RECEIPT_CXX_JSON}")
+get_filename_component(
+    _source_output_directory "${DEAC_BUILD_RECEIPT_OUTPUT_SOURCE}" DIRECTORY)
+get_filename_component(
+    _receipt_output_directory "${DEAC_BUILD_RECEIPT_OUTPUT_RECEIPT}" DIRECTORY)
+file(MAKE_DIRECTORY "${_source_output_directory}" "${_receipt_output_directory}")
+configure_file(
+    "${CMAKE_CURRENT_LIST_DIR}/deac_build_receipt_data.cpp.in"
+    "${DEAC_BUILD_RECEIPT_OUTPUT_SOURCE}"
+    @ONLY)
+file(WRITE "${DEAC_BUILD_RECEIPT_OUTPUT_RECEIPT}" "${_canonical_json}\n")

--- a/src/cmake/GenerateDeacBuildReceipt.cmake
+++ b/src/cmake/GenerateDeacBuildReceipt.cmake
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.27)
 
+include("${CMAKE_CURRENT_LIST_DIR}/DeacBuildReceipt.cmake")
+
 foreach(_required_variable
         DEAC_BUILD_RECEIPT_SOURCE_ROOT
         DEAC_BUILD_RECEIPT_CMAKE_SOURCE_ROOT
@@ -11,6 +13,7 @@ foreach(_required_variable
         DEAC_BUILD_RECEIPT_CACHE_KEYS
         DEAC_BUILD_RECEIPT_LANGUAGES
         DEAC_BUILD_RECEIPT_ARCHIVE_TOOLS
+        DEAC_BUILD_RECEIPT_REQUIRED_LINK_LIBRARY_COUNT
         DEAC_BUILD_RECEIPT_TOOLCHAIN_FINGERPRINT
         DEAC_BUILD_RECEIPT_CMAKE_PATH
         DEAC_BUILD_RECEIPT_CMAKE_REAL_PATH
@@ -23,22 +26,73 @@ foreach(_required_variable
         message(FATAL_ERROR "${_required_variable} is required")
     endif()
 endforeach()
-if(NOT DEFINED DEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS)
-    message(FATAL_ERROR "DEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS is required")
-endif()
+foreach(_required_list_variable
+        DEAC_BUILD_RECEIPT_CODEMODEL_DEPENDENCY_TARGETS
+        DEAC_BUILD_RECEIPT_INTERFACE_DEPENDENCY_TARGETS)
+    if(NOT DEFINED ${_required_list_variable})
+        message(FATAL_ERROR "${_required_list_variable} is required")
+    endif()
+endforeach()
 
 function(_deac_receipt_json_quote output value)
-    set(_value "${value}")
-    string(REPLACE "\\" "\\\\" _value "${_value}")
-    string(REPLACE "\"" "\\\"" _value "${_value}")
-    string(ASCII 8 _backspace)
-    string(ASCII 12 _form_feed)
-    string(REPLACE "${_backspace}" "\\b" _value "${_value}")
-    string(REPLACE "${_form_feed}" "\\f" _value "${_value}")
-    string(REPLACE "\n" "\\n" _value "${_value}")
-    string(REPLACE "\r" "\\r" _value "${_value}")
-    string(REPLACE "\t" "\\t" _value "${_value}")
-    set(${output} "\"${_value}\"" PARENT_SCOPE)
+    # Rebuild the string byte-by-byte.  The raw document reader rejects JSON
+    # NUL escapes before string(JSON) can truncate them; preserve JSON's short
+    # standard escapes and encode every other representable C0 control as
+    # \u00XX.
+    string(HEX "${value}" _value_hex)
+    string(LENGTH "${_value_hex}" _hex_length)
+    set(_quoted_value "")
+    if(_hex_length GREATER 0)
+        math(EXPR _last_byte_offset "${_hex_length} - 2")
+        foreach(_byte_offset RANGE 0 ${_last_byte_offset} 2)
+            string(SUBSTRING
+                "${_value_hex}" ${_byte_offset} 2 _byte_hex)
+            if(_byte_hex STREQUAL "08")
+                string(APPEND _quoted_value "\\b")
+            elseif(_byte_hex STREQUAL "09")
+                string(APPEND _quoted_value "\\t")
+            elseif(_byte_hex STREQUAL "0a")
+                string(APPEND _quoted_value "\\n")
+            elseif(_byte_hex STREQUAL "0c")
+                string(APPEND _quoted_value "\\f")
+            elseif(_byte_hex STREQUAL "0d")
+                string(APPEND _quoted_value "\\r")
+            elseif(_byte_hex MATCHES "^(0[0-9a-f]|1[0-9a-f])$")
+                string(APPEND _quoted_value "\\u00${_byte_hex}")
+            elseif(_byte_hex STREQUAL "22")
+                string(APPEND _quoted_value "\\\"")
+            elseif(_byte_hex STREQUAL "5c")
+                string(APPEND _quoted_value "\\\\")
+            else()
+                math(EXPR _byte_value "0x${_byte_hex}")
+                string(ASCII ${_byte_value} _byte)
+                string(APPEND _quoted_value "${_byte}")
+            endif()
+        endforeach()
+    endif()
+    set(${output} "\"${_quoted_value}\"" PARENT_SCOPE)
+endfunction()
+
+function(_deac_receipt_reject_raw_json_nul label document_hex)
+    # Anchor the repeated byte pairs so only an aligned 00 byte matches.
+    string(REGEX MATCH "^(..)*00" _raw_nul_prefix "${document_hex}")
+    if(NOT _raw_nul_prefix STREQUAL "")
+        message(FATAL_ERROR
+            "build-receipt ${label} contains a raw NUL byte")
+    endif()
+endfunction()
+
+function(_deac_receipt_reject_json_nul_escape label document)
+    # Removing every adjacent backslash pair leaves exactly the odd, semantic
+    # JSON escape introducers.  Do this in CMake's string implementation rather
+    # than a per-byte script loop over a potentially multi-megabyte reply.
+    string(REPLACE "\\\\" "" _unpaired_backslashes "${document}")
+    string(FIND "${_unpaired_backslashes}" "\\u0000" _nul_escape_position)
+    if(NOT _nul_escape_position EQUAL -1)
+        message(FATAL_ERROR
+            "build-receipt ${label} contains a JSON NUL escape that CMake "
+            "cannot preserve")
+    endif()
 endfunction()
 
 function(_deac_receipt_json_get output label document)
@@ -64,9 +118,12 @@ function(_deac_receipt_json_type output exists label document)
     if(_error STREQUAL "NOTFOUND")
         set(${output} "${_value}" PARENT_SCOPE)
         set(${exists} true PARENT_SCOPE)
-    else()
+    elseif(_error MATCHES "^member '.*' not found$")
         set(${output} "" PARENT_SCOPE)
         set(${exists} false PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR
+            "build-receipt ${label} is malformed: ${_error}")
     endif()
 endfunction()
 
@@ -177,7 +234,10 @@ function(_deac_receipt_read_json output label path)
     if(_size GREATER 8388608)
         message(FATAL_ERROR "build-receipt ${label} exceeds 8 MiB")
     endif()
+    file(READ "${path}" _document_hex HEX)
+    _deac_receipt_reject_raw_json_nul("${label}" "${_document_hex}")
     file(READ "${path}" _document)
+    _deac_receipt_reject_json_nul_escape("${label}" "${_document}")
     string(JSON _type ERROR_VARIABLE _error TYPE "${_document}")
     if(NOT _error STREQUAL "NOTFOUND" OR NOT _type STREQUAL "OBJECT")
         message(FATAL_ERROR "build-receipt ${label} is not a JSON object")
@@ -196,26 +256,42 @@ function(_deac_receipt_normalize_path output value)
     else()
         cmake_path(NORMAL_PATH _path OUTPUT_VARIABLE _path)
     endif()
-    foreach(_root_kind SOURCE BUILD)
-        if(_root_kind STREQUAL "SOURCE")
-            set(_root "${DEAC_BUILD_RECEIPT_CMAKE_SOURCE_ROOT}")
-            set(_token "<SOURCE_ROOT>")
-        else()
+    set(_best_root_length -1)
+    set(_best_relative "")
+    set(_best_token "")
+    # Prefer BUILD on an equal root, then select whichever containing root is
+    # most specific.  This keeps an in-source build relocatable instead of
+    # leaking its build-directory suffix beneath <SOURCE_ROOT>.
+    foreach(_root_kind BUILD SOURCE)
+        if(_root_kind STREQUAL "BUILD")
             set(_root "${DEAC_BUILD_RECEIPT_BUILD_ROOT}")
             set(_token "<BUILD_ROOT>")
+        else()
+            set(_root "${DEAC_BUILD_RECEIPT_CMAKE_SOURCE_ROOT}")
+            set(_token "<SOURCE_ROOT>")
         endif()
         cmake_path(NORMAL_PATH _root OUTPUT_VARIABLE _root)
         file(RELATIVE_PATH _relative "${_root}" "${_path}")
-        if(_relative STREQUAL "")
-            set(${output} "${_token}" PARENT_SCOPE)
-            return()
-        endif()
-        if(NOT IS_ABSOLUTE "${_relative}" AND
-                NOT _relative MATCHES "^\.\.(/|$)")
-            set(${output} "${_token}/${_relative}" PARENT_SCOPE)
-            return()
+        if((_relative STREQUAL "" OR
+                (NOT IS_ABSOLUTE "${_relative}" AND
+                 NOT _relative MATCHES "^\.\.(/|$)")))
+            string(LENGTH "${_root}" _root_length)
+            if(_root_length GREATER _best_root_length)
+                set(_best_root_length ${_root_length})
+                set(_best_relative "${_relative}")
+                set(_best_token "${_token}")
+            endif()
         endif()
     endforeach()
+    if(NOT _best_root_length EQUAL -1)
+        if(_best_relative STREQUAL "")
+            set(${output} "${_best_token}" PARENT_SCOPE)
+        else()
+            set(${output}
+                "${_best_token}/${_best_relative}" PARENT_SCOPE)
+        endif()
+        return()
+    endif()
     set(${output} "${_path}" PARENT_SCOPE)
 endfunction()
 
@@ -335,7 +411,15 @@ function(_deac_receipt_path_array output label document)
     set(${output} "${_json}" PARENT_SCOPE)
 endfunction()
 
-function(_deac_receipt_fragment_array output label document)
+function(_deac_receipt_fragment_array
+        output label fingerprint_policy document)
+    if(NOT fingerprint_policy MATCHES
+            "^(ALLOW_FINGERPRINT|REJECT_FINGERPRINT)$")
+        message(FATAL_ERROR
+            "build-receipt fragment validation has an invalid policy")
+    endif()
+    set(_fingerprint_identifier_pattern
+        "(^|[^A-Za-z0-9_]|[-/][DU])DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256([^A-Za-z0-9_]|$)")
     _deac_receipt_json_type(
         _type _exists "${label}" "${document}" ${ARGN})
     if(NOT _exists)
@@ -351,9 +435,40 @@ function(_deac_receipt_fragment_array output label document)
     if(_length GREATER 0)
         math(EXPR _last "${_length} - 1")
         foreach(_index RANGE 0 ${_last})
+            _deac_receipt_json_type(
+                _fragment_type _fragment_exists
+                "${label}[${_index}].fragment"
+                "${document}" ${ARGN} ${_index} fragment)
+            if(NOT _fragment_exists OR NOT _fragment_type STREQUAL "STRING")
+                message(FATAL_ERROR
+                    "build-receipt ${label}[${_index}].fragment must be a string")
+            endif()
             _deac_receipt_json_get(
                 _fragment "${label}[${_index}].fragment"
                 "${document}" ${ARGN} ${_index} fragment)
+            _deac_build_receipt_require_posix_shell_literal(
+                "${_fragment}" "${label}[${_index}] fragment")
+            if(fingerprint_policy STREQUAL "REJECT_FINGERPRINT")
+                # The structured File API defines array is the only accepted
+                # source of the reserved fingerprint macro.  Decode first so
+                # attached or separate -D or /D operands, quoting, escaping, and
+                # compiler-driver forwarding spellings cannot hide another
+                # effective definition (or undefinition) in a flags fragment.
+                separate_arguments(
+                    _fragment_arguments UNIX_COMMAND "${_fragment}")
+                foreach(_fragment_argument IN LISTS _fragment_arguments)
+                    if("${_fragment_argument}" MATCHES
+                            "${_fingerprint_identifier_pattern}")
+                        message(FATAL_ERROR
+                            "build-receipt reserved fingerprint fragment "
+                            "conflict: ${label}[${_index}] does not contain "
+                            "exactly one configured toolchain fingerprint "
+                            "without a duplicate or conflicting macro "
+                            "definition; the reserved identifier appears "
+                            "outside the structured definitions array")
+                    endif()
+                endforeach()
+            endif()
             _deac_receipt_json_quote(_fragment_json "${_fragment}")
             _deac_receipt_optional_string(
                 _role_json "${label}[${_index}].role"
@@ -489,6 +604,10 @@ function(_deac_receipt_compile_groups
         _type _exists "${label} compile groups"
         "${target_document}" compileGroups)
     if(NOT _exists)
+        if(require_fingerprint)
+            message(FATAL_ERROR
+                "build-receipt ${label} has no compile groups")
+        endif()
         set(${output} "[]" PARENT_SCOPE)
         set(${languages_output} "" PARENT_SCOPE)
         return()
@@ -519,6 +638,7 @@ function(_deac_receipt_compile_groups
                 _sources_json ${_group} "${target_document}")
             _deac_receipt_fragment_array(
                 _fragments_json "${label} compile group fragments"
+                REJECT_FINGERPRINT
                 "${target_document}"
                 compileGroups ${_group} compileCommandFragments)
             _deac_receipt_named_array(
@@ -550,6 +670,7 @@ function(_deac_receipt_compile_groups
                     "${label} compile group definitions"
                     "${target_document}" compileGroups ${_group} defines)
                 set(_fingerprint_matches 0)
+                set(_fingerprint_definition_count 0)
                 if(_definitions_exist)
                     _deac_receipt_json_length(
                         _definition_count "${label} compile group definitions"
@@ -561,17 +682,24 @@ function(_deac_receipt_compile_groups
                                 _definition "${label} compile definition"
                                 "${target_document}" compileGroups ${_group}
                                 defines ${_definition_index} define)
-                            if(_definition STREQUAL _expected_definition)
+                            if(_definition MATCHES
+                                    "^DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256([^A-Za-z0-9_]|$)")
+                                math(EXPR _fingerprint_definition_count
+                                    "${_fingerprint_definition_count} + 1")
+                            endif()
+                            if(_definition STREQUAL "${_expected_definition}")
                                 math(EXPR _fingerprint_matches
                                     "${_fingerprint_matches} + 1")
                             endif()
                         endforeach()
                     endif()
                 endif()
-                if(NOT _fingerprint_matches EQUAL 1)
+                if(NOT _fingerprint_matches EQUAL 1 OR
+                        NOT _fingerprint_definition_count EQUAL 1)
                     message(FATAL_ERROR
                         "build-receipt ${label} compile group does not contain "
-                        "exactly one configured toolchain fingerprint")
+                        "exactly one configured toolchain fingerprint without "
+                        "a duplicate or conflicting macro definition")
                 endif()
             endif()
 
@@ -614,6 +742,7 @@ function(_deac_receipt_link output language_output label target_document require
     _deac_receipt_json_quote(_language_json "${_language}")
     _deac_receipt_fragment_array(
         _fragments_json "${label} link fragments"
+        ALLOW_FINGERPRINT
         "${target_document}" link commandFragments)
     _deac_receipt_optional_boolean(
         _lto_json "${label} link LTO" "${target_document}" link lto)
@@ -641,6 +770,7 @@ function(_deac_receipt_archive output label target_document)
     endif()
     _deac_receipt_fragment_array(
         _fragments_json "${label} archive fragments"
+        ALLOW_FINGERPRINT
         "${target_document}" archive commandFragments)
     _deac_receipt_optional_boolean(
         _lto_json "${label} archive LTO" "${target_document}" archive lto)
@@ -832,6 +962,104 @@ _deac_receipt_link(
     _link_json _link_language "target ${_target_name}" "${_target}" true)
 set(_used_languages ${_target_compile_languages} "${_link_language}")
 
+if(NOT DEAC_BUILD_RECEIPT_REQUIRED_LINK_LIBRARY_COUNT
+        MATCHES "^[0-9]+$")
+    message(FATAL_ERROR
+        "DEAC_BUILD_RECEIPT_REQUIRED_LINK_LIBRARY_COUNT must be nonnegative")
+endif()
+_deac_receipt_json_length(
+    _target_link_fragment_count "target ${_target_name} link fragments"
+    "${_target}" link commandFragments)
+if(DEAC_BUILD_RECEIPT_REQUIRED_LINK_LIBRARY_COUNT GREATER 0)
+    math(EXPR _required_link_library_last
+        "${DEAC_BUILD_RECEIPT_REQUIRED_LINK_LIBRARY_COUNT} - 1")
+    set(_required_link_library_artifacts)
+    # Resolve and de-duplicate every selected-configuration artifact before
+    # checking any link occurrence.  Otherwise two logical providers can both
+    # claim the same one link argument independently.
+    foreach(_required_link_library_index
+            RANGE 0 ${_required_link_library_last})
+        set(_required_name_variable
+            "DEAC_BUILD_RECEIPT_REQUIRED_LINK_LIBRARY_NAME_${_required_link_library_index}")
+        set(_required_artifact_variable
+            "DEAC_BUILD_RECEIPT_REQUIRED_LINK_LIBRARY_ARTIFACT_${_required_link_library_index}")
+        foreach(_required_variable
+                "${_required_name_variable}" "${_required_artifact_variable}")
+            if(NOT DEFINED ${_required_variable} OR
+                    "${${_required_variable}}" STREQUAL "")
+                message(FATAL_ERROR "${_required_variable} is required")
+            endif()
+        endforeach()
+        set(_required_artifact "${${_required_artifact_variable}}")
+        if(NOT IS_ABSOLUTE "${_required_artifact}" OR
+                NOT EXISTS "${_required_artifact}" OR
+                IS_DIRECTORY "${_required_artifact}")
+            message(FATAL_ERROR
+                "required link-library artifact is not an absolute regular "
+                "file for ${${_required_name_variable}}: ${_required_artifact}")
+        endif()
+        cmake_path(NORMAL_PATH _required_artifact)
+        if(_required_artifact IN_LIST _required_link_library_artifacts)
+            message(FATAL_ERROR
+                "build-receipt selected configuration contains duplicate "
+                "required link-library artifact: ${_required_artifact}")
+        endif()
+        list(APPEND _required_link_library_artifacts "${_required_artifact}")
+    endforeach()
+
+    foreach(_required_link_library_index
+            RANGE 0 ${_required_link_library_last})
+        set(_required_name_variable
+            "DEAC_BUILD_RECEIPT_REQUIRED_LINK_LIBRARY_NAME_${_required_link_library_index}")
+        list(GET _required_link_library_artifacts
+            ${_required_link_library_index} _required_artifact)
+        set(_required_artifact_matches 0)
+        if(_target_link_fragment_count GREATER 0)
+            math(EXPR _target_link_fragment_last
+                "${_target_link_fragment_count} - 1")
+            foreach(_fragment_index RANGE 0 ${_target_link_fragment_last})
+                _deac_receipt_json_get(
+                    _fragment "target link fragment"
+                    "${_target}" link commandFragments
+                    ${_fragment_index} fragment)
+                _deac_receipt_optional_string(
+                    _fragment_role_json "target link fragment role"
+                    "${_target}" link commandFragments
+                    ${_fragment_index} role)
+                if(_fragment_role_json STREQUAL "\"libraries\"")
+                    # The supported generators use POSIX shell encoding in
+                    # File API command fragments.  Decode without executing it
+                    # so a quoted/escaped artifact path is compared as its
+                    # actual filesystem argument.  Count every exact argument,
+                    # including duplicates grouped into one fragment.
+                    separate_arguments(
+                        _fragment_arguments UNIX_COMMAND "${_fragment}")
+                    foreach(_fragment_argument IN LISTS _fragment_arguments)
+                        set(_normalized_fragment_argument
+                            "${_fragment_argument}")
+                        if(IS_ABSOLUTE "${_normalized_fragment_argument}")
+                            cmake_path(
+                                NORMAL_PATH _normalized_fragment_argument)
+                        endif()
+                        if(_normalized_fragment_argument STREQUAL
+                                _required_artifact)
+                            math(EXPR _required_artifact_matches
+                                "${_required_artifact_matches} + 1")
+                        endif()
+                    endforeach()
+                endif()
+            endforeach()
+        endif()
+        if(NOT _required_artifact_matches EQUAL 1)
+            message(FATAL_ERROR
+                "build-receipt target ${_target_name} must contain exactly "
+                "one resolved libraries-role link fragment for "
+                "${${_required_name_variable}} (${_required_artifact}); got "
+                "${_required_artifact_matches}")
+        endif()
+    endforeach()
+endif()
+
 _deac_receipt_json_type(
     _dependencies_type _dependencies_exist
     "target ${_target_name} dependencies" "${_target}" dependencies)
@@ -880,19 +1108,45 @@ foreach(_dependency_id IN LISTS _dependency_ids)
     endif()
 endforeach()
 list(SORT _actual_dependency_names)
-string(REPLACE "," ";" _expected_dependency_names
-    "${DEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS}")
-list(SORT _expected_dependency_names)
+string(REPLACE "," ";" _expected_codemodel_dependency_names
+    "${DEAC_BUILD_RECEIPT_CODEMODEL_DEPENDENCY_TARGETS}")
+list(SORT _expected_codemodel_dependency_names)
 if(NOT "${_actual_dependency_names}" STREQUAL
-        "${_expected_dependency_names}")
+        "${_expected_codemodel_dependency_names}")
     message(FATAL_ERROR
-        "build-receipt target dependencies changed: expected "
-        "[${_expected_dependency_names}], got [${_actual_dependency_names}]")
+        "build-receipt codemodel dependencies changed: expected "
+        "[${_expected_codemodel_dependency_names}], got "
+        "[${_actual_dependency_names}]")
 endif()
+
+string(REPLACE "," ";" _expected_interface_dependency_names
+    "${DEAC_BUILD_RECEIPT_INTERFACE_DEPENDENCY_TARGETS}")
+list(SORT _expected_interface_dependency_names)
+set(_expected_dependency_names
+    ${_expected_codemodel_dependency_names}
+    ${_expected_interface_dependency_names})
+list(LENGTH _expected_dependency_names _expected_dependency_count)
+list(REMOVE_DUPLICATES _expected_dependency_names)
+list(LENGTH _expected_dependency_names _unique_dependency_count)
+if(NOT _expected_dependency_count EQUAL _unique_dependency_count)
+    message(FATAL_ERROR
+        "build-receipt dependency appears in both codemodel and interface lists")
+endif()
+list(SORT _expected_dependency_names)
 
 set(_dependencies_json "[")
 set(_dependency_separator "")
 foreach(_expected_name IN LISTS _expected_dependency_names)
+    if(_expected_name IN_LIST _expected_interface_dependency_names)
+        _deac_receipt_json_quote(_dependency_name_json "${_expected_name}")
+        string(APPEND _dependencies_json
+            "${_dependency_separator}{\"archive\":null,"
+            "\"compile_groups\":[],\"link\":null,"
+            "\"name\":${_dependency_name_json},"
+            "\"type\":\"INTERFACE_LIBRARY\"}")
+        set(_dependency_separator ",")
+        continue()
+    endif()
     set(_dependency_json_file "")
     set(_dependency_matches 0)
     if(_target_count GREATER 0)
@@ -930,9 +1184,20 @@ foreach(_expected_name IN LISTS _expected_dependency_names)
     if(NOT _dependency_name STREQUAL "${_expected_name}")
         message(FATAL_ERROR "build-receipt dependency target name changed")
     endif()
+    set(_buildable_dependency_types
+        EXECUTABLE
+        MODULE_LIBRARY
+        OBJECT_LIBRARY
+        SHARED_LIBRARY
+        STATIC_LIBRARY)
+    set(_dependency_requires_fingerprint false)
+    if(_dependency_type IN_LIST _buildable_dependency_types)
+        set(_dependency_requires_fingerprint true)
+    endif()
     _deac_receipt_compile_groups(
         _dependency_compile_groups _dependency_languages
-        "dependency ${_dependency_name}" "${_dependency}" false)
+        "dependency ${_dependency_name}" "${_dependency}"
+        ${_dependency_requires_fingerprint})
     _deac_receipt_link(
         _dependency_link _dependency_link_language
         "dependency ${_dependency_name}" "${_dependency}" false)
@@ -1006,6 +1271,8 @@ foreach(_language IN LISTS _used_languages)
         "DEAC_BUILD_RECEIPT_CONFIGURED_${_language}_ID")
     set(_configured_version_variable
         "DEAC_BUILD_RECEIPT_CONFIGURED_${_language}_VERSION")
+    set(_configured_target_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${_language}_TARGET")
     foreach(_variable
             ${_configured_path_variable}
             ${_configured_real_variable}
@@ -1021,6 +1288,20 @@ foreach(_language IN LISTS _used_languages)
             NOT _compiler_version STREQUAL "${${_configured_version_variable}}")
         message(FATAL_ERROR
             "build-receipt ${_language} toolchain disagrees with configure-time identity")
+    endif()
+    _deac_receipt_optional_string(
+        _target_json "${_language} compiler target" "${_toolchains}"
+        toolchains ${_toolchain_index} compiler target)
+    if(DEFINED ${_configured_target_variable})
+        _deac_receipt_json_quote(
+            _configured_target_json "${${_configured_target_variable}}")
+    else()
+        set(_configured_target_json "null")
+    endif()
+    if(NOT _target_json STREQUAL _configured_target_json)
+        message(FATAL_ERROR
+            "build-receipt ${_language} compiler target disagrees with "
+            "configure-time identity")
     endif()
     get_filename_component(_compiler_real "${_compiler_path}" REALPATH)
     if(NOT EXISTS "${_compiler_real}" OR IS_DIRECTORY "${_compiler_real}")
@@ -1042,9 +1323,6 @@ foreach(_language IN LISTS _used_languages)
     _deac_receipt_json_quote(_sha_json "${_compiler_sha256}")
     _deac_receipt_json_quote(_id_json "${_compiler_id}")
     _deac_receipt_json_quote(_version_json "${_compiler_version}")
-    _deac_receipt_optional_string(
-        _target_json "${_language} compiler target" "${_toolchains}"
-        toolchains ${_toolchain_index} compiler target)
     _deac_receipt_path_array(
         _implicit_includes "${_language} implicit include directories"
         "${_toolchains}"

--- a/src/cmake/VerifyDeacBuildReceiptTools.cmake
+++ b/src/cmake/VerifyDeacBuildReceiptTools.cmake
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.27)
+
+foreach(_required_variable
+        DEAC_BUILD_RECEIPT_LANGUAGES
+        DEAC_BUILD_RECEIPT_CMAKE_PATH
+        DEAC_BUILD_RECEIPT_CMAKE_REAL_PATH
+        DEAC_BUILD_RECEIPT_CMAKE_SHA256)
+    if(NOT DEFINED ${_required_variable} OR
+            "${${_required_variable}}" STREQUAL "")
+        message(FATAL_ERROR "${_required_variable} is required")
+    endif()
+endforeach()
+
+function(_deac_verify_build_receipt_tool label path expected_real expected_sha256)
+    get_filename_component(_real_path "${path}" REALPATH)
+    if(NOT EXISTS "${_real_path}" OR IS_DIRECTORY "${_real_path}")
+        message(FATAL_ERROR
+            "build-receipt ${label} is no longer a regular file: ${path}")
+    endif()
+    file(SHA256 "${_real_path}" _sha256)
+    if(NOT _real_path STREQUAL "${expected_real}" OR
+            NOT _sha256 STREQUAL "${expected_sha256}")
+        message(FATAL_ERROR
+            "build-receipt ${label} changed after configuration; "
+            "rerun CMake before building")
+    endif()
+endfunction()
+
+_deac_verify_build_receipt_tool(
+    "CMake executable"
+    "${DEAC_BUILD_RECEIPT_CMAKE_PATH}"
+    "${DEAC_BUILD_RECEIPT_CMAKE_REAL_PATH}"
+    "${DEAC_BUILD_RECEIPT_CMAKE_SHA256}")
+
+string(REPLACE "," ";" _languages "${DEAC_BUILD_RECEIPT_LANGUAGES}")
+foreach(_language IN LISTS _languages)
+    set(_path_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${_language}_PATH")
+    set(_real_path_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${_language}_REAL_PATH")
+    set(_sha256_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${_language}_SHA256")
+    foreach(_variable
+            ${_path_variable} ${_real_path_variable} ${_sha256_variable})
+        if(NOT DEFINED ${_variable} OR "${${_variable}}" STREQUAL "")
+            message(FATAL_ERROR "${_variable} is required")
+        endif()
+    endforeach()
+    _deac_verify_build_receipt_tool(
+        "${_language} compiler"
+        "${${_path_variable}}"
+        "${${_real_path_variable}}"
+        "${${_sha256_variable}}")
+endforeach()

--- a/src/cmake/VerifyDeacBuildReceiptTools.cmake
+++ b/src/cmake/VerifyDeacBuildReceiptTools.cmake
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.27)
 
 foreach(_required_variable
         DEAC_BUILD_RECEIPT_LANGUAGES
+        DEAC_BUILD_RECEIPT_ARCHIVE_TOOLS
         DEAC_BUILD_RECEIPT_CMAKE_PATH
         DEAC_BUILD_RECEIPT_CMAKE_REAL_PATH
         DEAC_BUILD_RECEIPT_CMAKE_SHA256)
@@ -25,6 +26,31 @@ function(_deac_verify_build_receipt_tool label path expected_real expected_sha25
             "rerun CMake before building")
     endif()
 endfunction()
+
+string(REPLACE "," ";" _archive_tools
+    "${DEAC_BUILD_RECEIPT_ARCHIVE_TOOLS}")
+foreach(_tool IN LISTS _archive_tools)
+    if(NOT _tool MATCHES "^CMAKE_[A-Z0-9_]+$")
+        message(FATAL_ERROR "invalid build-receipt archive tool: ${_tool}")
+    endif()
+    set(_path_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${_tool}_PATH")
+    set(_real_path_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${_tool}_REAL_PATH")
+    set(_sha256_variable
+        "DEAC_BUILD_RECEIPT_CONFIGURED_${_tool}_SHA256")
+    foreach(_variable
+            ${_path_variable} ${_real_path_variable} ${_sha256_variable})
+        if(NOT DEFINED ${_variable} OR "${${_variable}}" STREQUAL "")
+            message(FATAL_ERROR "${_variable} is required")
+        endif()
+    endforeach()
+    _deac_verify_build_receipt_tool(
+        "${_tool} executable"
+        "${${_path_variable}}"
+        "${${_real_path_variable}}"
+        "${${_sha256_variable}}")
+endforeach()
 
 _deac_verify_build_receipt_tool(
     "CMake executable"

--- a/src/cmake/deac_build_receipt_data.cpp.in
+++ b/src/cmake/deac_build_receipt_data.cpp.in
@@ -1,0 +1,11 @@
+#include "build_identity.hpp"
+
+#include <string_view>
+
+namespace deac_build_identity {
+
+std::string_view build_receipt_json() noexcept {
+    return "@DEAC_BUILD_RECEIPT_CXX_JSON@";
+}
+
+}  // namespace deac_build_identity

--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -322,6 +322,7 @@ deac_target_add_build_receipt(${exe}
     BACKEND "${GPU_BACKEND}"
     CACHE_KEYS ${DEAC_BUILD_RECEIPT_CACHE_KEYS}
     DEPENDENCY_TARGETS ${DEAC_BUILD_IDENTITY_OBJECT_TARGET})
+set(DEAC_PRIMARY_BUILD_RECEIPT "${DEAC_BUILD_RECEIPT}")
 
 # 'make install' to the correct locations (provided by GNUInstallDirs).
 install(TARGETS ${exe} EXPORT ${exe}Config
@@ -618,6 +619,19 @@ if(NOT USE_ALLOW_NEGATIVE_SPECTRAL_WEIGHT)
         target_link_libraries(
             deac_invalid_normalization_evolution_test_exe stdc++fs)
     endif()
+    deac_target_add_build_receipt(
+        deac_invalid_normalization_evolution_test_exe
+        SOURCE_ROOT "${CMAKE_SOURCE_DIR}/.."
+        GENERATED_DIRECTORY
+            "${CMAKE_CURRENT_BINARY_DIR}/generated/receipt"
+        IDENTITY_NAME deac
+        RECEIPT
+            "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<CONFIG>/deac-invalid-normalization-build-receipt.json"
+        BACKEND "${GPU_BACKEND}"
+        CACHE_KEYS ${DEAC_BUILD_RECEIPT_CACHE_KEYS}
+        DEPENDENCY_TARGETS ${DEAC_BUILD_IDENTITY_OBJECT_TARGET})
+    set(DEAC_INVALID_NORMALIZATION_BUILD_RECEIPT
+        "${DEAC_BUILD_RECEIPT}")
 endif()
 
 # The HIP+BLAS package, includes, and link dependency are represented by one
@@ -759,6 +773,16 @@ if(Python3_Interpreter_FOUND)
         list(APPEND DEAC_BUILD_IDENTITY_CONFIG_ARGS
             --build-config $<CONFIG>)
     endif()
+    set(DEAC_BUILD_RECEIPT_HELPER_ARGS)
+    if(TARGET deac_invalid_normalization_evolution_test_exe)
+        list(APPEND DEAC_BUILD_RECEIPT_HELPER_ARGS
+            --helper-exe
+                $<TARGET_FILE:deac_invalid_normalization_evolution_test_exe>
+            --helper-receipt
+                ${DEAC_INVALID_NORMALIZATION_BUILD_RECEIPT}
+            --expected-helper-target
+                deac_invalid_normalization_evolution_test_exe)
+    endif()
     add_test(
         NAME deac_build_identity
         COMMAND
@@ -783,7 +807,7 @@ if(Python3_Interpreter_FOUND)
             ${Python3_EXECUTABLE}
             ${DEAC_BUILD_RECEIPT_TEST}
             --exe $<TARGET_FILE:${exe}>
-            --receipt ${DEAC_BUILD_RECEIPT}
+            --receipt ${DEAC_PRIMARY_BUILD_RECEIPT}
             --build-dir ${CMAKE_BINARY_DIR}
             --source-dir ${CMAKE_SOURCE_DIR}
             --workdir ${CMAKE_CURRENT_BINARY_DIR}/build-receipt-test
@@ -791,6 +815,7 @@ if(Python3_Interpreter_FOUND)
             --expected-backend ${GPU_BACKEND}
             --expected-target ${exe}
             --expected-dependency-target ${DEAC_BUILD_IDENTITY_OBJECT_TARGET}
+            ${DEAC_BUILD_RECEIPT_HELPER_ARGS}
             ${DEAC_BUILD_IDENTITY_CONFIG_ARGS}
     )
     if(DEAC_NINJA_EXECUTABLE)

--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18.0)
+cmake_minimum_required(VERSION 3.27.0)
 
 project(deac.e LANGUAGES CXX)
 
@@ -262,6 +262,66 @@ if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
     message("Linking filesystem libraries -lstdc++fs for older compilers")
     target_link_libraries(${exe} stdc++fs)
 endif()
+
+# Embed a target-specific attribution receipt generated from CMake's final
+# codemodel, toolchain, and cache replies.  The adjacent JSON is diagnostic;
+# the executable's --build-receipt response is authoritative.
+include("${CMAKE_SOURCE_DIR}/cmake/DeacBuildReceipt.cmake")
+set(DEAC_BUILD_RECEIPT_CACHE_KEYS
+    BUILD_SHARED_LIBS
+    CMAKE_AR
+    CMAKE_BUILD_TYPE
+    CMAKE_CONFIGURATION_TYPES
+    CMAKE_CUDA_ARCHITECTURES
+    CMAKE_CUDA_COMPILER
+    CMAKE_CUDA_FLAGS
+    CMAKE_CXX_COMPILER
+    CMAKE_CXX_COMPILER_LAUNCHER
+    CMAKE_CXX_FLAGS
+    CMAKE_EXE_LINKER_FLAGS
+    CMAKE_GENERATOR
+    CMAKE_GENERATOR_INSTANCE
+    CMAKE_GENERATOR_PLATFORM
+    CMAKE_GENERATOR_TOOLSET
+    CMAKE_HIP_ARCHITECTURES
+    CMAKE_HOME_DIRECTORY
+    CMAKE_INTERPROCEDURAL_OPTIMIZATION
+    CMAKE_LINKER
+    CMAKE_MAKE_PROGRAM
+    CMAKE_PREFIX_PATH
+    CMAKE_RANLIB
+    CMAKE_SYSROOT
+    CMAKE_SYSROOT_COMPILE
+    CMAKE_SYSROOT_LINK
+    CMAKE_TOOLCHAIN_FILE
+    DEAC_MODEL
+    GPU_BACKEND
+    GPU_BLOCK_SIZE
+    MAX_GPU_STREAMS
+    MKLROOT
+    SINGLE_PARTICLE_FERMIONIC_SPECTRAL_FUNCTION
+    STATIC
+    SUB_GROUP_SIZE
+    SYCL_FLAGS
+    USE_ALLOW_NEGATIVE_SPECTRAL_WEIGHT
+    USE_BLAS
+    USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+    USE_SYCL_MATMUL_WA)
+foreach(_configuration
+        DEBUG RELEASE MINSIZEREL RELWITHDEBINFO ZEROT ZEROTDEBUG)
+    list(APPEND DEAC_BUILD_RECEIPT_CACHE_KEYS
+        "CMAKE_CXX_FLAGS_${_configuration}"
+        "CMAKE_EXE_LINKER_FLAGS_${_configuration}")
+endforeach()
+deac_target_add_build_receipt(${exe}
+    SOURCE_ROOT "${CMAKE_SOURCE_DIR}/.."
+    GENERATED_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/receipt"
+    IDENTITY_NAME deac
+    RECEIPT
+        "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<CONFIG>/deac-build-receipt.json"
+    BACKEND "${GPU_BACKEND}"
+    CACHE_KEYS ${DEAC_BUILD_RECEIPT_CACHE_KEYS}
+    DEPENDENCY_TARGETS ${DEAC_BUILD_IDENTITY_OBJECT_TARGET})
 
 # 'make install' to the correct locations (provided by GNUInstallDirs).
 install(TARGETS ${exe} EXPORT ${exe}Config
@@ -576,6 +636,11 @@ if(Python3_Interpreter_FOUND)
     set(DEAC_PARITY_TEST "${CMAKE_SOURCE_DIR}/../test/deac_parity_test.py")
     set(DEAC_BUILD_IDENTITY_TEST
         "${CMAKE_SOURCE_DIR}/../test/deac_build_identity_test.py")
+    set(DEAC_BUILD_RECEIPT_TEST
+        "${CMAKE_SOURCE_DIR}/../test/deac_build_receipt_test.py")
+    set(DEAC_BUILD_RECEIPT_FIXTURE_TEST
+        "${CMAKE_SOURCE_DIR}/../test/deac_build_receipt_fixture_test.py")
+    find_program(DEAC_NINJA_EXECUTABLE NAMES ninja)
     set(DEAC_SMOKE_VARIANT_ARGS)
     if(USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF)
         list(APPEND DEAC_SMOKE_VARIANT_ARGS --detailed-balance)
@@ -712,6 +777,36 @@ if(Python3_Interpreter_FOUND)
             ${DEAC_BUILD_IDENTITY_CONFIG_ARGS}
             ${DEAC_BUILD_IDENTITY_GIT_ARGS}
     )
+    add_test(
+        NAME deac_build_receipt
+        COMMAND
+            ${Python3_EXECUTABLE}
+            ${DEAC_BUILD_RECEIPT_TEST}
+            --exe $<TARGET_FILE:${exe}>
+            --receipt ${DEAC_BUILD_RECEIPT}
+            --build-dir ${CMAKE_BINARY_DIR}
+            --source-dir ${CMAKE_SOURCE_DIR}
+            --workdir ${CMAKE_CURRENT_BINARY_DIR}/build-receipt-test
+            --cmake ${CMAKE_COMMAND}
+            --expected-backend ${GPU_BACKEND}
+            --expected-target ${exe}
+            --expected-dependency-target ${DEAC_BUILD_IDENTITY_OBJECT_TARGET}
+            ${DEAC_BUILD_IDENTITY_CONFIG_ARGS}
+    )
+    if(DEAC_NINJA_EXECUTABLE)
+        add_test(
+            NAME deac_build_receipt_fixture
+            COMMAND
+                ${Python3_EXECUTABLE}
+                ${DEAC_BUILD_RECEIPT_FIXTURE_TEST}
+                --cmake ${CMAKE_COMMAND}
+                --ninja ${DEAC_NINJA_EXECUTABLE}
+                --solver-source-root ${CMAKE_SOURCE_DIR}
+                --cxx-compiler ${CMAKE_CXX_COMPILER}
+                --workdir
+                    ${CMAKE_CURRENT_BINARY_DIR}/build-receipt-fixture-test
+        )
+    endif()
     add_test(
         NAME deac_first_moment_fitness
         COMMAND

--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -895,6 +895,10 @@ if(Python3_Interpreter_FOUND)
                 --workdir
                     ${CMAKE_CURRENT_BINARY_DIR}/build-receipt-fixture-test
         )
+        # The fixture launches a broad adversarial File-API regeneration
+        # matrix.  Keep ordinary solver tests on the caller's short timeout,
+        # while allowing this integration test to finish on a loaded node.
+        set_tests_properties(deac_build_receipt_fixture PROPERTIES TIMEOUT 600)
     endif()
     add_test(
         NAME deac_first_moment_fitness

--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -803,6 +803,7 @@ if(Python3_Interpreter_FOUND)
                 --ninja ${DEAC_NINJA_EXECUTABLE}
                 --solver-source-root ${CMAKE_SOURCE_DIR}
                 --cxx-compiler ${CMAKE_CXX_COMPILER}
+                --archiver ${CMAKE_AR}
                 --workdir
                     ${CMAKE_CURRENT_BINARY_DIR}/build-receipt-fixture-test
         )

--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -278,6 +278,7 @@ set(DEAC_BUILD_RECEIPT_CACHE_KEYS
     CMAKE_CXX_COMPILER
     CMAKE_CXX_COMPILER_LAUNCHER
     CMAKE_CXX_FLAGS
+    CMAKE_DISABLE_FIND_PACKAGE_hipblas
     CMAKE_EXE_LINKER_FLAGS
     CMAKE_GENERATOR
     CMAKE_GENERATOR_INSTANCE
@@ -294,9 +295,12 @@ set(DEAC_BUILD_RECEIPT_CACHE_KEYS
     CMAKE_SYSROOT_COMPILE
     CMAKE_SYSROOT_LINK
     CMAKE_TOOLCHAIN_FILE
+    DEAC_HIPBLAS_INCLUDE_DIR
+    DEAC_HIPBLAS_LIBRARY
     DEAC_MODEL
     GPU_BACKEND
     GPU_BLOCK_SIZE
+    HIP_RUNTIME_INCLUDE_DIR
     MAX_GPU_STREAMS
     MKLROOT
     SINGLE_PARTICLE_FERMIONIC_SPECTRAL_FUNCTION
@@ -306,24 +310,15 @@ set(DEAC_BUILD_RECEIPT_CACHE_KEYS
     USE_ALLOW_NEGATIVE_SPECTRAL_WEIGHT
     USE_BLAS
     USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-    USE_SYCL_MATMUL_WA)
+    USE_SYCL_MATMUL_WA
+    hipblas_DIR
+    hipblas_ROOT)
 foreach(_configuration
         DEBUG RELEASE MINSIZEREL RELWITHDEBINFO ZEROT ZEROTDEBUG)
     list(APPEND DEAC_BUILD_RECEIPT_CACHE_KEYS
         "CMAKE_CXX_FLAGS_${_configuration}"
         "CMAKE_EXE_LINKER_FLAGS_${_configuration}")
 endforeach()
-deac_target_add_build_receipt(${exe}
-    SOURCE_ROOT "${CMAKE_SOURCE_DIR}/.."
-    GENERATED_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/receipt"
-    IDENTITY_NAME deac
-    RECEIPT
-        "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<CONFIG>/deac-build-receipt.json"
-    BACKEND "${GPU_BACKEND}"
-    CACHE_KEYS ${DEAC_BUILD_RECEIPT_CACHE_KEYS}
-    DEPENDENCY_TARGETS ${DEAC_BUILD_IDENTITY_OBJECT_TARGET})
-set(DEAC_PRIMARY_BUILD_RECEIPT "${DEAC_BUILD_RECEIPT}")
-
 # 'make install' to the correct locations (provided by GNUInstallDirs).
 install(TARGETS ${exe} EXPORT ${exe}Config
     ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -619,6 +614,67 @@ if(NOT USE_ALLOW_NEGATIVE_SPECTRAL_WEIGHT)
         target_link_libraries(
             deac_invalid_normalization_evolution_test_exe stdc++fs)
     endif()
+endif()
+
+# The HIP+BLAS package, includes, and link dependency are represented by one
+# target-scoped contract shared by every target that compiles the GPU solver
+# implementation.  The helper is a no-op for every other configuration.
+deac_target_link_hipblas(${DEAC_HIPBLAS_CONSUMER_TARGETS})
+
+# Receipt registration must follow every target graph mutation.  The identity
+# object is always a compiled dependency.  HIP+BLAS additionally contributes
+# an interface-only contract whose resolved provider is visible in the final
+# executable link fragments even though CMake omits interface targets from the
+# File API codemodel target list.
+set(DEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS
+    ${DEAC_BUILD_IDENTITY_OBJECT_TARGET})
+set(DEAC_BUILD_RECEIPT_LINK_LIBRARY_NAMES)
+set(DEAC_BUILD_RECEIPT_LINK_LIBRARY_ARTIFACTS)
+if(USE_BLAS AND "${GPU_BACKEND}" STREQUAL "hip")
+    if(NOT TARGET deac_hipblas_link_contract)
+        message(FATAL_ERROR
+            "HIP+BLAS receipt registration requires the final hipBLAS contract.")
+    endif()
+    _deac_hipblas_validate_link_contract(deac_hipblas_link_contract)
+    list(APPEND DEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS
+        deac_hipblas_link_contract)
+    get_target_property(DEAC_HIPBLAS_PROVIDER_TARGET
+        deac_hipblas_link_contract DEAC_HIPBLAS_PROVIDER_TARGET)
+    if(NOT TARGET "${DEAC_HIPBLAS_PROVIDER_TARGET}")
+        message(FATAL_ERROR
+            "The hipBLAS contract has no receipt-capable provider target.")
+    endif()
+    get_target_property(DEAC_HIPBLAS_PROVIDER_ARTIFACT
+        deac_hipblas_link_contract DEAC_HIPBLAS_PROVIDER_ARTIFACT)
+    if(NOT DEAC_HIPBLAS_PROVIDER_ARTIFACT OR
+            DEAC_HIPBLAS_PROVIDER_ARTIFACT MATCHES "-NOTFOUND$")
+        message(FATAL_ERROR
+            "The hipBLAS contract has no receipt-capable provider artifact.")
+    endif()
+    list(APPEND DEAC_BUILD_RECEIPT_LINK_LIBRARY_NAMES
+        "${DEAC_HIPBLAS_PROVIDER_TARGET}")
+    list(APPEND DEAC_BUILD_RECEIPT_LINK_LIBRARY_ARTIFACTS
+        "${DEAC_HIPBLAS_PROVIDER_ARTIFACT}")
+elseif(TARGET deac_hipblas_link_contract)
+    message(FATAL_ERROR
+        "A hipBLAS contract exists outside the HIP+BLAS configuration.")
+endif()
+deac_target_add_build_receipt(${exe}
+    SOURCE_ROOT "${CMAKE_SOURCE_DIR}/.."
+    GENERATED_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/receipt"
+    IDENTITY_NAME deac
+    RECEIPT
+        "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<CONFIG>/deac-build-receipt.json"
+    BACKEND "${GPU_BACKEND}"
+    CACHE_KEYS ${DEAC_BUILD_RECEIPT_CACHE_KEYS}
+    DEPENDENCY_TARGETS ${DEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS}
+    REQUIRED_LINK_LIBRARY_NAMES
+        ${DEAC_BUILD_RECEIPT_LINK_LIBRARY_NAMES}
+    REQUIRED_LINK_LIBRARY_ARTIFACTS
+        ${DEAC_BUILD_RECEIPT_LINK_LIBRARY_ARTIFACTS})
+set(DEAC_PRIMARY_BUILD_RECEIPT "${DEAC_BUILD_RECEIPT}")
+
+if(TARGET deac_invalid_normalization_evolution_test_exe)
     deac_target_add_build_receipt(
         deac_invalid_normalization_evolution_test_exe
         SOURCE_ROOT "${CMAKE_SOURCE_DIR}/.."
@@ -629,15 +685,14 @@ if(NOT USE_ALLOW_NEGATIVE_SPECTRAL_WEIGHT)
             "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<CONFIG>/deac-invalid-normalization-build-receipt.json"
         BACKEND "${GPU_BACKEND}"
         CACHE_KEYS ${DEAC_BUILD_RECEIPT_CACHE_KEYS}
-        DEPENDENCY_TARGETS ${DEAC_BUILD_IDENTITY_OBJECT_TARGET})
+        DEPENDENCY_TARGETS ${DEAC_BUILD_RECEIPT_DEPENDENCY_TARGETS}
+        REQUIRED_LINK_LIBRARY_NAMES
+            ${DEAC_BUILD_RECEIPT_LINK_LIBRARY_NAMES}
+        REQUIRED_LINK_LIBRARY_ARTIFACTS
+            ${DEAC_BUILD_RECEIPT_LINK_LIBRARY_ARTIFACTS})
     set(DEAC_INVALID_NORMALIZATION_BUILD_RECEIPT
         "${DEAC_BUILD_RECEIPT}")
 endif()
-
-# The HIP+BLAS package, includes, and link dependency are represented by one
-# target-scoped contract shared by every target that compiles the GPU solver
-# implementation.  The helper is a no-op for every other configuration.
-deac_target_link_hipblas(${DEAC_HIPBLAS_CONSUMER_TARGETS})
 
 if(Python3_Interpreter_FOUND)
     add_test(
@@ -783,6 +838,13 @@ if(Python3_Interpreter_FOUND)
             --expected-helper-target
                 deac_invalid_normalization_evolution_test_exe)
     endif()
+    set(DEAC_BUILD_RECEIPT_LINK_LIBRARY_ARGS)
+    foreach(_link_library_artifact
+            IN LISTS DEAC_BUILD_RECEIPT_LINK_LIBRARY_ARTIFACTS)
+        list(APPEND DEAC_BUILD_RECEIPT_LINK_LIBRARY_ARGS
+            --expected-link-library
+                "${_link_library_artifact}")
+    endforeach()
     add_test(
         NAME deac_build_identity
         COMMAND
@@ -815,6 +877,7 @@ if(Python3_Interpreter_FOUND)
             --expected-backend ${GPU_BACKEND}
             --expected-target ${exe}
             --expected-dependency-target ${DEAC_BUILD_IDENTITY_OBJECT_TARGET}
+            ${DEAC_BUILD_RECEIPT_LINK_LIBRARY_ARGS}
             ${DEAC_BUILD_RECEIPT_HELPER_ARGS}
             ${DEAC_BUILD_IDENTITY_CONFIG_ARGS}
     )

--- a/src/deac/src/build_identity.hpp
+++ b/src/deac/src/build_identity.hpp
@@ -6,5 +6,6 @@ namespace deac_build_identity {
 
 std::string_view semantic_version() noexcept;
 std::string_view canonical_json() noexcept;
+std::string_view build_receipt_json() noexcept;
 
 }  // namespace deac_build_identity

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -59,6 +59,10 @@ void print_build_identity(std::ostream& output) {
     output << deac_build_identity::canonical_json() << std::endl;
 }
 
+void print_build_receipt(std::ostream& output) {
+    output << deac_build_identity::build_receipt_json() << std::endl;
+}
+
 template<typename ... Args>
 std::string string_format( const std::string& format, Args ... args ) {
     //See https://stackoverflow.com/questions/2342162/stdstring-formatting-like-sprintf
@@ -2042,6 +2046,15 @@ int deac_main (int argc, char *argv[]) {
         })
         .default_value(false)
         .help("prints canonical JSON build identity and exits")
+        .implicit_value(true)
+        .nargs(0);
+    program.add_argument("--build-receipt")
+        .action([](const auto&) {
+            print_build_receipt(std::cout);
+            std::exit(0);
+        })
+        .default_value(false)
+        .help("prints canonical JSON effective build receipt and exits")
         .implicit_value(true)
         .nargs(0);
     program.add_argument("-T", "--temperature")

--- a/test/deac_build_receipt_fixture_test.py
+++ b/test/deac_build_receipt_fixture_test.py
@@ -1,0 +1,510 @@
+import argparse
+import hashlib
+import json
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def run(command, cwd, *, check=True):
+    result = subprocess.run(
+        [str(part) for part in command],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"command failed with exit {result.returncode}: {command}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def write(path, contents, *, executable=False):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents, encoding="utf-8")
+    if executable:
+        path.chmod(0o755)
+
+
+def copy_fixture_modules(solver_source, fixture_source):
+    module_names = [
+        "DeacBuildIdentity.cmake",
+        "DeacBuildReceipt.cmake",
+        "GenerateDeacBuildReceipt.cmake",
+        "VerifyDeacBuildReceiptTools.cmake",
+        "deac_build_receipt_data.cpp.in",
+    ]
+    module_directory = fixture_source / "src" / "cmake"
+    module_directory.mkdir(parents=True)
+    for name in module_names:
+        shutil.copy2(solver_source / "cmake" / name, module_directory / name)
+    support_directory = fixture_source / "src" / "deac" / "src"
+    support_directory.mkdir(parents=True)
+    shutil.copy2(
+        solver_source / "deac" / "src" / "build_identity.hpp",
+        support_directory / "build_identity.hpp",
+    )
+
+
+def create_fixture_source(solver_source, fixture_source):
+    fixture_source.mkdir(parents=True)
+    copy_fixture_modules(solver_source, fixture_source)
+    write(fixture_source / "VERSION", "1.2.3\n")
+    write(
+        fixture_source / "src" / "dependency.cpp",
+        "int receipt_dependency() { return 17; }\n",
+    )
+    write(
+        fixture_source / "src" / "probe.cpp",
+        """#include "build_identity.hpp"
+#include <iostream>
+
+int receipt_dependency();
+
+int main() {
+    if (receipt_dependency() != 17) {
+        return 2;
+    }
+    std::cout << deac_build_identity::build_receipt_json() << '\\n';
+    return 0;
+}
+""",
+    )
+    write(
+        fixture_source / "src" / "CMakeLists.txt",
+        """cmake_minimum_required(VERSION 3.27)
+project(deac_build_receipt_fixture LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(GPU_BACKEND none CACHE STRING "fixture backend")
+
+add_library(receipt_dependency STATIC dependency.cpp)
+add_executable(receipt_probe probe.cpp)
+target_link_libraries(receipt_probe PRIVATE receipt_dependency)
+
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/DeacBuildReceipt.cmake")
+deac_target_add_build_receipt(receipt_probe
+    SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/.."
+    GENERATED_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/receipt"
+    IDENTITY_NAME fixture
+    RECEIPT
+        "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<CONFIG>/build-receipt.json"
+    BACKEND "${GPU_BACKEND}"
+    CACHE_KEYS
+        CMAKE_BUILD_TYPE
+        CMAKE_CONFIGURATION_TYPES
+        CMAKE_CXX_COMPILER
+        CMAKE_CXX_FLAGS
+        CMAKE_EXE_LINKER_FLAGS
+        CMAKE_GENERATOR
+        CMAKE_HOME_DIRECTORY
+        CMAKE_PREFIX_PATH
+        GPU_BACKEND
+    DEPENDENCY_TARGETS receipt_dependency)
+""",
+    )
+
+
+def compiler_shim_contents(real_compiler, marker):
+    return (
+        "#!/bin/sh\n"
+        f"# receipt fixture compiler marker: {marker}\n"
+        f"exec {shlex.quote(str(real_compiler))} \"$@\"\n"
+    )
+
+
+def configure(cmake, source, build, compiler, *extra, check=True):
+    return run(
+        [
+            cmake,
+            "-S",
+            source / "src",
+            "-B",
+            build,
+            "-DCMAKE_BUILD_TYPE=Release",
+            f"-DCMAKE_CXX_COMPILER={compiler}",
+            "-DGPU_BACKEND=none",
+            *extra,
+        ],
+        source,
+        check=check,
+    )
+
+
+def build(cmake, build_directory, *, config=None, check=True):
+    command = [cmake, "--build", build_directory, "--parallel", "2", "--verbose"]
+    if config is not None:
+        command.extend(["--config", config])
+    return run(command, build_directory, check=check)
+
+
+def parse_receipt(path):
+    raw = path.read_text(encoding="utf-8")
+    document = json.loads(raw)
+    canonical = json.dumps(document, ensure_ascii=False, separators=(",", ":"))
+    if raw != canonical + "\n":
+        raise AssertionError("fixture receipt is not canonical JSON")
+    payload = json.dumps(
+        document["receipt"], ensure_ascii=False, separators=(",", ":")
+    )
+    expected = hashlib.sha256(payload.encode()).hexdigest()
+    if document["receipt_sha256"] != expected:
+        raise AssertionError("fixture receipt digest does not bind its payload")
+    return document
+
+
+def assert_static_dependency(document, fingerprint):
+    dependencies = document["receipt"]["target_dependencies"]
+    if len(dependencies) != 1:
+        raise AssertionError(f"unexpected fixture dependencies: {dependencies!r}")
+    dependency = dependencies[0]
+    if dependency["name"] != "receipt_dependency":
+        raise AssertionError(f"unexpected fixture dependency: {dependency!r}")
+    if dependency["type"] != "STATIC_LIBRARY":
+        raise AssertionError(f"dependency is not a static library: {dependency!r}")
+    if dependency["link"] is not None or not isinstance(dependency["archive"], dict):
+        raise AssertionError(f"static dependency archive is missing: {dependency!r}")
+    if not isinstance(dependency["archive"].get("command_fragments"), list):
+        raise TypeError("static dependency archive fragments are malformed")
+    groups = dependency["compile_groups"]
+    sources = [source for group in groups for source in group["sources"]]
+    if not any(source.endswith("/dependency.cpp") for source in sources):
+        raise AssertionError("static dependency source is absent from the receipt")
+    definition = f"DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256={fingerprint}"
+    if any(group["definitions"].count(definition) != 1 for group in groups):
+        raise AssertionError("static dependency does not bind the tool fingerprint")
+
+
+def assert_embedded_matches(executable, receipt_path):
+    endpoint = run([executable], executable.parent)
+    if endpoint.stderr:
+        raise AssertionError(f"fixture endpoint wrote stderr: {endpoint.stderr!r}")
+    if endpoint.stdout != receipt_path.read_text(encoding="utf-8"):
+        raise AssertionError("fixture embedded and adjacent receipts disagree")
+
+
+def assert_build_actions(result, required):
+    output = result.stdout + result.stderr
+    missing = [needle for needle in required if needle not in output]
+    if missing:
+        raise AssertionError(
+            f"build output omitted required actions {missing!r}:\n{output}"
+        )
+
+
+def test_single_config_refresh_and_replacement(
+    cmake, source, workdir, compiler_shim, real_compiler
+):
+    build_directory = workdir / "single-build"
+    write(
+        compiler_shim,
+        compiler_shim_contents(real_compiler, "first"),
+        executable=True,
+    )
+    configure(cmake, source, build_directory, compiler_shim)
+    first_build = build(cmake, build_directory)
+    assert_build_actions(
+        first_build,
+        [
+            "Embedding effective build receipt",
+            "build_receipt.cpp",
+            "receipt_probe",
+        ],
+    )
+    receipt_path = build_directory / "receipt" / "Release" / "build-receipt.json"
+    first_receipt = parse_receipt(receipt_path)
+    first_fingerprint = first_receipt["receipt"]["target"][
+        "toolchain_fingerprint_sha256"
+    ]
+    assert_static_dependency(first_receipt, first_fingerprint)
+    executable = build_directory / "receipt_probe"
+    assert_embedded_matches(executable, receipt_path)
+
+    second_build = build(cmake, build_directory)
+    assert_build_actions(
+        second_build,
+        [
+            "Embedding effective build receipt",
+            (
+                "Building CXX object "
+                "CMakeFiles/receipt_probe.dir/generated/receipt/Release/"
+                "fixture_receipt_probe_build_receipt.cpp.o"
+            ),
+            "Linking CXX executable receipt_probe",
+        ],
+    )
+
+    write(
+        compiler_shim,
+        compiler_shim_contents(real_compiler, "replacement"),
+        executable=True,
+    )
+    rejected = build(cmake, build_directory, check=False)
+    if rejected.returncode == 0:
+        raise AssertionError("persistent compiler replacement was accepted")
+    rejected_output = rejected.stdout + rejected.stderr
+    if "compiler changed after configuration" not in rejected_output:
+        raise AssertionError(
+            "compiler replacement failed for an unexpected reason:\n" + rejected_output
+        )
+
+    configure(cmake, source, build_directory, compiler_shim)
+    replacement_build = build(cmake, build_directory)
+    assert_build_actions(
+        replacement_build,
+        [
+            "dependency.cpp",
+            "probe.cpp",
+            "build_receipt.cpp",
+            "receipt_dependency",
+            "receipt_probe",
+        ],
+    )
+    replacement_receipt = parse_receipt(receipt_path)
+    replacement_fingerprint = replacement_receipt["receipt"]["target"][
+        "toolchain_fingerprint_sha256"
+    ]
+    if replacement_fingerprint == first_fingerprint:
+        raise AssertionError("compiler replacement did not change the fingerprint")
+    assert_static_dependency(replacement_receipt, replacement_fingerprint)
+    assert_embedded_matches(build_directory / "receipt_probe", receipt_path)
+
+
+def graph_configurations(ninja, build_directory, configuration):
+    result = run(
+        [
+            ninja,
+            "-C",
+            build_directory,
+            "-f",
+            f"build-{configuration}.ninja",
+            "-t",
+            "commands",
+            "receipt_probe",
+        ],
+        build_directory,
+    )
+    marker = "DEAC_BUILD_RECEIPT_CONFIGURATION:STRING="
+    configurations = set()
+    for line in result.stdout.splitlines():
+        if marker in line:
+            configurations.add(line.split(marker, 1)[1].split()[0])
+    return configurations
+
+
+def test_ninja_multi_config(cmake, ninja, source, workdir, compiler_shim):
+    build_directory = workdir / "multi-build"
+    run(
+        [
+            cmake,
+            "-S",
+            source / "src",
+            "-B",
+            build_directory,
+            "-G",
+            "Ninja Multi-Config",
+            f"-DCMAKE_MAKE_PROGRAM={ninja}",
+            f"-DCMAKE_CXX_COMPILER={compiler_shim}",
+            "-DCMAKE_CONFIGURATION_TYPES=Debug;Release;RelWithDebInfo",
+            (
+                "-DCMAKE_PREFIX_PATH="
+                f"{source / 'src' / 'prefix-a'};"
+                f"{build_directory / 'prefix-b'};/external"
+            ),
+            "-DGPU_BACKEND=none",
+        ],
+        source,
+    )
+    for configuration in ("Release", "Debug"):
+        graph = graph_configurations(ninja, build_directory, configuration)
+        if graph != {configuration}:
+            raise AssertionError(
+                f"{configuration} graph crosses receipt configurations: {graph!r}"
+            )
+
+    build(cmake, build_directory, config="Release")
+    generated_root = build_directory / "generated" / "receipt"
+    receipt_root = build_directory / "receipt"
+    release_source = generated_root / "Release" / "fixture_receipt_probe_build_receipt.cpp"
+    release_receipt = receipt_root / "Release" / "build-receipt.json"
+    if not release_source.is_file() or not release_receipt.is_file():
+        raise AssertionError("Release receipt outputs were not generated")
+    for other in ("Debug", "RelWithDebInfo"):
+        if (generated_root / other).exists() or (receipt_root / other).exists():
+            raise AssertionError(f"Release build mutated {other} receipt outputs")
+    release_bytes = (release_source.read_bytes(), release_receipt.read_bytes())
+    release_times = (release_source.stat().st_mtime_ns, release_receipt.stat().st_mtime_ns)
+
+    build(cmake, build_directory, config="Debug")
+    debug_source = generated_root / "Debug" / "fixture_receipt_probe_build_receipt.cpp"
+    debug_receipt = receipt_root / "Debug" / "build-receipt.json"
+    if not debug_source.is_file() or not debug_receipt.is_file():
+        raise AssertionError("Debug receipt outputs were not generated")
+    if release_bytes != (release_source.read_bytes(), release_receipt.read_bytes()):
+        raise AssertionError("Debug build changed Release receipt bytes")
+    if release_times != (
+        release_source.stat().st_mtime_ns,
+        release_receipt.stat().st_mtime_ns,
+    ):
+        raise AssertionError("Debug build touched Release receipt outputs")
+    release_document = parse_receipt(release_receipt)
+    debug_document = parse_receipt(debug_receipt)
+    if release_document["receipt"]["build_system"]["configuration"] != "Release":
+        raise AssertionError("Release receipt records another configuration")
+    if debug_document["receipt"]["build_system"]["configuration"] != "Debug":
+        raise AssertionError("Debug receipt records another configuration")
+    for document in (release_document, debug_document):
+        entries = {
+            entry["name"]: entry["value"]
+            for entry in document["receipt"]["cache_entries"]
+        }
+        expected_configurations = "Debug;Release;RelWithDebInfo"
+        if entries.get("CMAKE_CONFIGURATION_TYPES") != expected_configurations:
+            raise AssertionError(
+                "multi-config cache value lost list separators: "
+                f"{entries.get('CMAKE_CONFIGURATION_TYPES')!r}"
+            )
+        expected_prefix_path = (
+            "<SOURCE_ROOT>/prefix-a;<BUILD_ROOT>/prefix-b;/external"
+        )
+        if entries.get("CMAKE_PREFIX_PATH") != expected_prefix_path:
+            raise AssertionError(
+                "path-list cache value was not normalized elementwise: "
+                f"{entries.get('CMAKE_PREFIX_PATH')!r}"
+            )
+    assert_embedded_matches(
+        build_directory / "Release" / "receipt_probe", release_receipt
+    )
+    assert_embedded_matches(
+        build_directory / "Debug" / "receipt_probe", debug_receipt
+    )
+
+
+def assert_configure_rejected(cmake, source, build_directory, compiler, arguments, text):
+    result = configure(
+        cmake,
+        source,
+        build_directory,
+        compiler,
+        *arguments,
+        check=False,
+    )
+    if result.returncode == 0:
+        raise AssertionError(f"unsupported configure route was accepted: {arguments!r}")
+    output = result.stdout + result.stderr
+    if text not in output:
+        raise AssertionError(
+            f"configure rejection did not mention {text!r}:\n{output}"
+        )
+
+
+def test_rule_override_rejections(cmake, source, workdir, real_compiler):
+    compile_rule = (
+        "/usr/bin/env <CMAKE_CXX_COMPILER> <DEFINES> <INCLUDES> <FLAGS> "
+        "-o <OBJECT> -c <SOURCE>"
+    )
+    link_rule = (
+        "/usr/bin/env <CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> "
+        "<LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>"
+    )
+    attacks = [
+        ("compile", [f"-DCMAKE_CXX_COMPILE_OBJECT={compile_rule}"], "CMAKE_CXX_COMPILE_OBJECT"),
+        ("link", [f"-DCMAKE_CXX_LINK_EXECUTABLE={link_rule}"], "CMAKE_CXX_LINK_EXECUTABLE"),
+        (
+            "cuda",
+            ["-DCMAKE_CUDA_COMPILE_OBJECT=/usr/bin/env <CMAKE_CUDA_COMPILER>"],
+            "CMAKE_CUDA_COMPILE_OBJECT",
+        ),
+        (
+            "hip",
+            ["-DCMAKE_HIP_LINK_EXECUTABLE=/usr/bin/env <CMAKE_HIP_COMPILER>"],
+            "CMAKE_HIP_LINK_EXECUTABLE",
+        ),
+        (
+            "cuda-device-link",
+            [
+                (
+                    "-DCMAKE_CUDA_DEVICE_LINK_EXECUTABLE="
+                    "/usr/bin/env <CMAKE_CUDA_COMPILER>"
+                )
+            ],
+            "CMAKE_CUDA_DEVICE_LINK_EXECUTABLE",
+        ),
+    ]
+    for name, arguments, expected in attacks:
+        assert_configure_rejected(
+            cmake,
+            source,
+            workdir / f"rejected-{name}",
+            real_compiler,
+            arguments,
+            expected,
+        )
+
+    override = workdir / "user-rules.cmake"
+    write(override, "# intentionally empty override route\n")
+    assert_configure_rejected(
+        cmake,
+        source,
+        workdir / "rejected-user-rules",
+        real_compiler,
+        [f"-DCMAKE_USER_MAKE_RULES_OVERRIDE={override}"],
+        "CMAKE_USER_MAKE_RULES_OVERRIDE",
+    )
+    toolchain = workdir / "toolchain.cmake"
+    write(toolchain, f"set(CMAKE_CXX_COMPILER {json.dumps(str(real_compiler))})\n")
+    assert_configure_rejected(
+        cmake,
+        source,
+        workdir / "rejected-toolchain",
+        real_compiler,
+        [f"-DCMAKE_TOOLCHAIN_FILE={toolchain}"],
+        "CMAKE_TOOLCHAIN_FILE",
+    )
+    assert_configure_rejected(
+        cmake,
+        source,
+        workdir / "rejected-module-path",
+        real_compiler,
+        [f"-DCMAKE_MODULE_PATH={workdir}"],
+        "CMAKE_MODULE_PATH",
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cmake", required=True)
+    parser.add_argument("--ninja", required=True)
+    parser.add_argument("--solver-source-root", required=True)
+    parser.add_argument("--cxx-compiler", required=True)
+    parser.add_argument("--workdir", required=True)
+    args = parser.parse_args()
+
+    workdir = Path(args.workdir).resolve()
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+    source = workdir / "fixture-source"
+    solver_source = Path(args.solver_source_root).resolve()
+    real_compiler = Path(args.cxx_compiler).resolve()
+    compiler_shim = workdir / "compiler-shim"
+    create_fixture_source(solver_source, source)
+
+    test_single_config_refresh_and_replacement(
+        args.cmake, source, workdir, compiler_shim, real_compiler
+    )
+    test_ninja_multi_config(
+        args.cmake, Path(args.ninja).resolve(), source, workdir, compiler_shim
+    )
+    test_rule_override_rejections(
+        args.cmake, source, workdir, real_compiler
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/deac_build_receipt_fixture_test.py
+++ b/test/deac_build_receipt_fixture_test.py
@@ -30,6 +30,14 @@ def write(path, contents, *, executable=False):
         path.chmod(0o755)
 
 
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
 def copy_fixture_modules(solver_source, fixture_source):
     module_names = [
         "DeacBuildIdentity.cmake",
@@ -75,6 +83,26 @@ int main() {
 """,
     )
     write(
+        fixture_source / "src" / "dependency_two.cpp",
+        "int receipt_dependency_two() { return 23; }\n",
+    )
+    write(
+        fixture_source / "src" / "probe_two.cpp",
+        """#include "build_identity.hpp"
+#include <iostream>
+
+int receipt_dependency_two();
+
+int main() {
+    if (receipt_dependency_two() != 23) {
+        return 2;
+    }
+    std::cout << deac_build_identity::build_receipt_json() << '\\n';
+    return 0;
+}
+""",
+    )
+    write(
         fixture_source / "src" / "CMakeLists.txt",
         """cmake_minimum_required(VERSION 3.27)
 project(deac_build_receipt_fixture LANGUAGES CXX)
@@ -82,12 +110,69 @@ project(deac_build_receipt_fixture LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(GPU_BACKEND none CACHE STRING "fixture backend")
+set(DEAC_FIXTURE_ARCHIVER "" CACHE FILEPATH "effective fixture CMAKE_AR")
+set(DEAC_FIXTURE_RULE_ATTACK "" CACHE STRING "fixture rule attack")
+set(DEAC_FIXTURE_NATIVE_LANGUAGE_SHAPE "" CACHE STRING "native language shape")
+option(DEAC_FIXTURE_PARALLEL_CONSUMERS "add a second receipt consumer" OFF)
+option(DEAC_FIXTURE_DEPENDENCY_IPO_RELEASE "enable dependency Release IPO" OFF)
+
+# CMake's persisted compiler-information file restores CMAKE_AR as a normal
+# variable on every reconfigure, shadowing a changed -DCMAKE_AR cache entry.
+# Rebind both scopes so the fixture can exercise a genuine effective archiver
+# transition in one build tree.
+if(NOT DEAC_FIXTURE_ARCHIVER STREQUAL "")
+    set(CMAKE_AR "${DEAC_FIXTURE_ARCHIVER}" CACHE FILEPATH
+        "effective fixture CMAKE_AR" FORCE)
+    set(CMAKE_AR "${DEAC_FIXTURE_ARCHIVER}")
+endif()
 
 add_library(receipt_dependency STATIC dependency.cpp)
 add_executable(receipt_probe probe.cpp)
 target_link_libraries(receipt_probe PRIVATE receipt_dependency)
+if(DEAC_FIXTURE_DEPENDENCY_IPO_RELEASE)
+    set_property(TARGET receipt_dependency PROPERTY
+        INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+endif()
+if(DEAC_FIXTURE_PARALLEL_CONSUMERS)
+    add_library(receipt_dependency_two STATIC dependency_two.cpp)
+    add_executable(receipt_probe_two probe_two.cpp)
+    target_link_libraries(receipt_probe_two PRIVATE receipt_dependency_two)
+endif()
+
+if(DEAC_FIXTURE_RULE_ATTACK STREQUAL "compile-and")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " && \\\"${CMAKE_COMMAND}\\\" -E false")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "link-or")
+    string(APPEND CMAKE_CXX_LINK_EXECUTABLE
+        " || \\\"${CMAKE_COMMAND}\\\" -E true")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "archive-pipe")
+    string(APPEND CMAKE_CXX_ARCHIVE_CREATE
+        " | \\\"${CMAKE_COMMAND}\\\" -E true")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "quoted-pipe")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT " \\\"literal|argument\\\"")
+elseif(NOT DEAC_FIXTURE_RULE_ATTACK STREQUAL "")
+    message(FATAL_ERROR "unknown fixture rule attack")
+endif()
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/DeacBuildReceipt.cmake")
+if(DEAC_FIXTURE_NATIVE_LANGUAGE_SHAPE MATCHES "^(CUDA|HIP)$")
+    _deac_build_receipt_reject_unsupported_languages(
+        CXX "${DEAC_FIXTURE_NATIVE_LANGUAGE_SHAPE}")
+elseif(NOT DEAC_FIXTURE_NATIVE_LANGUAGE_SHAPE STREQUAL "")
+    message(FATAL_ERROR "invalid native language shape")
+endif()
+set(DEAC_FIXTURE_CACHE_KEYS
+    CMAKE_AR
+    CMAKE_BUILD_TYPE
+    CMAKE_CONFIGURATION_TYPES
+    CMAKE_CXX_COMPILER
+    CMAKE_CXX_FLAGS
+    CMAKE_EXE_LINKER_FLAGS
+    CMAKE_GENERATOR
+    CMAKE_HOME_DIRECTORY
+    CMAKE_PREFIX_PATH
+    CMAKE_RANLIB
+    GPU_BACKEND)
 deac_target_add_build_receipt(receipt_probe
     SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/.."
     GENERATED_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/receipt"
@@ -95,17 +180,19 @@ deac_target_add_build_receipt(receipt_probe
     RECEIPT
         "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<CONFIG>/build-receipt.json"
     BACKEND "${GPU_BACKEND}"
-    CACHE_KEYS
-        CMAKE_BUILD_TYPE
-        CMAKE_CONFIGURATION_TYPES
-        CMAKE_CXX_COMPILER
-        CMAKE_CXX_FLAGS
-        CMAKE_EXE_LINKER_FLAGS
-        CMAKE_GENERATOR
-        CMAKE_HOME_DIRECTORY
-        CMAKE_PREFIX_PATH
-        GPU_BACKEND
+    CACHE_KEYS ${DEAC_FIXTURE_CACHE_KEYS}
     DEPENDENCY_TARGETS receipt_dependency)
+if(DEAC_FIXTURE_PARALLEL_CONSUMERS)
+    deac_target_add_build_receipt(receipt_probe_two
+        SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/.."
+        GENERATED_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/receipt"
+        IDENTITY_NAME fixture
+        RECEIPT
+            "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<CONFIG>/build-receipt-two.json"
+        BACKEND "${GPU_BACKEND}"
+        CACHE_KEYS ${DEAC_FIXTURE_CACHE_KEYS}
+        DEPENDENCY_TARGETS receipt_dependency_two)
+endif()
 """,
     )
 
@@ -115,6 +202,14 @@ def compiler_shim_contents(real_compiler, marker):
         "#!/bin/sh\n"
         f"# receipt fixture compiler marker: {marker}\n"
         f"exec {shlex.quote(str(real_compiler))} \"$@\"\n"
+    )
+
+
+def archive_shim_contents(real_archiver, marker):
+    return (
+        "#!/bin/sh\n"
+        f"# receipt fixture archiver marker: {marker}\n"
+        f"exec {shlex.quote(str(real_archiver))} \"$@\"\n"
     )
 
 
@@ -136,13 +231,13 @@ def configure(cmake, source, build, compiler, *extra, check=True):
     )
 
 
-def build(cmake, build_directory, *, config=None, check=True):
+def build(cmake, build_directory, *, config=None, parallel=1, check=True):
     command = [
         cmake,
         "--build",
         build_directory,
         "--parallel",
-        "1",
+        str(parallel),
         "--verbose",
     ]
     if config is not None:
@@ -162,15 +257,67 @@ def parse_receipt(path):
     expected = hashlib.sha256(payload.encode()).hexdigest()
     if document["receipt_sha256"] != expected:
         raise AssertionError("fixture receipt digest does not bind its payload")
+    expected_keys = [
+        "archive_tools",
+        "backend",
+        "build_system",
+        "cache_entries",
+        "compile_groups",
+        "link",
+        "source_identity",
+        "target",
+        "target_dependencies",
+        "toolchains",
+    ]
+    if list(document["receipt"]) != expected_keys:
+        raise AssertionError("fixture receipt payload keys are not canonical")
     return document
 
 
-def assert_static_dependency(document, fingerprint):
+def archive_tool(document, name):
+    tools = document["receipt"]["archive_tools"]
+    if [tool.get("name") for tool in tools] != ["CMAKE_AR", "CMAKE_RANLIB"]:
+        raise AssertionError(f"unexpected archive tools: {tools!r}")
+    tool = next(tool for tool in tools if tool["name"] == name)
+    if list(tool) != ["name", "path", "real_path", "sha256"]:
+        raise AssertionError(f"noncanonical archive tool: {tool!r}")
+    if len(tool["sha256"]) != 64 or any(
+        character not in "0123456789abcdef" for character in tool["sha256"]
+    ):
+        raise AssertionError(f"invalid archive tool digest: {tool!r}")
+    if not tool["real_path"].startswith("<"):
+        if (
+            not tool["path"].startswith("<")
+            and Path(tool["path"]).resolve() != Path(tool["real_path"])
+        ):
+            raise AssertionError(f"archive tool paths disagree: {tool!r}")
+        if sha256_file(tool["real_path"]) != tool["sha256"]:
+            raise AssertionError(f"archive tool digest disagrees: {tool!r}")
+    return tool
+
+
+def assert_no_git_source(document, version):
+    expected = {
+        "schema_version": 1,
+        "semantic_version": version,
+        "source_sha": None,
+        "source_state": "unavailable",
+    }
+    if document["receipt"]["source_identity"] != expected:
+        raise AssertionError(
+            "no-Git fixture acquired unexpected source identity: "
+            f"{document['receipt']['source_identity']!r}"
+        )
+
+
+def assert_static_dependency(
+    document, fingerprint, expected_name="receipt_dependency"
+):
     dependencies = document["receipt"]["target_dependencies"]
     if len(dependencies) != 1:
         raise AssertionError(f"unexpected fixture dependencies: {dependencies!r}")
     dependency = dependencies[0]
-    if dependency["name"] != "receipt_dependency":
+    if dependency["name"] != expected_name:
         raise AssertionError(f"unexpected fixture dependency: {dependency!r}")
     if dependency["type"] != "STATIC_LIBRARY":
         raise AssertionError(f"dependency is not a static library: {dependency!r}")
@@ -180,8 +327,11 @@ def assert_static_dependency(document, fingerprint):
         raise TypeError("static dependency archive fragments are malformed")
     groups = dependency["compile_groups"]
     sources = [source for group in groups for source in group["sources"]]
-    if not any(source.endswith("/dependency.cpp") for source in sources):
-        raise AssertionError("static dependency source is absent from the receipt")
+    expected_source = expected_name.removeprefix("receipt_") + ".cpp"
+    if not any(source.endswith("/" + expected_source) for source in sources):
+        raise AssertionError(
+            f"static dependency source {expected_source!r} is absent from the receipt"
+        )
     definition = f"DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256={fingerprint}"
     if any(group["definitions"].count(definition) != 1 for group in groups):
         raise AssertionError("static dependency does not bind the tool fingerprint")
@@ -202,6 +352,21 @@ def assert_build_actions(result, required):
         raise AssertionError(
             f"build output omitted required actions {missing!r}:\n{output}"
         )
+
+
+def receipt_fingerprint(document):
+    return document["receipt"]["target"]["toolchain_fingerprint_sha256"]
+
+
+def cache_value(document, name):
+    matches = [
+        entry["value"]
+        for entry in document["receipt"]["cache_entries"]
+        if entry["name"] == name
+    ]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one {name} cache entry, got {matches!r}")
+    return matches[0]
 
 
 def test_single_config_refresh_and_replacement(
@@ -230,6 +395,9 @@ def test_single_config_refresh_and_replacement(
     first_fingerprint = first_receipt["receipt"]["target"][
         "toolchain_fingerprint_sha256"
     ]
+    archive_tool(first_receipt, "CMAKE_AR")
+    archive_tool(first_receipt, "CMAKE_RANLIB")
+    assert_no_git_source(first_receipt, "1.2.3")
     assert_static_dependency(first_receipt, first_fingerprint)
     executable = build_directory / "receipt_probe"
     assert_embedded_matches(executable, receipt_path)
@@ -250,6 +418,7 @@ def test_single_config_refresh_and_replacement(
         raise AssertionError("material receipt refresh did not change its digest")
     if changed_receipt["receipt"]["source_identity"]["semantic_version"] != "1.2.4":
         raise AssertionError("material receipt refresh retained the old version")
+    assert_no_git_source(changed_receipt, "1.2.4")
     assert_embedded_matches(executable, receipt_path)
 
     write(
@@ -284,7 +453,165 @@ def test_single_config_refresh_and_replacement(
     ]
     if replacement_fingerprint == first_fingerprint:
         raise AssertionError("compiler replacement did not change the fingerprint")
+    assert_no_git_source(replacement_receipt, "1.2.4")
     assert_static_dependency(replacement_receipt, replacement_fingerprint)
+    assert_embedded_matches(build_directory / "receipt_probe", receipt_path)
+
+
+def test_single_config_ninja(cmake, ninja, source, workdir, real_compiler):
+    build_directory = workdir / "ninja-single-build"
+    configure(
+        cmake,
+        source,
+        build_directory,
+        real_compiler,
+        "-G",
+        "Ninja",
+        f"-DCMAKE_MAKE_PROGRAM={ninja}",
+    )
+    required = [
+        "GenerateDeacBuildReceipt.cmake",
+        "fixture_receipt_probe_build_receipt.cpp.o",
+        "-o receipt_probe",
+    ]
+    first_build = build(cmake, build_directory)
+    assert_build_actions(first_build, required)
+    second_build = build(cmake, build_directory)
+    assert_build_actions(second_build, required)
+
+    receipt_path = build_directory / "receipt" / "Release" / "build-receipt.json"
+    document = parse_receipt(receipt_path)
+    generator = document["receipt"]["build_system"]["generator"]
+    if generator["name"] != "Ninja" or generator["multi_config"]:
+        raise AssertionError(f"unexpected single-config Ninja receipt: {generator!r}")
+    assert_no_git_source(document, "1.2.4")
+    assert_static_dependency(document, receipt_fingerprint(document))
+    assert_embedded_matches(build_directory / "receipt_probe", receipt_path)
+
+
+def test_material_flag_reconfiguration(cmake, source, workdir, real_compiler):
+    build_directory = workdir / "material-flag-build"
+    configure(cmake, source, build_directory, real_compiler)
+    build(cmake, build_directory)
+    receipt_path = build_directory / "receipt" / "Release" / "build-receipt.json"
+    first_receipt = parse_receipt(receipt_path)
+
+    flag = "-DDEAC_FIXTURE_MATERIAL_FLAG=17"
+    configure(
+        cmake,
+        source,
+        build_directory,
+        real_compiler,
+        f"-DCMAKE_CXX_FLAGS={flag}",
+    )
+    changed_build = build(cmake, build_directory)
+    assert_build_actions(
+        changed_build,
+        [
+            flag,
+            "dependency.cpp.o",
+            "probe.cpp.o",
+            "fixture_receipt_probe_build_receipt.cpp.o",
+            "Linking CXX static library libreceipt_dependency.a",
+            "Linking CXX executable receipt_probe",
+        ],
+    )
+    changed_receipt = parse_receipt(receipt_path)
+    if changed_receipt["receipt_sha256"] == first_receipt["receipt_sha256"]:
+        raise AssertionError("material flag reconfigure did not change the receipt")
+    if receipt_fingerprint(changed_receipt) != receipt_fingerprint(first_receipt):
+        raise AssertionError("material flags unexpectedly changed the tool fingerprint")
+    if cache_value(changed_receipt, "CMAKE_CXX_FLAGS") != flag:
+        raise AssertionError("material flag is absent from the receipt cache")
+    if flag not in json.dumps(changed_receipt, separators=(",", ":")):
+        raise AssertionError("material flag is absent from effective command data")
+    assert_no_git_source(changed_receipt, "1.2.4")
+    assert_embedded_matches(build_directory / "receipt_probe", receipt_path)
+
+
+def test_archive_tool_reconfiguration(
+    cmake, source, workdir, real_compiler, real_archiver
+):
+    build_directory = workdir / "archive-tool-build"
+    tool_directory = workdir / "archive-tools"
+    ar_one = tool_directory / "ar-one"
+    ar_two = tool_directory / "ar-two"
+    write(
+        ar_one,
+        archive_shim_contents(real_archiver, "one"),
+        executable=True,
+    )
+    write(
+        ar_two,
+        archive_shim_contents(real_archiver, "two"),
+        executable=True,
+    )
+
+    configure(
+        cmake,
+        source,
+        build_directory,
+        real_compiler,
+        f"-DDEAC_FIXTURE_ARCHIVER={ar_one}",
+    )
+    first_build = build(cmake, build_directory)
+    assert_build_actions(
+        first_build,
+        [str(ar_one), "Linking CXX static library libreceipt_dependency.a"],
+    )
+    receipt_path = build_directory / "receipt" / "Release" / "build-receipt.json"
+    first_receipt = parse_receipt(receipt_path)
+    first_ar = archive_tool(first_receipt, "CMAKE_AR")
+    if first_ar["path"] != str(ar_one):
+        raise AssertionError(f"receipt recorded the wrong first archiver: {first_ar!r}")
+    if cache_value(first_receipt, "CMAKE_AR") != str(ar_one):
+        raise AssertionError("receipt cache omitted the first effective archiver")
+    assert_embedded_matches(build_directory / "receipt_probe", receipt_path)
+
+    write(
+        ar_one,
+        archive_shim_contents(real_archiver, "tampered"),
+        executable=True,
+    )
+    rejected = build(cmake, build_directory, check=False)
+    if rejected.returncode == 0:
+        raise AssertionError("persistent CMAKE_AR replacement was accepted")
+    rejected_output = rejected.stdout + rejected.stderr
+    if "CMAKE_AR executable changed after configuration" not in rejected_output:
+        raise AssertionError(
+            "CMAKE_AR replacement failed for an unexpected reason:\n"
+            + rejected_output
+        )
+
+    configure(
+        cmake,
+        source,
+        build_directory,
+        real_compiler,
+        f"-DDEAC_FIXTURE_ARCHIVER={ar_two}",
+    )
+    second_build = build(cmake, build_directory)
+    assert_build_actions(
+        second_build,
+        [
+            str(ar_two),
+            "dependency.cpp.o",
+            "Linking CXX static library libreceipt_dependency.a",
+            "Linking CXX executable receipt_probe",
+        ],
+    )
+    second_receipt = parse_receipt(receipt_path)
+    second_ar = archive_tool(second_receipt, "CMAKE_AR")
+    if second_ar["path"] != str(ar_two) or second_ar["sha256"] != sha256_file(ar_two):
+        raise AssertionError(f"receipt recorded the wrong second archiver: {second_ar!r}")
+    if cache_value(second_receipt, "CMAKE_AR") != str(ar_two):
+        raise AssertionError("receipt cache omitted the second effective archiver")
+    if receipt_fingerprint(second_receipt) == receipt_fingerprint(first_receipt):
+        raise AssertionError("archiver reconfigure did not invalidate the fingerprint")
+    if second_receipt["receipt_sha256"] == first_receipt["receipt_sha256"]:
+        raise AssertionError("archiver reconfigure did not change the receipt identity")
+    assert_static_dependency(second_receipt, receipt_fingerprint(second_receipt))
+    assert_no_git_source(second_receipt, "1.2.4")
     assert_embedded_matches(build_directory / "receipt_probe", receipt_path)
 
 
@@ -390,12 +717,67 @@ def test_ninja_multi_config(cmake, ninja, source, workdir, compiler_shim):
                 "path-list cache value was not normalized elementwise: "
                 f"{entries.get('CMAKE_PREFIX_PATH')!r}"
             )
+        assert_no_git_source(document, "1.2.4")
+        assert_static_dependency(document, receipt_fingerprint(document))
     assert_embedded_matches(
         build_directory / "Release" / "receipt_probe", release_receipt
     )
     assert_embedded_matches(
         build_directory / "Debug" / "receipt_probe", debug_receipt
     )
+
+
+def test_parallel_receipt_consumers(
+    cmake, ninja, solver_source, workdir, real_compiler
+):
+    source = workdir / "parallel-source"
+    create_fixture_source(solver_source, source)
+    build_directory = workdir / "parallel-build"
+    configure(
+        cmake,
+        source,
+        build_directory,
+        real_compiler,
+        "-G",
+        "Ninja",
+        f"-DCMAKE_MAKE_PROGRAM={ninja}",
+        "-DDEAC_FIXTURE_PARALLEL_CONSUMERS=ON",
+    )
+    result = build(cmake, build_directory, parallel=4)
+    assert_build_actions(
+        result,
+        [
+            "fixture_receipt_probe_build_receipt.cpp.o",
+            "fixture_receipt_probe_two_build_receipt.cpp.o",
+            "-o receipt_probe ",
+            "-o receipt_probe_two",
+        ],
+    )
+
+    receipt_root = build_directory / "receipt" / "Release"
+    checks = [
+        (
+            "receipt_probe",
+            "receipt_dependency",
+            receipt_root / "build-receipt.json",
+        ),
+        (
+            "receipt_probe_two",
+            "receipt_dependency_two",
+            receipt_root / "build-receipt-two.json",
+        ),
+    ]
+    for executable_name, dependency_name, receipt_path in checks:
+        document = parse_receipt(receipt_path)
+        if document["receipt"]["target"]["name"] != executable_name:
+            raise AssertionError(f"parallel receipt names the wrong target: {document!r}")
+        assert_no_git_source(document, "1.2.3")
+        assert_static_dependency(
+            document,
+            receipt_fingerprint(document),
+            expected_name=dependency_name,
+        )
+        assert_embedded_matches(build_directory / executable_name, receipt_path)
 
 
 def assert_configure_rejected(cmake, source, build_directory, compiler, arguments, text):
@@ -416,7 +798,9 @@ def assert_configure_rejected(cmake, source, build_directory, compiler, argument
         )
 
 
-def test_rule_override_rejections(cmake, source, workdir, real_compiler):
+def test_rule_override_rejections(
+    cmake, ninja, source, workdir, real_compiler
+):
     compile_rule = (
         "/usr/bin/env <CMAKE_CXX_COMPILER> <DEFINES> <INCLUDES> <FLAGS> "
         "-o <OBJECT> -c <SOURCE>"
@@ -459,6 +843,80 @@ def test_rule_override_rejections(cmake, source, workdir, real_compiler):
             expected,
         )
 
+    project_rule_attacks = [
+        ("compile-and", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("link-or", "CMAKE_CXX_LINK_EXECUTABLE"),
+        ("archive-pipe", "CMAKE_CXX_ARCHIVE_CREATE"),
+    ]
+    for attack, expected in project_rule_attacks:
+        assert_configure_rejected(
+            cmake,
+            source,
+            workdir / f"rejected-project-rule-{attack}",
+            real_compiler,
+            [f"-DDEAC_FIXTURE_RULE_ATTACK={attack}"],
+            expected,
+        )
+
+    # A literal operator inside a quoted argument remains one represented
+    # command and must not be confused with an active shell pipeline.
+    configure(
+        cmake,
+        source,
+        workdir / "accepted-quoted-pipe",
+        real_compiler,
+        "-DDEAC_FIXTURE_RULE_ATTACK=quoted-pipe",
+    )
+
+    assert_configure_rejected(
+        cmake,
+        source,
+        workdir / "rejected-generic-ipo",
+        real_compiler,
+        ["-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON"],
+        "INTERPROCEDURAL_OPTIMIZATION",
+    )
+    assert_configure_rejected(
+        cmake,
+        source,
+        workdir / "rejected-release-ipo",
+        real_compiler,
+        ["-DCMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE=ON"],
+        "INTERPROCEDURAL_OPTIMIZATION_RELEASE",
+    )
+    assert_configure_rejected(
+        cmake,
+        source,
+        workdir / "rejected-dependency-release-ipo",
+        real_compiler,
+        ["-DDEAC_FIXTURE_DEPENDENCY_IPO_RELEASE=ON"],
+        "INTERPROCEDURAL_OPTIMIZATION_RELEASE",
+    )
+    assert_configure_rejected(
+        cmake,
+        source,
+        workdir / "rejected-multi-release-ipo",
+        real_compiler,
+        [
+            "-G",
+            "Ninja Multi-Config",
+            f"-DCMAKE_MAKE_PROGRAM={ninja}",
+            "-DCMAKE_CONFIGURATION_TYPES=Debug;Release;RelWithDebInfo",
+            "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE=ON",
+        ],
+        "INTERPROCEDURAL_OPTIMIZATION_RELEASE",
+    )
+
+    for language in ("CUDA", "HIP"):
+        assert_configure_rejected(
+            cmake,
+            source,
+            workdir / f"rejected-native-{language.lower()}",
+            real_compiler,
+            [f"-DDEAC_FIXTURE_NATIVE_LANGUAGE_SHAPE={language}"],
+            f"native CMake {language} language",
+        )
+
     override = workdir / "user-rules.cmake"
     write(override, "# intentionally empty override route\n")
     assert_configure_rejected(
@@ -495,6 +953,7 @@ def main():
     parser.add_argument("--ninja", required=True)
     parser.add_argument("--solver-source-root", required=True)
     parser.add_argument("--cxx-compiler", required=True)
+    parser.add_argument("--archiver", required=True)
     parser.add_argument("--workdir", required=True)
     args = parser.parse_args()
 
@@ -505,17 +964,31 @@ def main():
     source = workdir / "fixture-source"
     solver_source = Path(args.solver_source_root).resolve()
     real_compiler = Path(args.cxx_compiler).resolve()
+    real_archiver = Path(args.archiver).resolve()
+    ninja = Path(args.ninja).resolve()
     compiler_shim = workdir / "compiler-shim"
     create_fixture_source(solver_source, source)
 
     test_single_config_refresh_and_replacement(
         args.cmake, source, workdir, compiler_shim, real_compiler
     )
+    test_single_config_ninja(
+        args.cmake, ninja, source, workdir, real_compiler
+    )
+    test_material_flag_reconfiguration(
+        args.cmake, source, workdir, real_compiler
+    )
+    test_archive_tool_reconfiguration(
+        args.cmake, source, workdir, real_compiler, real_archiver
+    )
     test_ninja_multi_config(
-        args.cmake, Path(args.ninja).resolve(), source, workdir, compiler_shim
+        args.cmake, ninja, source, workdir, compiler_shim
+    )
+    test_parallel_receipt_consumers(
+        args.cmake, ninja, solver_source, workdir, real_compiler
     )
     test_rule_override_rejections(
-        args.cmake, source, workdir, real_compiler
+        args.cmake, ninja, source, workdir, real_compiler
     )
 
 

--- a/test/deac_build_receipt_fixture_test.py
+++ b/test/deac_build_receipt_fixture_test.py
@@ -137,7 +137,14 @@ def configure(cmake, source, build, compiler, *extra, check=True):
 
 
 def build(cmake, build_directory, *, config=None, check=True):
-    command = [cmake, "--build", build_directory, "--parallel", "2", "--verbose"]
+    command = [
+        cmake,
+        "--build",
+        build_directory,
+        "--parallel",
+        "1",
+        "--verbose",
+    ]
     if config is not None:
         command.extend(["--config", config])
     return run(command, build_directory, check=check)
@@ -207,15 +214,17 @@ def test_single_config_refresh_and_replacement(
         executable=True,
     )
     configure(cmake, source, build_directory, compiler_shim)
+    receipt_actions = [
+        "Embedding effective build receipt",
+        (
+            "Building CXX object "
+            "CMakeFiles/receipt_probe.dir/generated/receipt/Release/"
+            "fixture_receipt_probe_build_receipt.cpp.o"
+        ),
+        "Linking CXX executable receipt_probe",
+    ]
     first_build = build(cmake, build_directory)
-    assert_build_actions(
-        first_build,
-        [
-            "Embedding effective build receipt",
-            "build_receipt.cpp",
-            "receipt_probe",
-        ],
-    )
+    assert_build_actions(first_build, receipt_actions)
     receipt_path = build_directory / "receipt" / "Release" / "build-receipt.json"
     first_receipt = parse_receipt(receipt_path)
     first_fingerprint = first_receipt["receipt"]["target"][
@@ -226,18 +235,22 @@ def test_single_config_refresh_and_replacement(
     assert_embedded_matches(executable, receipt_path)
 
     second_build = build(cmake, build_directory)
-    assert_build_actions(
-        second_build,
-        [
-            "Embedding effective build receipt",
-            (
-                "Building CXX object "
-                "CMakeFiles/receipt_probe.dir/generated/receipt/Release/"
-                "fixture_receipt_probe_build_receipt.cpp.o"
-            ),
-            "Linking CXX executable receipt_probe",
-        ],
-    )
+    assert_build_actions(second_build, receipt_actions)
+    assert_embedded_matches(executable, receipt_path)
+
+    # Refresh a material build-time input without reconfiguring.  The same
+    # generated graph must compile the new receipt object before relinking;
+    # comparing only the freely replaceable adjacent JSON would miss a stale
+    # embedded receipt.
+    write(source / "VERSION", "1.2.4\n")
+    changed_build = build(cmake, build_directory)
+    assert_build_actions(changed_build, receipt_actions)
+    changed_receipt = parse_receipt(receipt_path)
+    if changed_receipt["receipt_sha256"] == first_receipt["receipt_sha256"]:
+        raise AssertionError("material receipt refresh did not change its digest")
+    if changed_receipt["receipt"]["source_identity"]["semantic_version"] != "1.2.4":
+        raise AssertionError("material receipt refresh retained the old version")
+    assert_embedded_matches(executable, receipt_path)
 
     write(
         compiler_shim,

--- a/test/deac_build_receipt_fixture_test.py
+++ b/test/deac_build_receipt_fixture_test.py
@@ -2875,6 +2875,395 @@ def test_json_control_encoding(cmake, source, workdir, real_compiler):
         assert_embedded_matches(build_directory / "receipt_probe", receipt_path)
 
 
+def test_unbound_compile_input_rejections(
+    cmake, source, workdir, real_compiler
+):
+    build_directory = workdir / "rejected-unbound-compile-inputs"
+    configure(cmake, source, build_directory, real_compiler)
+    target_reply = file_api_target_reply(build_directory, "receipt_probe")
+    original = json.loads(target_reply.read_text(encoding="utf-8"))
+    compile_groups = original.get("compileGroups")
+    if not isinstance(compile_groups, list) or not compile_groups:
+        raise TypeError("fixture target compile groups are malformed")
+    original_fragments = compile_groups[0].get("compileCommandFragments")
+    if not isinstance(original_fragments, list):
+        raise TypeError("fixture target compile fragments are malformed")
+
+    route_mutations = (
+        ("response-file", "@/tmp/deac-flags.rsp"),
+        ("wa-response-file", "-Wa,@/tmp/deac-assembler.rsp"),
+        (
+            "wa-list-response-file",
+            "-Wa,-compress-debug-sections,@/tmp/deac-assembler.rsp",
+        ),
+        ("include-separate", "-include /tmp/deac-force.hpp"),
+        ("include-equals", "-include=/tmp/deac-force.hpp"),
+        ("include-joined", "-include/tmp/deac-force.hpp"),
+        ("long-include-separate", "--include /tmp/deac-force.hpp"),
+        ("long-include-attached", "--include=/tmp/deac-force.hpp"),
+        ("long-include-joined", "--include/tmp/deac-force.hpp"),
+        ("imacros-separate", "-imacros /tmp/deac-macros.hpp"),
+        ("imacros-equals", "-imacros=/tmp/deac-macros.hpp"),
+        ("imacros-joined", "-imacros/tmp/deac-macros.hpp"),
+        ("long-imacros-separate", "--imacros /tmp/deac-macros.hpp"),
+        ("long-imacros-attached", "--imacros=/tmp/deac-macros.hpp"),
+        ("long-imacros-joined", "--imacros/tmp/deac-macros.hpp"),
+        ("include-pch-separate", "-include-pch /tmp/deac.pch"),
+        ("include-pch-equals", "-include-pch=/tmp/deac.pch"),
+        ("include-pch-joined", "-include-pch/tmp/deac.pch"),
+        ("include-pth-separate", "-include-pth /tmp/deac.pth"),
+        ("include-pth-equals", "-include-pth=/tmp/deac.pth"),
+        ("include-pth-joined", "-include-pth/tmp/deac.pth"),
+        ("slash-fi-separate", "/FI /tmp/deac-force.hpp"),
+        ("slash-fi-equals", "/FI=/tmp/deac-force.hpp"),
+        ("slash-fi-joined", "/FI/tmp/deac-force.hpp"),
+        ("dash-fi-separate", "-FI /tmp/deac-force.hpp"),
+        ("dash-fi-attached", "-FI/tmp/deac-force.hpp"),
+        (
+            "define-macro-separate",
+            "--define-macro USE_STANDARD_MODEL=0",
+        ),
+        ("define-macro-attached", "--define-macro=USE_STANDARD_MODEL=0"),
+        ("undefine-macro-separate", "--undefine-macro USE_STANDARD_MODEL"),
+        ("undefine-macro-attached", "--undefine-macro=USE_STANDARD_MODEL"),
+        ("wp-separate", "-Wp -include,/tmp/deac-force.hpp"),
+        ("wp-attached", "-Wp,-include,/tmp/deac-force.hpp"),
+        (
+            "qoption-preprocessor-separate",
+            "-Qoption,preprocessor -include,/tmp/deac-force.hpp",
+        ),
+        (
+            "qoption-preprocessor-attached",
+            "-Qoption,preprocessor,-include,/tmp/deac-force.hpp",
+        ),
+        ("qoption-component", "-Qoption,c,-include,/tmp/deac-force.hpp"),
+        ("xpreprocessor-separate", "-Xpreprocessor -include"),
+        ("xpreprocessor-attached", "-Xpreprocessor=-include"),
+        ("xclang-separate", "-Xclang -include"),
+        ("xclang-attached", "-Xclang=-include"),
+        ("xarch-host-separate", "-Xarch_host -include"),
+        ("xarch-host-attached", "-Xarch_host=-include"),
+        ("xarch-device-separate", "-Xarch_device -include"),
+        ("xoffload-compiler-separate", "-Xoffload-compiler -include"),
+        ("xoffload-compiler-attached", "-Xoffload-compiler=-include"),
+        ("xopenmp-target-separate", "-Xopenmp-target -include"),
+        ("xopenmp-target-attached", "-Xopenmp-target=-include"),
+        (
+            "xsycl-frontend-separate",
+            "-Xsycl-target-frontend -include",
+        ),
+        (
+            "xsycl-frontend-attached",
+            "-Xsycl-target-frontend=-include",
+        ),
+        (
+            "xsycl-frontend-qualified",
+            "-Xsycl-target-frontend=spir64 -include",
+        ),
+        ("xsycl-backend-separate", "-Xsycl-target-backend @deac.rsp"),
+        ("xsycl-backend-attached", "-Xsycl-target-backend=@deac.rsp"),
+        (
+            "sycl-host-options-separate",
+            "-fsycl-host-compiler-options -include",
+        ),
+        (
+            "sycl-host-options-attached",
+            "-fsycl-host-compiler-options=-include",
+        ),
+        (
+            "sycl-host-compiler-separate",
+            "-fsycl-host-compiler /tmp/deac-host-cxx",
+        ),
+        (
+            "sycl-host-compiler-attached",
+            "-fsycl-host-compiler=/tmp/deac-host-cxx",
+        ),
+        ("slash-clang", "/clang:-include"),
+        ("dash-clang", "-clang:-include"),
+        ("slash-yu-separate", "/Yu /tmp/deac.pch"),
+        ("slash-yu-attached", "/Yu/tmp/deac.pch"),
+        ("dash-yu-separate", "-Yu /tmp/deac.pch"),
+        ("dash-yu-attached", "-Yu/tmp/deac.pch"),
+        ("slash-yc-separate", "/Yc /tmp/deac.hpp"),
+        ("slash-yc-attached", "/Yc/tmp/deac.hpp"),
+        ("dash-yc-separate", "-Yc /tmp/deac.hpp"),
+        ("dash-yc-attached", "-Yc/tmp/deac.hpp"),
+        ("slash-fp-separate", "/Fp /tmp/deac.pch"),
+        ("slash-fp-attached", "/Fp/tmp/deac.pch"),
+        ("dash-fp-separate", "-Fp /tmp/deac.pch"),
+        ("dash-fp-attached", "-Fp/tmp/deac.pch"),
+        ("slash-fu-separate", "/FU /tmp/deac.ifc"),
+        ("slash-fu-attached", "/FU/tmp/deac.ifc"),
+        ("dash-fu-separate", "-FU /tmp/deac.ifc"),
+        ("dash-fu-attached", "-FU/tmp/deac.ifc"),
+        (
+            "header-unit-separate",
+            "/headerUnit:angle vector=/tmp/deac-vector.ifc",
+        ),
+        (
+            "header-unit-attached",
+            "/headerUnit:quote=deac.hpp=/tmp/deac.ifc",
+        ),
+        (
+            "dash-header-unit-separate",
+            "-headerUnit:angle vector=/tmp/deac-vector.ifc",
+        ),
+        (
+            "dash-header-unit-attached",
+            "-headerUnit:quote=deac.hpp=/tmp/deac.ifc",
+        ),
+        ("ifc-search-separate", "/ifcSearchDir /tmp/deac-ifc"),
+        ("ifc-search-attached", "/ifcSearchDir=/tmp/deac-ifc"),
+        ("dash-ifc-search-separate", "-ifcSearchDir /tmp/deac-ifc"),
+        ("dash-ifc-search-attached", "-ifcSearchDir=/tmp/deac-ifc"),
+        ("reference-separate", "/reference deac=/tmp/deac.ifc"),
+        ("reference-attached", "/reference=deac=/tmp/deac.ifc"),
+        ("dash-reference-separate", "-reference deac=/tmp/deac.ifc"),
+        ("dash-reference-attached", "-reference=deac=/tmp/deac.ifc"),
+        ("config-separate", "--config /tmp/deac.cfg"),
+        ("config-attached", "--config=/tmp/deac.cfg"),
+        ("config-dir-separate", "--config-dir /tmp"),
+        ("config-dir-attached", "--config-dir=/tmp"),
+        ("config-system-dir-separate", "--config-system-dir /tmp"),
+        ("config-system-dir-attached", "--config-system-dir=/tmp"),
+        ("config-user-dir-separate", "--config-user-dir /tmp"),
+        ("config-user-dir-attached", "--config-user-dir=/tmp"),
+        ("multi-lib-config-separate", "-multi-lib-config /tmp/deac.cfg"),
+        ("multi-lib-config-attached", "-multi-lib-config=/tmp/deac.cfg"),
+        ("ivfsoverlay-separate", "-ivfsoverlay /tmp/deac-vfs.yaml"),
+        ("ivfsoverlay-attached", "-ivfsoverlay=/tmp/deac-vfs.yaml"),
+        ("ivfsoverlay-joined", "-ivfsoverlay/tmp/deac-vfs.yaml"),
+        ("vfsoverlay-separate", "-vfsoverlay /tmp/deac-vfs.yaml"),
+        ("vfsoverlay-attached", "-vfsoverlay=/tmp/deac-vfs.yaml"),
+        ("vfsoverlay-joined", "-vfsoverlay/tmp/deac-vfs.yaml"),
+        (
+            "ivfsoverlay-lib-separate",
+            "-ivfsoverlay-lib /tmp/deac-vfs.so",
+        ),
+        ("ivfsoverlay-lib-attached", "-ivfsoverlay-lib=/tmp/deac-vfs.so"),
+        ("ivfsoverlay-lib-joined", "-ivfsoverlay-lib/tmp/deac-vfs.so"),
+        ("fplugin-separate", "-fplugin /tmp/deac-plugin.so"),
+        ("fplugin-attached", "-fplugin=/tmp/deac-plugin.so"),
+        ("fplugin-joined", "-fplugin/tmp/deac-plugin.so"),
+        ("pass-plugin-separate", "-fpass-plugin /tmp/deac-pass.so"),
+        ("pass-plugin-attached", "-fpass-plugin=/tmp/deac-pass.so"),
+        ("pch-use-separate", "-pch-use /tmp/deac.pch"),
+        ("pch-use-attached", "-pch-use=/tmp/deac.pch"),
+        ("fpch-preprocess", "-fpch-preprocess"),
+        ("fpch-preprocess-attached", "-fpch-preprocess=/tmp/deac.pch"),
+        ("module-file-separate", "-fmodule-file /tmp/deac.pcm"),
+        ("module-file-attached", "-fmodule-file=/tmp/deac.pcm"),
+        ("module-mapper-separate", "-fmodule-mapper /tmp/deac.mapper"),
+        ("module-mapper-attached", "-fmodule-mapper=/tmp/deac.mapper"),
+        (
+            "module-map-separate",
+            "-fmodule-map-file /tmp/deac.modulemap",
+        ),
+        (
+            "module-map-attached",
+            "-fmodule-map-file=/tmp/deac.modulemap",
+        ),
+        (
+            "prebuilt-module-path-separate",
+            "-fprebuilt-module-path /tmp/deac-modules",
+        ),
+        (
+            "prebuilt-module-path-attached",
+            "-fprebuilt-module-path=/tmp/deac-modules",
+        ),
+        (
+            "modules-cache-path-separate",
+            "-fmodules-cache-path /tmp/deac-module-cache",
+        ),
+        (
+            "modules-cache-path-attached",
+            "-fmodules-cache-path=/tmp/deac-module-cache",
+        ),
+        ("tool-prefix-separate", "-B /tmp/deac-tools"),
+        ("tool-prefix-attached", "-B/tmp/deac-tools"),
+        ("intel-icx", "--icx"),
+        ("wrapper-separate", "-wrapper /tmp/deac-wrapper"),
+        ("wrapper-attached", "-wrapper=/tmp/deac-wrapper"),
+        ("gcc-toolchain-separate", "-gcc-toolchain /tmp/deac-gcc"),
+        ("gcc-toolchain-attached", "-gcc-toolchain=/tmp/deac-gcc"),
+        ("long-gcc-toolchain-separate", "--gcc-toolchain /tmp/deac-gcc"),
+        ("long-gcc-toolchain-attached", "--gcc-toolchain=/tmp/deac-gcc"),
+        ("specs-separate", "-specs /tmp/deac.specs"),
+        ("specs-attached", "-specs=/tmp/deac.specs"),
+        ("specs-joined", "-specs/tmp/deac.specs"),
+        ("long-specs-separate", "--specs /tmp/deac.specs"),
+        ("long-specs-attached", "--specs=/tmp/deac.specs"),
+        ("long-specs-joined", "--specs/tmp/deac.specs"),
+    )
+    receipt_path = (
+        build_directory / "receipt" / "Release" / "build-receipt.json"
+    )
+    for name, extra_fragment in route_mutations:
+        document = json.loads(json.dumps(original))
+        document["compileGroups"][0]["compileCommandFragments"].append(
+            {"fragment": extra_fragment}
+        )
+        write(
+            target_reply,
+            json.dumps(document, ensure_ascii=False, separators=(",", ":"))
+            + "\n",
+        )
+        result = build(
+            cmake,
+            build_directory,
+            target="deac_fixture_generate_receipt",
+            check=False,
+        )
+        assert_rejected(
+            result,
+            context=name,
+            expected=(
+                "unsupported unbound build input route"
+                if "response-file" in name
+                else "unsupported unbound compile input route"
+            ),
+        )
+        if receipt_path.exists():
+            raise AssertionError(f"{name} produced a build receipt")
+
+    link_response_fragments = (
+        ("link-response-file", "@/tmp/deac-link.rsp"),
+        ("link-wl-response-file", "-Wl,@/tmp/deac-link.rsp"),
+        (
+            "link-wl-list-response-file",
+            "-Wl,-z,defs,@/tmp/deac-link.rsp",
+        ),
+        ("link-xlinker-response-file", "-Xlinker=@/tmp/deac-link.rsp"),
+        ("link-xlinker-split-response-file", "-Xlinker @/tmp/deac-link.rsp"),
+    )
+    for name, extra_fragment in link_response_fragments:
+        document = json.loads(json.dumps(original))
+        link = document.get("link")
+        if not isinstance(link, dict) or not isinstance(
+            link.get("commandFragments"), list
+        ):
+            raise TypeError("fixture target link fragments are malformed")
+        link["commandFragments"].append({"fragment": extra_fragment})
+        write(
+            target_reply,
+            json.dumps(document, ensure_ascii=False, separators=(",", ":"))
+            + "\n",
+        )
+        result = build(
+            cmake,
+            build_directory,
+            target="deac_fixture_generate_receipt",
+            check=False,
+        )
+        assert_rejected(
+            result,
+            context=name,
+            expected="unsupported unbound build input route",
+        )
+        if receipt_path.exists():
+            raise AssertionError(f"{name} produced a build receipt")
+
+    write(
+        target_reply,
+        json.dumps(original, ensure_ascii=False, separators=(",", ":")) + "\n",
+    )
+    dependency_reply = file_api_target_reply(
+        build_directory, "receipt_dependency"
+    )
+    dependency_original = json.loads(
+        dependency_reply.read_text(encoding="utf-8")
+    )
+    archive_document = json.loads(json.dumps(dependency_original))
+    archive = archive_document.get("archive")
+    if not isinstance(archive, dict):
+        raise TypeError("fixture dependency archive fragments are malformed")
+    archive_fragments = archive.setdefault("commandFragments", [])
+    if not isinstance(archive_fragments, list):
+        raise TypeError("fixture dependency archive fragments are malformed")
+    archive_fragments.append(
+        {"fragment": "@/tmp/deac-archive.rsp"}
+    )
+    write(
+        dependency_reply,
+        json.dumps(
+            archive_document, ensure_ascii=False, separators=(",", ":")
+        )
+        + "\n",
+    )
+    archive_result = build(
+        cmake,
+        build_directory,
+        target="deac_fixture_generate_receipt",
+        check=False,
+    )
+    assert_rejected(
+        archive_result,
+        context="archive response file",
+        expected="unsupported unbound build input route",
+    )
+    if receipt_path.exists():
+        raise AssertionError("archive response file produced a build receipt")
+    write(
+        dependency_reply,
+        json.dumps(
+            dependency_original, ensure_ascii=False, separators=(",", ":")
+        )
+        + "\n",
+    )
+
+    pch_document = json.loads(json.dumps(original))
+    pch_document["compileGroups"][0]["precompileHeaders"] = [
+        {"header": "/tmp/deac.pch"}
+    ]
+    write(
+        target_reply,
+        json.dumps(pch_document, ensure_ascii=False, separators=(",", ":"))
+        + "\n",
+    )
+    pch_result = build(
+        cmake,
+        build_directory,
+        target="deac_fixture_generate_receipt",
+        check=False,
+    )
+    assert_rejected(
+        pch_result,
+        context="structured precompiled header",
+        expected="unsupported nonempty structured precompiled headers",
+    )
+    if receipt_path.exists():
+        raise AssertionError("structured precompiled header produced a receipt")
+
+    accepted_warning_document = json.loads(json.dumps(original))
+    accepted_warning_document["compileGroups"][0][
+        "compileCommandFragments"
+    ].append({"fragment": "-fsycl -Wpedantic -finline-functions"})
+    write(
+        target_reply,
+        json.dumps(
+            accepted_warning_document,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        + "\n",
+    )
+    build(
+        cmake,
+        build_directory,
+        target="deac_fixture_generate_receipt",
+    )
+    accepted_receipt = parse_receipt(receipt_path)
+    accepted_fragments = [
+        fragment["fragment"]
+        for group in accepted_receipt["receipt"]["compile_groups"]
+        for fragment in group["command_fragments"]
+    ]
+    if "-fsycl -Wpedantic -finline-functions" not in accepted_fragments:
+        raise AssertionError(
+            "current -fsycl and safe lowercase optimization flags were lost"
+        )
+
+
 def file_api_target_reply(build_directory, target_name):
     reply_directory = build_directory / ".cmake" / "api" / "v1" / "reply"
     indices = sorted(reply_directory.glob("index-*.json"))
@@ -3415,6 +3804,9 @@ def main():
         args.cmake, source, workdir, real_compiler
     )
     test_json_control_encoding(
+        args.cmake, source, workdir, real_compiler
+    )
+    test_unbound_compile_input_rejections(
         args.cmake, source, workdir, real_compiler
     )
     test_file_api_shape_rejections(

--- a/test/deac_build_receipt_fixture_test.py
+++ b/test/deac_build_receipt_fixture_test.py
@@ -1,19 +1,21 @@
 import argparse
 import hashlib
 import json
+import os
 import shlex
 import shutil
 import subprocess
 from pathlib import Path
 
 
-def run(command, cwd, *, check=True):
+def run(command, cwd, *, check=True, environment=None):
     result = subprocess.run(
         [str(part) for part in command],
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        env=environment,
     )
     if check and result.returncode != 0:
         raise AssertionError(
@@ -42,6 +44,7 @@ def copy_fixture_modules(solver_source, fixture_source):
     module_names = [
         "DeacBuildIdentity.cmake",
         "DeacBuildReceipt.cmake",
+        "DeacHipblas.cmake",
         "GenerateDeacBuildReceipt.cmake",
         "VerifyDeacBuildReceiptTools.cmake",
         "deac_build_receipt_data.cpp.in",
@@ -110,10 +113,40 @@ project(deac_build_receipt_fixture LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(GPU_BACKEND none CACHE STRING "fixture backend")
+set(CMAKE_DISABLE_FIND_PACKAGE_hipblas FALSE CACHE BOOL
+    "disable fixture hipBLAS package discovery")
 set(DEAC_FIXTURE_ARCHIVER "" CACHE FILEPATH "effective fixture CMAKE_AR")
 set(DEAC_FIXTURE_RULE_ATTACK "" CACHE STRING "fixture rule attack")
+set(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK "" CACHE STRING
+    "effective CMAKE_CXX_FLAGS shell mutation")
+set(DEAC_FIXTURE_LATE_ATTACK "" CACHE STRING
+    "post-registration build-receipt mutation")
+set(DEAC_FIXTURE_DEPENDENCY_FINGERPRINT_ATTACK "" CACHE STRING
+    "post-registration dependency fingerprint mutation")
+set(DEAC_FIXTURE_RECEIPT_ATTACK "" CACHE STRING
+    "build-receipt output expression mutation")
+set(DEAC_FIXTURE_CONTROL_CACHE "" CACHE STRING
+    "build-receipt JSON control-character input")
 set(DEAC_FIXTURE_NATIVE_LANGUAGE_SHAPE "" CACHE STRING "native language shape")
+set(DEAC_FIXTURE_HIPBLAS_MODE "" CACHE STRING "mock hipBLAS receipt mode")
+set(DEAC_FIXTURE_HIPBLAS_CONTRACT_ATTACK "" CACHE STRING
+    "mock hipBLAS contract mutation")
+set(DEAC_FIXTURE_LINK_LIBRARY_ATTACK "" CACHE STRING
+    "build-receipt link-library input mutation")
+set(DEAC_FIXTURE_CONTROL_LINK_ARTIFACT "" CACHE STRING
+    "required link artifact with a control-byte filename")
+set(DEAC_FIXTURE_SUBDIRECTORY_DEPENDENCY_MODE "" CACHE STRING
+    "subdirectory dependency attribution mode")
+set(DEAC_FIXTURE_HIPBLAS_INCLUDE_DIR "" CACHE PATH "mock hipBLAS include root")
+set(DEAC_FIXTURE_HIPBLAS_LIBRARY "" CACHE FILEPATH "mock hipBLAS library")
+set(DEAC_FIXTURE_HIPBLAS_PACKAGE_DIR "" CACHE PATH "mock hipBLAS package")
+set(DEAC_FIXTURE_EXPECTED_HIPBLAS_ARTIFACT "" CACHE FILEPATH
+    "expected resolved mock hipBLAS artifact")
 option(DEAC_FIXTURE_PARALLEL_CONSUMERS "add a second receipt consumer" OFF)
+option(DEAC_FIXTURE_SHARED_DEPENDENCY
+    "make parallel receipt consumers share one compiled dependency" OFF)
+set(DEAC_FIXTURE_SHARED_FINGERPRINT_ATTACK "" CACHE STRING
+    "between-registration shared-target fingerprint mutation")
 option(DEAC_FIXTURE_DEPENDENCY_IPO_RELEASE "enable dependency Release IPO" OFF)
 
 # CMake's persisted compiler-information file restores CMAKE_AR as a normal
@@ -126,7 +159,55 @@ if(NOT DEAC_FIXTURE_ARCHIVER STREQUAL "")
     set(CMAKE_AR "${DEAC_FIXTURE_ARCHIVER}")
 endif()
 
-add_library(receipt_dependency STATIC dependency.cpp)
+if(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "dollar-variable")
+    set(CMAKE_CXX_FLAGS "$DEAC_UNATTESTED_FLAGS" CACHE STRING
+        "fixture effective CXX flags" FORCE)
+elseif(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "braced-variable")
+    string(CONCAT DEAC_FIXTURE_ATTACK_FLAGS "$" "{DEAC_UNATTESTED_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${DEAC_FIXTURE_ATTACK_FLAGS}" CACHE STRING
+        "fixture effective CXX flags" FORCE)
+elseif(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "glob")
+    set(CMAKE_CXX_FLAGS "-include *.hpp" CACHE STRING
+        "fixture effective CXX flags" FORCE)
+elseif(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "redirection")
+    set(CMAKE_CXX_FLAGS "-DDEAC_FLAG_PROBE=1 > deac-flags.log" CACHE STRING
+        "fixture effective CXX flags" FORCE)
+elseif(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "comment")
+    set(CMAKE_CXX_FLAGS "-DDEAC_FLAG_PROBE=1 # ignored" CACHE STRING
+        "fixture effective CXX flags" FORCE)
+elseif(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "command-substitution")
+    set(CMAKE_CXX_FLAGS "$(deac_receipt_attack)" CACHE STRING
+        "fixture effective CXX flags" FORCE)
+elseif(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "backtick-substitution")
+    set(CMAKE_CXX_FLAGS "`deac_receipt_attack`" CACHE STRING
+        "fixture effective CXX flags" FORCE)
+elseif(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "process-substitution")
+    set(CMAKE_CXX_FLAGS "<(deac_receipt_attack)" CACHE STRING
+        "fixture effective CXX flags" FORCE)
+elseif(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "quoted-dollar")
+    set(CMAKE_CXX_FLAGS "-DDEAC_UNSAFE_DOLLAR='literal$argument'"
+        CACHE STRING "fixture effective CXX flags" FORCE)
+elseif(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "escaped-dollar")
+    set(CMAKE_CXX_FLAGS "-DDEAC_UNSAFE_DOLLAR=literal\\\\$argument"
+        CACHE STRING "fixture effective CXX flags" FORCE)
+elseif(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "safe-quoted")
+    set(CMAKE_CXX_FLAGS "-DDEAC_SAFE_GLOB='literal*argument'"
+        CACHE STRING "fixture effective CXX flags" FORCE)
+elseif(DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "safe-escaped")
+    set(CMAKE_CXX_FLAGS "-DDEAC_SAFE_GLOB=literal\\\\*argument"
+        CACHE STRING "fixture effective CXX flags" FORCE)
+elseif(NOT DEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK STREQUAL "")
+    message(FATAL_ERROR "unknown effective CMAKE_CXX_FLAGS shell mutation")
+endif()
+
+if(DEAC_FIXTURE_SUBDIRECTORY_DEPENDENCY_MODE STREQUAL "")
+    add_library(receipt_dependency STATIC dependency.cpp)
+elseif(DEAC_FIXTURE_SUBDIRECTORY_DEPENDENCY_MODE MATCHES
+        "^(normal|launcher|rule|compiler)$")
+    add_subdirectory(subdirectory_dependency)
+else()
+    message(FATAL_ERROR "unknown subdirectory dependency attribution mode")
+endif()
 add_executable(receipt_probe probe.cpp)
 target_link_libraries(receipt_probe PRIVATE receipt_dependency)
 if(DEAC_FIXTURE_DEPENDENCY_IPO_RELEASE)
@@ -134,9 +215,136 @@ if(DEAC_FIXTURE_DEPENDENCY_IPO_RELEASE)
         INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
 endif()
 if(DEAC_FIXTURE_PARALLEL_CONSUMERS)
-    add_library(receipt_dependency_two STATIC dependency_two.cpp)
-    add_executable(receipt_probe_two probe_two.cpp)
-    target_link_libraries(receipt_probe_two PRIVATE receipt_dependency_two)
+    if(DEAC_FIXTURE_SHARED_DEPENDENCY)
+        add_executable(receipt_probe_two probe.cpp)
+        target_link_libraries(receipt_probe_two PRIVATE receipt_dependency)
+    else()
+        add_library(receipt_dependency_two STATIC dependency_two.cpp)
+        add_executable(receipt_probe_two probe_two.cpp)
+        target_link_libraries(receipt_probe_two PRIVATE receipt_dependency_two)
+    endif()
+endif()
+
+if(DEAC_FIXTURE_HIPBLAS_MODE STREQUAL "imported_target")
+    set(GPU_BACKEND hip CACHE STRING "fixture backend" FORCE)
+    set(USE_BLAS ON CACHE BOOL "fixture BLAS mode" FORCE)
+    set(CMAKE_DISABLE_FIND_PACKAGE_hipblas FALSE CACHE BOOL
+        "disable fixture hipBLAS package discovery" FORCE)
+    set(hipblas_DIR "${DEAC_FIXTURE_HIPBLAS_PACKAGE_DIR}"
+        CACHE PATH "mock hipBLAS package" FORCE)
+elseif(DEAC_FIXTURE_HIPBLAS_MODE STREQUAL "compatibility_library")
+    set(GPU_BACKEND hip CACHE STRING "fixture backend" FORCE)
+    set(USE_BLAS ON CACHE BOOL "fixture BLAS mode" FORCE)
+    set(CMAKE_DISABLE_FIND_PACKAGE_hipblas TRUE CACHE BOOL
+        "disable fixture hipBLAS package discovery" FORCE)
+    set(DEAC_HIPBLAS_INCLUDE_DIR "${DEAC_FIXTURE_HIPBLAS_INCLUDE_DIR}"
+        CACHE PATH "mock hipBLAS include root" FORCE)
+    set(DEAC_HIPBLAS_LIBRARY "${DEAC_FIXTURE_HIPBLAS_LIBRARY}"
+        CACHE FILEPATH "mock hipBLAS library" FORCE)
+elseif(DEAC_FIXTURE_HIPBLAS_MODE STREQUAL "blas_off")
+    set(GPU_BACKEND hip CACHE STRING "fixture backend" FORCE)
+    set(USE_BLAS OFF CACHE BOOL "fixture BLAS mode" FORCE)
+    set(CMAKE_DISABLE_FIND_PACKAGE_hipblas TRUE CACHE BOOL
+        "disable fixture hipBLAS package discovery" FORCE)
+elseif(DEAC_FIXTURE_HIPBLAS_MODE STREQUAL "non_hip")
+    set(GPU_BACKEND sycl CACHE STRING "fixture backend" FORCE)
+    set(USE_BLAS ON CACHE BOOL "fixture BLAS mode" FORCE)
+    set(CMAKE_DISABLE_FIND_PACKAGE_hipblas TRUE CACHE BOOL
+        "disable fixture hipBLAS package discovery" FORCE)
+elseif(NOT DEAC_FIXTURE_HIPBLAS_MODE STREQUAL "")
+    message(FATAL_ERROR "unknown mock hipBLAS receipt mode")
+endif()
+
+# Exercise a backend transition through ordinary CXX compilation without
+# requiring a SYCL compiler.  These definitions are the effective File API
+# evidence that the regenerated graph followed the changed backend.
+if(GPU_BACKEND STREQUAL "sycl")
+    target_compile_definitions(receipt_probe PRIVATE USE_GPU=1 USE_SYCL=1)
+    if(DEAC_FIXTURE_PARALLEL_CONSUMERS)
+        target_compile_definitions(
+            receipt_probe_two PRIVATE USE_GPU=1 USE_SYCL=1)
+    endif()
+endif()
+
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/DeacHipblas.cmake")
+set(DEAC_FIXTURE_HIPBLAS_CONSUMERS receipt_probe)
+if(DEAC_FIXTURE_PARALLEL_CONSUMERS)
+    list(APPEND DEAC_FIXTURE_HIPBLAS_CONSUMERS receipt_probe_two)
+endif()
+deac_target_link_hipblas(${DEAC_FIXTURE_HIPBLAS_CONSUMERS})
+if(DEAC_FIXTURE_HIPBLAS_CONTRACT_ATTACK STREQUAL "duplicate-provider")
+    get_target_property(DEAC_FIXTURE_ATTACK_PROVIDER
+        deac_hipblas_link_contract DEAC_HIPBLAS_PROVIDER_TARGET)
+    set_property(TARGET deac_hipblas_link_contract PROPERTY
+        INTERFACE_LINK_LIBRARIES
+        "${DEAC_FIXTURE_ATTACK_PROVIDER};${DEAC_FIXTURE_ATTACK_PROVIDER}")
+elseif(NOT DEAC_FIXTURE_HIPBLAS_CONTRACT_ATTACK STREQUAL "")
+    message(FATAL_ERROR "unknown mock hipBLAS contract mutation")
+endif()
+
+set(DEAC_FIXTURE_RECEIPT_DEPENDENCIES receipt_dependency)
+set(DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_NAMES)
+set(DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_ARTIFACTS)
+if(NOT DEAC_FIXTURE_CONTROL_LINK_ARTIFACT STREQUAL "")
+    list(APPEND DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_NAMES control-provider)
+    list(APPEND DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_ARTIFACTS
+        "${DEAC_FIXTURE_CONTROL_LINK_ARTIFACT}")
+endif()
+if(USE_BLAS AND GPU_BACKEND STREQUAL "hip")
+    if(NOT TARGET deac_hipblas_link_contract)
+        message(FATAL_ERROR "mock HIP+BLAS contract is absent")
+    endif()
+    _deac_hipblas_validate_link_contract(deac_hipblas_link_contract)
+    list(APPEND DEAC_FIXTURE_RECEIPT_DEPENDENCIES
+        deac_hipblas_link_contract)
+    get_target_property(DEAC_FIXTURE_HIPBLAS_PROVIDER_TARGET
+        deac_hipblas_link_contract DEAC_HIPBLAS_PROVIDER_TARGET)
+    if(NOT TARGET "${DEAC_FIXTURE_HIPBLAS_PROVIDER_TARGET}")
+        message(FATAL_ERROR "mock HIP+BLAS provider target is absent")
+    endif()
+    if(DEAC_FIXTURE_HIPBLAS_MODE STREQUAL "imported_target" AND
+            NOT DEAC_FIXTURE_HIPBLAS_PROVIDER_TARGET STREQUAL
+                "deac_fixture_hipblas_provider")
+        message(FATAL_ERROR
+            "mock imported provider alias was not canonicalized")
+    endif()
+    get_target_property(DEAC_FIXTURE_HIPBLAS_PROVIDER_ARTIFACT
+        deac_hipblas_link_contract DEAC_HIPBLAS_PROVIDER_ARTIFACT)
+    if(NOT DEAC_FIXTURE_HIPBLAS_PROVIDER_ARTIFACT OR
+            DEAC_FIXTURE_HIPBLAS_PROVIDER_ARTIFACT MATCHES "-NOTFOUND$")
+        message(FATAL_ERROR "mock HIP+BLAS provider artifact is absent")
+    endif()
+    if(NOT DEAC_FIXTURE_EXPECTED_HIPBLAS_ARTIFACT STREQUAL "" AND
+            NOT DEAC_FIXTURE_HIPBLAS_PROVIDER_ARTIFACT STREQUAL
+                DEAC_FIXTURE_EXPECTED_HIPBLAS_ARTIFACT)
+        message(FATAL_ERROR
+            "mock HIP+BLAS receipt resolver selected the wrong artifact: "
+            "${DEAC_FIXTURE_HIPBLAS_PROVIDER_ARTIFACT}")
+    endif()
+    list(APPEND DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_NAMES
+        "${DEAC_FIXTURE_HIPBLAS_PROVIDER_TARGET}")
+    list(APPEND DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_ARTIFACTS
+        "${DEAC_FIXTURE_HIPBLAS_PROVIDER_ARTIFACT}")
+elseif(TARGET deac_hipblas_link_contract)
+    message(FATAL_ERROR "mock no-op mode created a hipBLAS contract")
+endif()
+
+if(DEAC_FIXTURE_LINK_LIBRARY_ATTACK STREQUAL "unequal-lists")
+    list(APPEND DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_NAMES extra-provider)
+elseif(DEAC_FIXTURE_LINK_LIBRARY_ATTACK STREQUAL "duplicate-name")
+    list(APPEND DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_NAMES
+        "${DEAC_FIXTURE_HIPBLAS_PROVIDER_TARGET}")
+    list(APPEND DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_ARTIFACTS
+        "${CMAKE_COMMAND}")
+elseif(DEAC_FIXTURE_LINK_LIBRARY_ATTACK STREQUAL "duplicate-artifact")
+    list(APPEND DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_NAMES extra-provider)
+    list(APPEND DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_ARTIFACTS
+        "${DEAC_FIXTURE_HIPBLAS_PROVIDER_ARTIFACT}")
+elseif(DEAC_FIXTURE_LINK_LIBRARY_ATTACK STREQUAL "missing-artifact")
+    set(DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_ARTIFACTS
+        "${CMAKE_CURRENT_BINARY_DIR}/missing-hipblas-provider.a")
+elseif(NOT DEAC_FIXTURE_LINK_LIBRARY_ATTACK STREQUAL "")
+    message(FATAL_ERROR "unknown build-receipt link-library input mutation")
 endif()
 
 if(DEAC_FIXTURE_RULE_ATTACK STREQUAL "compile-and")
@@ -158,11 +366,44 @@ elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "quoted-semicolon")
         " \\\"-DDEAC_RULE_LITERAL=literal\\\\;argument\\\"")
 elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "escaped-semicolon")
     string(APPEND CMAKE_CXX_COMPILE_OBJECT
-        " -DDEAC_RULE_LITERAL=literal\\\\\\\\;argument")
+        " -DDEAC_RULE_LITERAL=literal\\\\;argument")
 elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "compile-dollar-paren")
     string(APPEND CMAKE_CXX_COMPILE_OBJECT " $(deac_receipt_attack)")
 elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "compile-backtick")
     string(APPEND CMAKE_CXX_COMPILE_OBJECT " `deac_receipt_attack`")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "escaped-backtick")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " -DDEAC_RULE_LITERAL=literal\\\\`argument")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "compile-dollar-variable")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " -DDEAC_RULE_PROBE=$DEAC_RULE_PROBE")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "compile-glob")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT " -include *.hpp")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "compile-redirection")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT " > deac_receipt_attack.log")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "compile-comment")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT " # deac_receipt_attack")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "compile-process-substitution")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT " <(deac_receipt_attack)")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "link-dollar-variable")
+    string(APPEND CMAKE_CXX_LINK_EXECUTABLE " $DEAC_RULE_LINK_PROBE")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "archive-glob")
+    string(APPEND CMAKE_CXX_ARCHIVE_CREATE " *.deac-archive-input")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "quoted-dollar")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " '-DDEAC_RULE_LITERAL=literal$argument'")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "quoted-backtick")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " '-DDEAC_RULE_LITERAL=\\\"literal`argument\\\"'")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "quoted-glob")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " \\\"-DDEAC_RULE_LITERAL=literal*argument\\\"")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "escaped-dollar")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " -DDEAC_RULE_LITERAL=literal\\\\$argument")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "escaped-glob")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " -DDEAC_RULE_LITERAL=literal\\\\*argument")
 elseif(NOT DEAC_FIXTURE_RULE_ATTACK STREQUAL "")
     message(FATAL_ERROR "unknown fixture rule attack")
 endif()
@@ -184,22 +425,65 @@ set(DEAC_FIXTURE_CACHE_KEYS
     CMAKE_CONFIGURATION_TYPES
     CMAKE_CXX_COMPILER
     CMAKE_CXX_FLAGS
+    CMAKE_DISABLE_FIND_PACKAGE_hipblas
     CMAKE_EXE_LINKER_FLAGS
     CMAKE_GENERATOR
     CMAKE_HOME_DIRECTORY
     CMAKE_PREFIX_PATH
     CMAKE_RANLIB
+    DEAC_FIXTURE_CONTROL_CACHE
+    DEAC_HIPBLAS_INCLUDE_DIR
+    DEAC_HIPBLAS_LIBRARY
     GPU_BACKEND)
+list(APPEND DEAC_FIXTURE_CACHE_KEYS
+    HIP_RUNTIME_INCLUDE_DIR
+    USE_BLAS
+    hipblas_DIR
+    hipblas_ROOT)
+set(DEAC_FIXTURE_RECEIPT
+    "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<CONFIG>/build-receipt.json")
+if(DEAC_FIXTURE_RECEIPT_ATTACK STREQUAL "hidden-config")
+    set(DEAC_FIXTURE_RECEIPT
+        "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<$<BOOL:0>:$<CONFIG>>/build-receipt.json")
+elseif(NOT DEAC_FIXTURE_RECEIPT_ATTACK STREQUAL "")
+    message(FATAL_ERROR "unknown build-receipt output expression mutation")
+endif()
 deac_target_add_build_receipt(receipt_probe
     SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/.."
     GENERATED_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/receipt"
     IDENTITY_NAME fixture
-    RECEIPT
-        "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<CONFIG>/build-receipt.json"
+    RECEIPT "${DEAC_FIXTURE_RECEIPT}"
     BACKEND "${GPU_BACKEND}"
     CACHE_KEYS ${DEAC_FIXTURE_CACHE_KEYS}
-    DEPENDENCY_TARGETS receipt_dependency)
+    DEPENDENCY_TARGETS ${DEAC_FIXTURE_RECEIPT_DEPENDENCIES}
+    REQUIRED_LINK_LIBRARY_NAMES
+        ${DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_NAMES}
+    REQUIRED_LINK_LIBRARY_ARTIFACTS
+        ${DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_ARTIFACTS})
+add_custom_target(deac_fixture_generate_receipt
+    DEPENDS "${DEAC_BUILD_RECEIPT_REFRESH}")
+if(DEAC_FIXTURE_SHARED_FINGERPRINT_ATTACK STREQUAL "conflict")
+    if(NOT DEAC_FIXTURE_PARALLEL_CONSUMERS OR
+            NOT DEAC_FIXTURE_SHARED_DEPENDENCY)
+        message(FATAL_ERROR
+            "shared fingerprint attack requires two shared consumers")
+    endif()
+    set_property(TARGET receipt_dependency PROPERTY
+        DEAC_BUILD_RECEIPT_INJECTED_TOOLCHAIN_FINGERPRINT_SHA256
+        "0000000000000000000000000000000000000000000000000000000000000000")
+elseif(NOT DEAC_FIXTURE_SHARED_FINGERPRINT_ATTACK STREQUAL "")
+    message(FATAL_ERROR "unknown shared fingerprint attack")
+endif()
 if(DEAC_FIXTURE_PARALLEL_CONSUMERS)
+    if(DEAC_FIXTURE_SHARED_DEPENDENCY)
+        set(DEAC_FIXTURE_SECOND_RECEIPT_DEPENDENCIES receipt_dependency)
+    else()
+        set(DEAC_FIXTURE_SECOND_RECEIPT_DEPENDENCIES receipt_dependency_two)
+    endif()
+    if(TARGET deac_hipblas_link_contract)
+        list(APPEND DEAC_FIXTURE_SECOND_RECEIPT_DEPENDENCIES
+            deac_hipblas_link_contract)
+    endif()
     deac_target_add_build_receipt(receipt_probe_two
         SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/.."
         GENERATED_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/receipt"
@@ -208,7 +492,133 @@ if(DEAC_FIXTURE_PARALLEL_CONSUMERS)
             "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<CONFIG>/build-receipt-two.json"
         BACKEND "${GPU_BACKEND}"
         CACHE_KEYS ${DEAC_FIXTURE_CACHE_KEYS}
-        DEPENDENCY_TARGETS receipt_dependency_two)
+        DEPENDENCY_TARGETS ${DEAC_FIXTURE_SECOND_RECEIPT_DEPENDENCIES}
+        REQUIRED_LINK_LIBRARY_NAMES
+            ${DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_NAMES}
+        REQUIRED_LINK_LIBRARY_ARTIFACTS
+            ${DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_ARTIFACTS})
+endif()
+
+# These mutations intentionally happen after every receipt registration.  The
+# module's top-level deferred seal must observe final directory/target state,
+# not only the snapshot taken inside deac_target_add_build_receipt().
+if(DEAC_FIXTURE_LATE_ATTACK STREQUAL "launcher")
+    set_property(TARGET receipt_probe PROPERTY CXX_COMPILER_LAUNCHER
+        "${CMAKE_COMMAND};-E;env")
+elseif(DEAC_FIXTURE_LATE_ATTACK STREQUAL "rule")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " '-DDEAC_RULE_LITERAL=late-mutation'")
+elseif(DEAC_FIXTURE_LATE_ATTACK STREQUAL "ipo")
+    set_property(TARGET receipt_probe PROPERTY
+        INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+elseif(DEAC_FIXTURE_LATE_ATTACK STREQUAL "link-what-you-use")
+    set_property(TARGET receipt_probe PROPERTY LINK_WHAT_YOU_USE TRUE)
+elseif(DEAC_FIXTURE_LATE_ATTACK STREQUAL "interface-literal")
+    add_library(deac_fixture_late_interface INTERFACE)
+    target_link_libraries(receipt_probe PRIVATE deac_fixture_late_interface)
+elseif(DEAC_FIXTURE_LATE_ATTACK STREQUAL "interface-conditional")
+    add_library(deac_fixture_late_interface INTERFACE)
+    target_link_libraries(receipt_probe PRIVATE
+        "$<$<CONFIG:Release>:deac_fixture_late_interface>")
+elseif(DEAC_FIXTURE_LATE_ATTACK STREQUAL "archive-tool")
+    set(CMAKE_AR "${CMAKE_COMMAND}")
+elseif(DEAC_FIXTURE_LATE_ATTACK STREQUAL "archive-index-tool")
+    set(CMAKE_RANLIB "${CMAKE_COMMAND}")
+elseif(DEAC_FIXTURE_LATE_ATTACK STREQUAL "configuration-case-collision")
+    set(CMAKE_CONFIGURATION_TYPES "Debug;DEBUG")
+    set(CMAKE_CONFIGURATION_TYPES "Debug;DEBUG" CACHE STRING
+        "late invalid configuration list" FORCE)
+elseif(DEAC_FIXTURE_LATE_ATTACK STREQUAL "configuration-list")
+    set(CMAKE_CONFIGURATION_TYPES "Release;Debug")
+    set(CMAKE_CONFIGURATION_TYPES "Release;Debug" CACHE STRING
+        "late configuration list" FORCE)
+elseif(DEAC_FIXTURE_LATE_ATTACK STREQUAL "build-type")
+    set(CMAKE_BUILD_TYPE "Debug")
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "late build type" FORCE)
+elseif(DEAC_FIXTURE_LATE_ATTACK STREQUAL "shadowed-build-type-cache")
+    set(CMAKE_BUILD_TYPE "Release")
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "shadowed build type" FORCE)
+elseif(DEAC_FIXTURE_LATE_ATTACK STREQUAL "shadowed-configuration-cache")
+    set(CMAKE_CONFIGURATION_TYPES "Debug;Release")
+    set(CMAKE_CONFIGURATION_TYPES "Release" CACHE STRING
+        "shadowed configuration list" FORCE)
+elseif(NOT DEAC_FIXTURE_LATE_ATTACK STREQUAL "")
+    message(FATAL_ERROR "unknown post-registration build-receipt mutation")
+endif()
+
+if(DEAC_FIXTURE_DEPENDENCY_FINGERPRINT_ATTACK STREQUAL "remove")
+    set_property(TARGET receipt_dependency PROPERTY COMPILE_DEFINITIONS "")
+elseif(DEAC_FIXTURE_DEPENDENCY_FINGERPRINT_ATTACK STREQUAL "duplicate")
+    target_compile_definitions(receipt_dependency PRIVATE
+        "DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256=${DEAC_BUILD_RECEIPT_TOOLCHAIN_FINGERPRINT}")
+elseif(DEAC_FIXTURE_DEPENDENCY_FINGERPRINT_ATTACK STREQUAL "conflict")
+    target_compile_definitions(receipt_dependency PRIVATE
+        "DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256=0000000000000000000000000000000000000000000000000000000000000000")
+elseif(DEAC_FIXTURE_DEPENDENCY_FINGERPRINT_ATTACK STREQUAL "conflict-function")
+    target_compile_definitions(receipt_dependency PRIVATE
+        "DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256(x)=bad")
+elseif(DEAC_FIXTURE_DEPENDENCY_FINGERPRINT_ATTACK STREQUAL "conflict-spaced")
+    target_compile_definitions(receipt_dependency PRIVATE
+        "DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256 =bad")
+elseif(DEAC_FIXTURE_DEPENDENCY_FINGERPRINT_ATTACK STREQUAL "longer-name")
+    target_compile_definitions(receipt_dependency PRIVATE
+        "DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256_EXTRA=allowed")
+elseif(NOT DEAC_FIXTURE_DEPENDENCY_FINGERPRINT_ATTACK STREQUAL "")
+    message(FATAL_ERROR "unknown dependency fingerprint mutation")
+endif()
+""",
+    )
+    write(
+        fixture_source / "src" / "subdirectory_dependency" / "CMakeLists.txt",
+        """if(DEAC_FIXTURE_SUBDIRECTORY_DEPENDENCY_MODE STREQUAL "launcher")
+    set_property(DIRECTORY PROPERTY RULE_LAUNCH_COMPILE
+        "${CMAKE_COMMAND};-E;env")
+elseif(DEAC_FIXTURE_SUBDIRECTORY_DEPENDENCY_MODE STREQUAL "rule")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " '-DDEAC_SUBDIRECTORY_RULE_LITERAL=safe'")
+elseif(DEAC_FIXTURE_SUBDIRECTORY_DEPENDENCY_MODE STREQUAL "compiler")
+    set(CMAKE_CXX_COMPILER "${CMAKE_COMMAND}")
+elseif(NOT DEAC_FIXTURE_SUBDIRECTORY_DEPENDENCY_MODE STREQUAL "normal")
+    message(FATAL_ERROR "invalid subdirectory dependency attribution mode")
+endif()
+
+add_library(receipt_dependency STATIC ../dependency.cpp)
+""",
+    )
+
+
+def create_parent_mutation_fixture_source(solver_source, fixture_source):
+    child_source = fixture_source / "src" / "child"
+    create_fixture_source(solver_source, child_source)
+    write(
+        fixture_source / "src" / "CMakeLists.txt",
+        """cmake_minimum_required(VERSION 3.27)
+project(deac_parent_mutation_fixture LANGUAGES NONE)
+set(DEAC_FIXTURE_PARENT_MUTATION "launcher" CACHE STRING
+    "parent mutation after child receipt registration")
+
+add_subdirectory(child/src child-build)
+if(NOT TARGET receipt_probe)
+    message(FATAL_ERROR "child receipt target is absent")
+endif()
+
+# This parent-directory rule does not govern the child target.  A seal running
+# from the top level must query the captured child directory, then separately
+# catch the selected mutation made by its parent.
+if(DEAC_FIXTURE_PARENT_MUTATION STREQUAL "launcher")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " $DEAC_PARENT_RULE_MUST_NOT_BE_QUERIED")
+    set_property(TARGET receipt_probe PROPERTY CXX_COMPILER_LAUNCHER
+        "${CMAKE_COMMAND};-E;env")
+elseif(DEAC_FIXTURE_PARENT_MUTATION STREQUAL "build-type")
+    set(CMAKE_BUILD_TYPE "Debug")
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "late parent build type" FORCE)
+elseif(DEAC_FIXTURE_PARENT_MUTATION STREQUAL "configuration-list")
+    set(CMAKE_CONFIGURATION_TYPES "Release")
+    set(CMAKE_CONFIGURATION_TYPES "Release" CACHE STRING
+        "late parent configuration list" FORCE)
+else()
+    message(FATAL_ERROR "unknown parent mutation")
 endif()
 """,
     )
@@ -249,7 +659,16 @@ def configure(cmake, source, build, compiler, *extra, check=True):
     )
 
 
-def build(cmake, build_directory, *, config=None, parallel=1, check=True):
+def build(
+    cmake,
+    build_directory,
+    *,
+    config=None,
+    parallel=1,
+    target=None,
+    check=True,
+    environment=None,
+):
     command = [
         cmake,
         "--build",
@@ -260,7 +679,14 @@ def build(cmake, build_directory, *, config=None, parallel=1, check=True):
     ]
     if config is not None:
         command.extend(["--config", config])
-    return run(command, build_directory, check=check)
+    if target is not None:
+        command.extend(["--target", target])
+    return run(
+        command,
+        build_directory,
+        check=check,
+        environment=environment,
+    )
 
 
 def parse_receipt(path):
@@ -332,11 +758,16 @@ def assert_static_dependency(
     document, fingerprint, expected_name="receipt_dependency"
 ):
     dependencies = document["receipt"]["target_dependencies"]
-    if len(dependencies) != 1:
-        raise AssertionError(f"unexpected fixture dependencies: {dependencies!r}")
-    dependency = dependencies[0]
-    if dependency["name"] != expected_name:
-        raise AssertionError(f"unexpected fixture dependency: {dependency!r}")
+    matches = [
+        dependency
+        for dependency in dependencies
+        if dependency.get("name") == expected_name
+    ]
+    if len(matches) != 1:
+        raise AssertionError(
+            f"expected one {expected_name} dependency, got {dependencies!r}"
+        )
+    dependency = matches[0]
     if dependency["type"] != "STATIC_LIBRARY":
         raise AssertionError(f"dependency is not a static library: {dependency!r}")
     if dependency["link"] is not None or not isinstance(dependency["archive"], dict):
@@ -353,6 +784,188 @@ def assert_static_dependency(
     definition = f"DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256={fingerprint}"
     if any(group["definitions"].count(definition) != 1 for group in groups):
         raise AssertionError("static dependency does not bind the tool fingerprint")
+
+
+def assert_hipblas_contract(
+    document,
+    *,
+    static_dependency,
+    mode,
+    provider_library,
+    include_directory,
+    package_directory,
+    provider_root,
+):
+    active = mode in {"imported_target", "compatibility_library"}
+    expected_dependencies = {static_dependency: "STATIC_LIBRARY"}
+    if active:
+        expected_dependencies["deac_hipblas_link_contract"] = "INTERFACE_LIBRARY"
+    dependencies = document["receipt"]["target_dependencies"]
+    names = [dependency.get("name") for dependency in dependencies]
+    if names != sorted(expected_dependencies):
+        raise AssertionError(
+            f"{mode} receipt has unexpected dependencies: {dependencies!r}"
+        )
+    for dependency in dependencies:
+        expected_type = expected_dependencies[dependency["name"]]
+        if dependency["type"] != expected_type:
+            raise AssertionError(
+                f"{mode} dependency has wrong type: {dependency!r}"
+            )
+    if active:
+        interface = next(
+            dependency
+            for dependency in dependencies
+            if dependency["name"] == "deac_hipblas_link_contract"
+        )
+        if (
+            interface["archive"] is not None
+            or interface["compile_groups"] != []
+            or interface["link"] is not None
+        ):
+            raise AssertionError(
+                f"{mode} interface dependency has build artifacts: {interface!r}"
+            )
+
+    link_fragments = document["receipt"]["link"]["command_fragments"]
+    libraries = [
+        fragment["fragment"]
+        for fragment in link_fragments
+        if fragment["role"] == "libraries"
+    ]
+    provider_matches = [
+        fragment
+        for fragment in libraries
+        if Path(fragment).resolve() == provider_library.resolve()
+    ]
+    expected_provider_count = 1 if active else 0
+    if len(provider_matches) != expected_provider_count:
+        raise AssertionError(
+            f"{mode} receipt expected provider {expected_provider_count} time(s), "
+            f"got {libraries!r}"
+        )
+    hipblas_fragments = [
+        fragment for fragment in libraries if "hipblas" in fragment.casefold()
+    ]
+    if len(hipblas_fragments) != expected_provider_count:
+        raise AssertionError(
+            f"{mode} receipt has unexpected hipBLAS fragments: {libraries!r}"
+        )
+
+    expected_backend = "sycl" if mode == "non_hip" else "hip"
+    if document["receipt"]["backend"] != expected_backend:
+        raise AssertionError(f"{mode} receipt records the wrong backend")
+    if cache_value(document, "HIP_RUNTIME_INCLUDE_DIR") != str(include_directory):
+        raise AssertionError(f"{mode} receipt omits the HIP runtime include")
+    if cache_value(document, "hipblas_ROOT") != str(provider_root):
+        raise AssertionError(f"{mode} receipt omits hipblas_ROOT")
+    disable_entry = cache_entry(
+        document, "CMAKE_DISABLE_FIND_PACKAGE_hipblas"
+    )
+    expected_disable = "FALSE" if mode == "imported_target" else "TRUE"
+    if disable_entry != {
+        "name": "CMAKE_DISABLE_FIND_PACKAGE_hipblas",
+        "type": "BOOL",
+        "value": expected_disable,
+    }:
+        raise AssertionError(
+            f"{mode} receipt has the wrong package-disable cache input: "
+            f"{disable_entry!r}"
+        )
+    for cache_key in (
+        "DEAC_HIPBLAS_INCLUDE_DIR",
+        "DEAC_HIPBLAS_LIBRARY",
+        "hipblas_DIR",
+    ):
+        cache_value(document, cache_key)
+    if mode == "imported_target":
+        if cache_value(document, "hipblas_DIR") != str(package_directory):
+            raise AssertionError("imported-target receipt omits hipblas_DIR")
+    elif mode == "compatibility_library":
+        if cache_value(document, "DEAC_HIPBLAS_INCLUDE_DIR") != str(
+            include_directory
+        ):
+            raise AssertionError("fallback receipt omits the hipBLAS include")
+        if cache_value(document, "DEAC_HIPBLAS_LIBRARY") != str(
+            provider_library
+        ):
+            raise AssertionError("fallback receipt omits the hipBLAS library")
+
+
+def assert_mapped_hipblas_receipt(
+    document, *, configuration, provider_library, other_provider_library
+):
+    expected_dependency = {
+        "archive": None,
+        "compile_groups": [],
+        "link": None,
+        "name": "deac_hipblas_link_contract",
+        "type": "INTERFACE_LIBRARY",
+    }
+    dependencies = document["receipt"]["target_dependencies"]
+    if dependencies != [expected_dependency]:
+        raise AssertionError(
+            "mapped hipBLAS receipt does not contain only the synthetic "
+            f"contract dependency: {dependencies!r}"
+        )
+
+    target = document["receipt"]["target"]
+    if target["name"] != "receipt_probe":
+        raise AssertionError(f"mapped receipt names the wrong target: {target!r}")
+    build_system = document["receipt"]["build_system"]
+    generator = build_system["generator"]
+    if (
+        build_system["configuration"] != configuration
+        or generator["name"] != "Ninja Multi-Config"
+        or not generator["multi_config"]
+    ):
+        raise AssertionError(
+            f"mapped {configuration} receipt has the wrong build shape: "
+            f"{build_system!r}"
+        )
+    if cache_value(document, "CMAKE_CONFIGURATION_TYPES") != "Debug;Release":
+        raise AssertionError(
+            "mapped receipt does not bind the exact Debug/Release config set"
+        )
+    if cache_entry(document, "CMAKE_DISABLE_FIND_PACKAGE_hipblas") != {
+        "name": "CMAKE_DISABLE_FIND_PACKAGE_hipblas",
+        "type": "BOOL",
+        "value": "FALSE",
+    }:
+        raise AssertionError(
+            "mapped package receipt does not attest enabled package discovery"
+        )
+
+    library_fragments = [
+        fragment["fragment"]
+        for fragment in document["receipt"]["link"]["command_fragments"]
+        if fragment["role"] == "libraries"
+    ]
+    libraries = []
+    for fragment in library_fragments:
+        try:
+            libraries.extend(shlex.split(fragment))
+        except ValueError as error:
+            raise AssertionError(
+                f"mapped receipt has invalid native-shell link syntax: {fragment!r}"
+            ) from error
+    expected_library = str(provider_library.resolve())
+    other_library = str(other_provider_library.resolve())
+    if libraries.count(expected_library) != 1:
+        raise AssertionError(
+            f"mapped {configuration} provider is not present exactly once: "
+            f"fragments={library_fragments!r}, arguments={libraries!r}"
+        )
+    if other_library in libraries:
+        raise AssertionError(
+            f"mapped {configuration} receipt contains the other config's "
+            f"provider: {libraries!r}"
+        )
+    if libraries != [expected_library]:
+        raise AssertionError(
+            f"mapped {configuration} receipt has unexpected link libraries: "
+            f"{libraries!r}"
+        )
 
 
 def assert_embedded_matches(executable, receipt_path):
@@ -376,15 +989,256 @@ def receipt_fingerprint(document):
     return document["receipt"]["target"]["toolchain_fingerprint_sha256"]
 
 
-def cache_value(document, name):
+def cache_entry(document, name):
     matches = [
-        entry["value"]
+        entry
         for entry in document["receipt"]["cache_entries"]
         if entry["name"] == name
     ]
     if len(matches) != 1:
         raise AssertionError(f"expected one {name} cache entry, got {matches!r}")
     return matches[0]
+
+
+def cache_value(document, name):
+    return cache_entry(document, name)["value"]
+
+
+def target_definitions(document):
+    return [
+        definition
+        for group in document["receipt"]["compile_groups"]
+        for definition in group["definitions"]
+    ]
+
+
+def create_hipblas_provider(workdir):
+    provider_root = workdir / "external-hipblas-provider"
+    include_directory = provider_root / "include"
+    write(include_directory / "hip" / "hip_runtime.h", "#pragma once\n")
+    write(include_directory / "hipblas" / "hipblas.h", "#pragma once\n")
+    provider_library = provider_root / "lib" / "libhipblas.a"
+    provider_library.parent.mkdir(parents=True, exist_ok=True)
+    provider_library.write_bytes(b"!<arch>\n")
+    package_directory = provider_root / "lib" / "cmake" / "hipblas"
+    write(
+        package_directory / "hipblas-config.cmake",
+        f"""if(NOT TARGET roc::hipblas)
+    add_library(deac_fixture_hipblas_provider UNKNOWN IMPORTED)
+    add_library(roc::hipblas ALIAS deac_fixture_hipblas_provider)
+    set_target_properties(deac_fixture_hipblas_provider PROPERTIES
+        IMPORTED_LOCATION {json.dumps(str(provider_library))}
+        INTERFACE_INCLUDE_DIRECTORIES {json.dumps(str(include_directory))})
+endif()
+""",
+    )
+    return provider_root, include_directory, provider_library, package_directory
+
+
+def create_configless_mapped_hipblas_provider(workdir):
+    provider_root = workdir / "external-configless-mapped-hipblas-provider"
+    include_directory = provider_root / "include"
+    write(include_directory / "hip" / "hip_runtime.h", "#pragma once\n")
+    write(include_directory / "hipblas" / "hipblas.h", "#pragma once\n")
+    configless_library = provider_root / "lib" / "libhipblas-configless.a"
+    alternate_library = provider_root / "lib" / "libhipblas-alternate.a"
+    configless_library.parent.mkdir(parents=True, exist_ok=True)
+    configless_library.write_bytes(b"!<arch>\n")
+    alternate_library.write_bytes(b"!<arch>\n")
+    package_directory = provider_root / "lib" / "cmake" / "hipblas"
+    write(
+        package_directory / "hipblas-config.cmake",
+        f"""if(NOT TARGET roc::hipblas)
+    add_library(deac_fixture_hipblas_provider UNKNOWN IMPORTED)
+    add_library(roc::hipblas ALIAS deac_fixture_hipblas_provider)
+    set_target_properties(deac_fixture_hipblas_provider PROPERTIES
+        IMPORTED_CONFIGURATIONS ALTERNATE_ARCHIVE
+        IMPORTED_LOCATION {json.dumps(str(configless_library))}
+        IMPORTED_LOCATION_ALTERNATE_ARCHIVE {json.dumps(str(alternate_library))}
+        MAP_IMPORTED_CONFIG_RELEASE ";ALTERNATE_ARCHIVE"
+        INTERFACE_INCLUDE_DIRECTORIES {json.dumps(str(include_directory))})
+endif()
+""",
+    )
+    return (
+        provider_root,
+        include_directory,
+        configless_library,
+        alternate_library,
+        package_directory,
+    )
+
+
+def create_mapped_hipblas_provider(workdir):
+    # Keep both configured artifacts behind a path that the native link line
+    # must shell-encode.  The receipt must still compare their decoded paths,
+    # not the generator-specific spelling in the File API fragment.
+    provider_root = workdir / "external mapped hipblas provider"
+    include_directory = provider_root / "include"
+    write(include_directory / "hip" / "hip_runtime.h", "#pragma once\n")
+    write(include_directory / "hipblas" / "hipblas.h", "#pragma once\n")
+    debug_library = provider_root / "lib" / "libhipblas-debug.a"
+    release_library = provider_root / "lib" / "libhipblas-release.a"
+    debug_library.parent.mkdir(parents=True, exist_ok=True)
+    debug_library.write_bytes(b"!<arch>\n")
+    release_library.write_bytes(b"!<arch>\n")
+    package_directory = provider_root / "lib" / "cmake" / "hipblas"
+    write(
+        package_directory / "hipblas-config.cmake",
+        f"""if(NOT TARGET roc::hipblas)
+    add_library(deac_fixture_mapped_hipblas_provider UNKNOWN IMPORTED)
+    add_library(roc::hipblas ALIAS deac_fixture_mapped_hipblas_provider)
+    set_target_properties(deac_fixture_mapped_hipblas_provider PROPERTIES
+        IMPORTED_CONFIGURATIONS "DEBUG_ARCHIVE;RELEASE_ARCHIVE"
+        IMPORTED_LOCATION_DEBUG_ARCHIVE {json.dumps(str(debug_library))}
+        IMPORTED_LOCATION_RELEASE_ARCHIVE {json.dumps(str(release_library))}
+        MAP_IMPORTED_CONFIG_DEBUG DEBUG_ARCHIVE
+        MAP_IMPORTED_CONFIG_RELEASE RELEASE_ARCHIVE
+        INTERFACE_INCLUDE_DIRECTORIES {json.dumps(str(include_directory))})
+endif()
+""",
+    )
+    return (
+        provider_root,
+        include_directory,
+        debug_library,
+        release_library,
+        package_directory,
+    )
+
+
+def create_mapped_hipblas_fixture_source(solver_source, fixture_source):
+    fixture_source.mkdir(parents=True)
+    copy_fixture_modules(solver_source, fixture_source)
+    write(fixture_source / "VERSION", "1.2.3\n")
+    write(
+        fixture_source / "src" / "probe.cpp",
+        """#include "build_identity.hpp"
+#include <iostream>
+
+int main() {
+    std::cout << deac_build_identity::build_receipt_json() << '\\n';
+    return 0;
+}
+""",
+    )
+    write(
+        fixture_source / "src" / "CMakeLists.txt",
+        """cmake_minimum_required(VERSION 3.27)
+project(deac_mapped_hipblas_receipt_fixture LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(CMAKE_DISABLE_FIND_PACKAGE_hipblas FALSE CACHE BOOL
+    "disable fixture hipBLAS package discovery" FORCE)
+option(DEAC_FIXTURE_DUPLICATE_SELECTED_ARTIFACT
+    "duplicate one selected-config required provider artifact" OFF)
+foreach(DEAC_FIXTURE_REQUIRED_VARIABLE IN ITEMS
+        DEAC_FIXTURE_HIPBLAS_DEBUG_LIBRARY
+        DEAC_FIXTURE_HIPBLAS_RELEASE_LIBRARY
+        DEAC_FIXTURE_HIPBLAS_PACKAGE_DIR
+        HIP_RUNTIME_INCLUDE_DIR)
+    if(NOT DEFINED ${DEAC_FIXTURE_REQUIRED_VARIABLE} OR
+            "${${DEAC_FIXTURE_REQUIRED_VARIABLE}}" STREQUAL "")
+        message(FATAL_ERROR
+            "${DEAC_FIXTURE_REQUIRED_VARIABLE} is required")
+    endif()
+endforeach()
+if(NOT "${CMAKE_CONFIGURATION_TYPES}" STREQUAL "Debug;Release")
+    message(FATAL_ERROR
+        "mapped hipBLAS fixture requires exactly Debug;Release")
+endif()
+set(GPU_BACKEND hip CACHE STRING "fixture backend" FORCE)
+set(USE_BLAS ON CACHE BOOL "fixture BLAS mode" FORCE)
+set(hipblas_DIR "${DEAC_FIXTURE_HIPBLAS_PACKAGE_DIR}"
+    CACHE PATH "mock hipBLAS package" FORCE)
+
+add_executable(receipt_probe probe.cpp)
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/DeacHipblas.cmake")
+deac_target_link_hipblas(receipt_probe)
+_deac_hipblas_validate_link_contract(deac_hipblas_link_contract)
+get_target_property(DEAC_FIXTURE_HIPBLAS_PROVIDER_TARGET
+    deac_hipblas_link_contract DEAC_HIPBLAS_PROVIDER_TARGET)
+if(NOT DEAC_FIXTURE_HIPBLAS_PROVIDER_TARGET STREQUAL
+        "deac_fixture_mapped_hipblas_provider")
+    message(FATAL_ERROR
+        "mapped hipBLAS alias did not resolve to its canonical provider: "
+        "${DEAC_FIXTURE_HIPBLAS_PROVIDER_TARGET}")
+endif()
+get_target_property(DEAC_FIXTURE_HIPBLAS_PROVIDER_ARTIFACT
+    deac_hipblas_link_contract DEAC_HIPBLAS_PROVIDER_ARTIFACT)
+string(CONCAT DEAC_FIXTURE_EXPECTED_PROVIDER_ARTIFACT
+    "$<$<CONFIG:Debug>:${DEAC_FIXTURE_HIPBLAS_DEBUG_LIBRARY}>"
+    "$<$<CONFIG:Release>:${DEAC_FIXTURE_HIPBLAS_RELEASE_LIBRARY}>")
+if(NOT "${DEAC_FIXTURE_HIPBLAS_PROVIDER_ARTIFACT}" STREQUAL
+        "${DEAC_FIXTURE_EXPECTED_PROVIDER_ARTIFACT}")
+    message(FATAL_ERROR
+        "mapped hipBLAS provider artifact is not configuration exact: "
+        "${DEAC_FIXTURE_HIPBLAS_PROVIDER_ARTIFACT}")
+endif()
+
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/DeacBuildReceipt.cmake")
+set(DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_NAMES
+    "${DEAC_FIXTURE_HIPBLAS_PROVIDER_TARGET}")
+set(DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_ARTIFACTS
+    "${DEAC_FIXTURE_HIPBLAS_PROVIDER_ARTIFACT}")
+if(DEAC_FIXTURE_DUPLICATE_SELECTED_ARTIFACT)
+    string(CONCAT DEAC_FIXTURE_COLLIDING_PROVIDER_ARTIFACT
+        "$<$<CONFIG:Debug>:${DEAC_FIXTURE_HIPBLAS_DEBUG_LIBRARY}>"
+        "$<$<CONFIG:Release>:${CMAKE_COMMAND}>")
+    list(APPEND DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_NAMES
+        deac_fixture_colliding_provider)
+    list(APPEND DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_ARTIFACTS
+        "${DEAC_FIXTURE_COLLIDING_PROVIDER_ARTIFACT}")
+endif()
+deac_target_add_build_receipt(receipt_probe
+    SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/.."
+    GENERATED_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/receipt"
+    IDENTITY_NAME mapped_fixture
+    RECEIPT
+        "${CMAKE_CURRENT_BINARY_DIR}/receipt/$<CONFIG>/build-receipt.json"
+    BACKEND "${GPU_BACKEND}"
+    CACHE_KEYS
+        CMAKE_CONFIGURATION_TYPES
+        CMAKE_CXX_COMPILER
+        CMAKE_CXX_FLAGS
+        CMAKE_DISABLE_FIND_PACKAGE_hipblas
+        CMAKE_EXE_LINKER_FLAGS
+        CMAKE_GENERATOR
+        GPU_BACKEND
+        HIP_RUNTIME_INCLUDE_DIR
+        USE_BLAS
+        hipblas_DIR
+    DEPENDENCY_TARGETS deac_hipblas_link_contract
+    REQUIRED_LINK_LIBRARY_NAMES
+        ${DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_NAMES}
+    REQUIRED_LINK_LIBRARY_ARTIFACTS
+        ${DEAC_FIXTURE_REQUIRED_LINK_LIBRARY_ARTIFACTS})
+add_custom_target(deac_fixture_generate_receipt
+    DEPENDS "${DEAC_BUILD_RECEIPT_REFRESH}")
+""",
+    )
+
+
+def test_single_config_configuration_rejections(
+    cmake, source, workdir, real_compiler
+):
+    assert_configure_rejected(
+        cmake,
+        source,
+        workdir / "rejected-empty-build-type",
+        real_compiler,
+        ["-DCMAKE_BUILD_TYPE:STRING="],
+        "requires at least one configured build type",
+    )
+    assert_configure_rejected(
+        cmake,
+        source,
+        workdir / "rejected-list-build-type",
+        real_compiler,
+        ["-DCMAKE_BUILD_TYPE:STRING=Debug;Release"],
+        "single-config generator requires exactly one configured build type",
+    )
 
 
 def test_single_config_refresh_and_replacement(
@@ -552,6 +1406,63 @@ def test_material_flag_reconfiguration(cmake, source, workdir, real_compiler):
     assert_embedded_matches(build_directory / "receipt_probe", receipt_path)
 
 
+def test_backend_reconfiguration(cmake, source, workdir, real_compiler):
+    build_directory = workdir / "backend-reconfiguration-build"
+    receipt_path = (
+        build_directory / "receipt" / "Release" / "build-receipt.json"
+    )
+    executable = build_directory / "receipt_probe"
+
+    configure(cmake, source, build_directory, real_compiler)
+    build(cmake, build_directory)
+    none_receipt = parse_receipt(receipt_path)
+    if none_receipt["receipt"]["backend"] != "none":
+        raise AssertionError("initial backend receipt is not none")
+    if cache_value(none_receipt, "GPU_BACKEND") != "none":
+        raise AssertionError("initial backend cache entry is not none")
+    none_definitions = target_definitions(none_receipt)
+    if "USE_GPU=1" in none_definitions or "USE_SYCL=1" in none_definitions:
+        raise AssertionError(
+            f"none backend retained accelerator definitions: {none_definitions!r}"
+        )
+    assert_embedded_matches(executable, receipt_path)
+
+    # Reconfigure the same graph to a mocked SYCL backend.  The fixture remains
+    # an ordinary CXX project, while its effective definitions model the
+    # production backend selection closely enough to prove File API refresh.
+    configure(
+        cmake,
+        source,
+        build_directory,
+        real_compiler,
+        "-DGPU_BACKEND:STRING=sycl",
+    )
+    changed_build = build(cmake, build_directory)
+    assert_build_actions(
+        changed_build,
+        [
+            "probe.cpp.o",
+            "fixture_receipt_probe_build_receipt.cpp.o",
+            "Linking CXX executable receipt_probe",
+        ],
+    )
+    sycl_receipt = parse_receipt(receipt_path)
+    if sycl_receipt["receipt"]["backend"] != "sycl":
+        raise AssertionError("reconfigured backend receipt is not sycl")
+    if cache_value(sycl_receipt, "GPU_BACKEND") != "sycl":
+        raise AssertionError("reconfigured backend cache entry is not sycl")
+    sycl_definitions = target_definitions(sycl_receipt)
+    for definition in ("USE_GPU=1", "USE_SYCL=1"):
+        if sycl_definitions.count(definition) != 1:
+            raise AssertionError(
+                f"reconfigured backend has wrong {definition} definitions: "
+                f"{sycl_definitions!r}"
+            )
+    if sycl_receipt["receipt_sha256"] == none_receipt["receipt_sha256"]:
+        raise AssertionError("backend reconfiguration retained the old digest")
+    assert_embedded_matches(executable, receipt_path)
+
+
 def test_archive_tool_reconfiguration(
     cmake, source, workdir, real_compiler, real_archiver
 ):
@@ -677,7 +1588,64 @@ def graph_configurations(ninja, build_directory, configuration):
     return configurations
 
 
+def assert_graph_edge_count(graph_text, source, target, expected_count):
+    needle = f"// {source} -> {target}"
+    count = sum(
+        line.strip().endswith(needle) for line in graph_text.splitlines()
+    )
+    if count != expected_count:
+        raise AssertionError(
+            f"expected graph edge {source} -> {target} {expected_count} "
+            f"time(s), got {count}:\n{graph_text}"
+        )
+
+
 def test_ninja_multi_config(cmake, ninja, source, workdir, compiler_shim):
+    assert_configure_rejected(
+        cmake,
+        source,
+        workdir / "rejected-casefolded-configurations",
+        compiler_shim,
+        [
+            "-G",
+            "Ninja Multi-Config",
+            f"-DCMAKE_MAKE_PROGRAM={ninja}",
+            "-DCMAKE_CONFIGURATION_TYPES=Debug;DEBUG",
+        ],
+        "configurations must be unique ignoring ASCII case",
+    )
+    for attack, expected in (
+        (
+            "configuration-case-collision",
+            "configurations must be unique ignoring ASCII case",
+        ),
+        (
+            "configuration-list",
+            "generator configuration state changed after registration",
+        ),
+        (
+            "shadowed-configuration-cache",
+            (
+                "CMAKE_CONFIGURATION_TYPES cache value disagrees with "
+                "effective directory state"
+            ),
+        ),
+    ):
+        assert_configure_rejected(
+            cmake,
+            source,
+            workdir / f"rejected-late-{attack}",
+            compiler_shim,
+            [
+                "-G",
+                "Ninja Multi-Config",
+                f"-DCMAKE_MAKE_PROGRAM={ninja}",
+                "-DCMAKE_CONFIGURATION_TYPES=Debug;Release",
+                f"-DDEAC_FIXTURE_LATE_ATTACK={attack}",
+            ],
+            expected,
+        )
+
     build_directory = workdir / "multi-build"
     run(
         [
@@ -820,6 +1788,488 @@ def test_parallel_receipt_consumers(
         assert_embedded_matches(build_directory / executable_name, receipt_path)
 
 
+def test_shared_dependency_receipt_consumers(
+    cmake, ninja, solver_source, workdir, real_compiler
+):
+    source = workdir / "shared-dependency-source"
+    create_fixture_source(solver_source, source)
+    build_directory = workdir / "shared-dependency-build"
+    configure(
+        cmake,
+        source,
+        build_directory,
+        real_compiler,
+        "-G",
+        "Ninja",
+        f"-DCMAKE_MAKE_PROGRAM={ninja}",
+        "-DDEAC_FIXTURE_PARALLEL_CONSUMERS=ON",
+        "-DDEAC_FIXTURE_SHARED_DEPENDENCY=ON",
+    )
+    build(cmake, build_directory, parallel=4)
+
+    receipt_root = build_directory / "receipt" / "Release"
+    receipts = (
+        ("receipt_probe", receipt_root / "build-receipt.json"),
+        ("receipt_probe_two", receipt_root / "build-receipt-two.json"),
+    )
+    fingerprints = set()
+    for executable_name, receipt_path in receipts:
+        document = parse_receipt(receipt_path)
+        fingerprint = receipt_fingerprint(document)
+        fingerprints.add(fingerprint)
+        assert_static_dependency(
+            document,
+            fingerprint,
+            expected_name="receipt_dependency",
+        )
+        assert_embedded_matches(build_directory / executable_name, receipt_path)
+    if len(fingerprints) != 1:
+        raise AssertionError(
+            "shared dependency received incompatible receipt fingerprints"
+        )
+
+    rejected_build = workdir / "rejected-shared-fingerprint-conflict"
+    assert_configure_rejected(
+        cmake,
+        source,
+        rejected_build,
+        real_compiler,
+        [
+            "-G",
+            "Ninja",
+            f"-DCMAKE_MAKE_PROGRAM={ninja}",
+            "-DDEAC_FIXTURE_PARALLEL_CONSUMERS=ON",
+            "-DDEAC_FIXTURE_SHARED_DEPENDENCY=ON",
+            "-DDEAC_FIXTURE_SHARED_FINGERPRINT_ATTACK=conflict",
+        ],
+        "shared by incompatible toolchain fingerprints",
+    )
+    if list(rejected_build.glob("receipt/**/*.json")):
+        raise AssertionError("incompatible shared fingerprint produced a receipt")
+
+
+def test_mapped_hipblas_multi_config(
+    cmake, ninja, solver_source, workdir, real_compiler
+):
+    source = workdir / "mapped-hipblas-source"
+    create_mapped_hipblas_fixture_source(solver_source, source)
+    (
+        provider_root,
+        include_directory,
+        debug_library,
+        release_library,
+        package_directory,
+    ) = create_mapped_hipblas_provider(workdir)
+    if debug_library.resolve() == release_library.resolve():
+        raise AssertionError("mapped hipBLAS configurations share one artifact")
+
+    build_directory = workdir / "mapped-hipblas-build"
+    graph_path = build_directory / "targets.dot"
+    run(
+        [
+            cmake,
+            f"--graphviz={graph_path}",
+            "-S",
+            source / "src",
+            "-B",
+            build_directory,
+            "-G",
+            "Ninja Multi-Config",
+            f"-DCMAKE_MAKE_PROGRAM:FILEPATH={ninja}",
+            f"-DCMAKE_CXX_COMPILER:FILEPATH={real_compiler}",
+            "-DCMAKE_CONFIGURATION_TYPES:STRING=Debug;Release",
+            (
+                "-DDEAC_FIXTURE_HIPBLAS_DEBUG_LIBRARY:FILEPATH="
+                f"{debug_library}"
+            ),
+            (
+                "-DDEAC_FIXTURE_HIPBLAS_RELEASE_LIBRARY:FILEPATH="
+                f"{release_library}"
+            ),
+            f"-DDEAC_FIXTURE_HIPBLAS_PACKAGE_DIR:PATH={package_directory}",
+            f"-DHIP_RUNTIME_INCLUDE_DIR:PATH={include_directory}",
+            f"-Dhipblas_ROOT:PATH={provider_root}",
+        ],
+        source,
+    )
+    if not graph_path.is_file():
+        raise AssertionError("mapped hipBLAS configure did not emit Graphviz data")
+    graph_text = graph_path.read_text(encoding="utf-8")
+    provider_target = "deac_fixture_mapped_hipblas_provider"
+    canonical_label = f'{provider_target}\\n(roc::hipblas)'
+    if graph_text.count(canonical_label) != 1:
+        raise AssertionError(
+            "mapped hipBLAS graph does not expose exactly one canonical "
+            f"provider plus alias: {graph_text}"
+        )
+    assert_graph_edge_count(
+        graph_text, "receipt_probe", "deac_hipblas_link_contract", 1
+    )
+    assert_graph_edge_count(
+        graph_text, "deac_hipblas_link_contract", provider_target, 1
+    )
+    assert_graph_edge_count(graph_text, "receipt_probe", provider_target, 0)
+
+    receipts = {}
+    configurations = (
+        ("Debug", debug_library, release_library),
+        ("Release", release_library, debug_library),
+    )
+    for configuration, provider_library, other_provider_library in configurations:
+        build(cmake, build_directory, config=configuration, parallel=4)
+        receipt_path = (
+            build_directory
+            / "receipt"
+            / configuration
+            / "build-receipt.json"
+        )
+        document = parse_receipt(receipt_path)
+        assert_mapped_hipblas_receipt(
+            document,
+            configuration=configuration,
+            provider_library=provider_library,
+            other_provider_library=other_provider_library,
+        )
+        assert_no_git_source(document, "1.2.3")
+        assert_embedded_matches(
+            build_directory / configuration / "receipt_probe", receipt_path
+        )
+        receipts[configuration] = document
+    if (
+        receipts["Debug"]["receipt_sha256"]
+        == receipts["Release"]["receipt_sha256"]
+    ):
+        raise AssertionError(
+            "mapped Debug and Release artifacts produced one receipt identity"
+        )
+
+
+def test_selected_config_provider_collision(
+    cmake, ninja, solver_source, workdir, real_compiler
+):
+    source = workdir / "mapped-collision-source"
+    create_mapped_hipblas_fixture_source(solver_source, source)
+    (
+        provider_root,
+        include_directory,
+        debug_library,
+        release_library,
+        package_directory,
+    ) = create_mapped_hipblas_provider(workdir)
+    build_directory = workdir / "mapped-collision-build"
+    result = configure(
+        cmake,
+        source,
+        build_directory,
+        real_compiler,
+        "-G",
+        "Ninja Multi-Config",
+        f"-DCMAKE_MAKE_PROGRAM:FILEPATH={ninja}",
+        "-DCMAKE_CONFIGURATION_TYPES:STRING=Debug;Release",
+        f"-DDEAC_FIXTURE_HIPBLAS_DEBUG_LIBRARY:FILEPATH={debug_library}",
+        f"-DDEAC_FIXTURE_HIPBLAS_RELEASE_LIBRARY:FILEPATH={release_library}",
+        f"-DDEAC_FIXTURE_HIPBLAS_PACKAGE_DIR:PATH={package_directory}",
+        f"-DHIP_RUNTIME_INCLUDE_DIR:PATH={include_directory}",
+        f"-Dhipblas_ROOT:PATH={provider_root}",
+        "-DDEAC_FIXTURE_DUPLICATE_SELECTED_ARTIFACT:BOOL=ON",
+        check=False,
+    )
+    stage = "configure"
+    if result.returncode == 0:
+        result = build(
+            cmake,
+            build_directory,
+            config="Debug",
+            target="deac_fixture_generate_receipt",
+            check=False,
+        )
+        stage = "Debug build"
+    assert_rejected(
+        result,
+        context=f"{stage} selected-config provider collision",
+        expected=(
+            "selected configuration contains duplicate required "
+            "link-library artifact",
+            "required link-library artifacts must be unique",
+        ),
+    )
+    receipt_path = build_directory / "receipt" / "Debug" / "build-receipt.json"
+    if receipt_path.exists():
+        raise AssertionError("provider collision produced a Debug receipt")
+
+
+def test_nested_build_root_canonicalization(
+    cmake, ninja, solver_source, workdir, real_compiler
+):
+    source = workdir / "nested-build-source"
+    create_fixture_source(solver_source, source)
+    receipts = []
+    for suffix in ("a", "b"):
+        # Put the build inside CMAKE_SOURCE_DIR so both canonical roots match;
+        # BUILD_ROOT must win as the more-specific containing root.
+        build_directory = source / "src" / f"nested-build-{suffix}"
+        configure(
+            cmake,
+            source,
+            build_directory,
+            real_compiler,
+            "-G",
+            "Ninja",
+            f"-DCMAKE_MAKE_PROGRAM={ninja}",
+        )
+        build(cmake, build_directory)
+        receipt_path = (
+            build_directory / "receipt" / "Release" / "build-receipt.json"
+        )
+        document = parse_receipt(receipt_path)
+        generated_sources = [
+            path
+            for group in document["receipt"]["compile_groups"]
+            for path in group["sources"]
+            if path.endswith("fixture_receipt_probe_build_receipt.cpp")
+        ]
+        if len(generated_sources) != 1 or not generated_sources[0].startswith(
+            "<BUILD_ROOT>/generated/receipt/Release/"
+        ):
+            raise AssertionError(
+                "nested generated source did not prefer the most-specific "
+                f"build root: {generated_sources!r}"
+            )
+        receipts.append(receipt_path.read_bytes())
+    if receipts[0] != receipts[1]:
+        raise AssertionError(
+            "equivalent nested build roots produced different canonical receipts"
+        )
+
+
+def test_hidden_receipt_config_rejection(
+    cmake, ninja, source, workdir, real_compiler
+):
+    assert_configure_rejected(
+        cmake,
+        source,
+        workdir / "rejected-hidden-receipt-config",
+        real_compiler,
+        [
+            "-G",
+            "Ninja Multi-Config",
+            f"-DCMAKE_MAKE_PROGRAM={ninja}",
+            "-DCMAKE_CONFIGURATION_TYPES=Debug;Release",
+            "-DDEAC_FIXTURE_RECEIPT_ATTACK=hidden-config",
+        ],
+        "RECEIPT",
+    )
+
+
+def test_output_path_symlink_rejections(
+    cmake, source, workdir, real_compiler
+):
+    target_root = workdir / "output-path-symlink-targets"
+    target_root.mkdir()
+    attacks = (
+        ("generated-existing", Path("generated/receipt"), True),
+        ("generated-dangling", Path("generated/receipt"), False),
+        ("receipt-existing", Path("receipt"), True),
+        ("receipt-dangling", Path("receipt"), False),
+    )
+    for name, relative_link, target_exists in attacks:
+        build_directory = workdir / f"rejected-output-symlink-{name}"
+        build_directory.mkdir()
+        link = build_directory / relative_link
+        link.parent.mkdir(parents=True, exist_ok=True)
+        target = target_root / name
+        if target_exists:
+            target.mkdir()
+        link.symlink_to(target, target_is_directory=True)
+        if not link.is_symlink():
+            raise AssertionError(f"{name} fixture did not create a symlink")
+
+        result = configure(
+            cmake,
+            source,
+            build_directory,
+            real_compiler,
+            check=False,
+        )
+        assert_rejected(result, context=name, expected="symlink")
+        receipt_path = (
+            build_directory / "receipt" / "Release" / "build-receipt.json"
+        )
+        if receipt_path.exists():
+            raise AssertionError(f"{name} symlink produced a receipt")
+
+
+def test_configless_mapped_hipblas(
+    cmake, ninja, source, workdir, real_compiler
+):
+    (
+        provider_root,
+        include_directory,
+        configless_library,
+        alternate_library,
+        package_directory,
+    ) = create_configless_mapped_hipblas_provider(workdir)
+    if configless_library.resolve() == alternate_library.resolve():
+        raise AssertionError("configless and alternate providers are identical")
+
+    build_directory = workdir / "configless-mapped-hipblas-build"
+    configure(
+        cmake,
+        source,
+        build_directory,
+        real_compiler,
+        "-G",
+        "Ninja",
+        f"-DCMAKE_MAKE_PROGRAM:FILEPATH={ninja}",
+        "-DDEAC_FIXTURE_HIPBLAS_MODE=imported_target",
+        f"-DDEAC_FIXTURE_HIPBLAS_INCLUDE_DIR:PATH={include_directory}",
+        f"-DDEAC_FIXTURE_HIPBLAS_LIBRARY:FILEPATH={configless_library}",
+        f"-DDEAC_FIXTURE_HIPBLAS_PACKAGE_DIR:PATH={package_directory}",
+        (
+            "-DDEAC_FIXTURE_EXPECTED_HIPBLAS_ARTIFACT:FILEPATH="
+            f"{configless_library}"
+        ),
+        f"-DHIP_RUNTIME_INCLUDE_DIR:PATH={include_directory}",
+        f"-Dhipblas_ROOT:PATH={provider_root}",
+    )
+    build(cmake, build_directory, parallel=4)
+    receipt_path = (
+        build_directory / "receipt" / "Release" / "build-receipt.json"
+    )
+    document = parse_receipt(receipt_path)
+    assert_static_dependency(document, receipt_fingerprint(document))
+    assert_hipblas_contract(
+        document,
+        static_dependency="receipt_dependency",
+        mode="imported_target",
+        provider_library=configless_library,
+        include_directory=include_directory,
+        package_directory=package_directory,
+        provider_root=provider_root,
+    )
+
+    library_arguments = []
+    for fragment in document["receipt"]["link"]["command_fragments"]:
+        if fragment["role"] == "libraries":
+            library_arguments.extend(shlex.split(fragment["fragment"]))
+    expected_library = str(configless_library.resolve())
+    unexpected_library = str(alternate_library.resolve())
+    if library_arguments.count(expected_library) != 1:
+        raise AssertionError(
+            "File API did not select the configless mapped artifact exactly "
+            f"once: {library_arguments!r}"
+        )
+    if unexpected_library in library_arguments:
+        raise AssertionError(
+            "File API selected the alternate named mapped artifact: "
+            f"{library_arguments!r}"
+        )
+    assert_no_git_source(document, "1.2.4")
+    assert_embedded_matches(build_directory / "receipt_probe", receipt_path)
+
+
+def test_hipblas_receipt_contract(
+    cmake, ninja, source, workdir, real_compiler
+):
+    (
+        provider_root,
+        include_directory,
+        provider_library,
+        package_directory,
+    ) = create_hipblas_provider(workdir)
+    modes = (
+        "imported_target",
+        "compatibility_library",
+        "blas_off",
+        "non_hip",
+    )
+    for generator in ("Ninja", "Unix Makefiles"):
+        generator_slug = generator.lower().replace(" ", "-")
+        for mode in modes:
+            build_directory = workdir / f"hipblas-{generator_slug}-{mode}"
+            generator_arguments = ["-G", generator]
+            if generator == "Ninja":
+                generator_arguments.append(f"-DCMAKE_MAKE_PROGRAM={ninja}")
+            configure(
+                cmake,
+                source,
+                build_directory,
+                real_compiler,
+                *generator_arguments,
+                "-DDEAC_FIXTURE_PARALLEL_CONSUMERS=ON",
+                f"-DDEAC_FIXTURE_HIPBLAS_MODE={mode}",
+                f"-DDEAC_FIXTURE_HIPBLAS_INCLUDE_DIR={include_directory}",
+                f"-DDEAC_FIXTURE_HIPBLAS_LIBRARY={provider_library}",
+                f"-DDEAC_FIXTURE_HIPBLAS_PACKAGE_DIR={package_directory}",
+                f"-DHIP_RUNTIME_INCLUDE_DIR={include_directory}",
+                f"-Dhipblas_ROOT={provider_root}",
+            )
+            build(cmake, build_directory, parallel=4)
+            receipt_root = build_directory / "receipt" / "Release"
+            checks = (
+                (
+                    "receipt_probe",
+                    "receipt_dependency",
+                    receipt_root / "build-receipt.json",
+                ),
+                (
+                    "receipt_probe_two",
+                    "receipt_dependency_two",
+                    receipt_root / "build-receipt-two.json",
+                ),
+            )
+            for executable_name, dependency_name, receipt_path in checks:
+                document = parse_receipt(receipt_path)
+                assert_static_dependency(
+                    document,
+                    receipt_fingerprint(document),
+                    expected_name=dependency_name,
+                )
+                assert_hipblas_contract(
+                    document,
+                    static_dependency=dependency_name,
+                    mode=mode,
+                    provider_library=provider_library,
+                    include_directory=include_directory,
+                    package_directory=package_directory,
+                    provider_root=provider_root,
+                )
+                assert_embedded_matches(
+                    build_directory / executable_name, receipt_path
+                )
+
+
+def diagnostic_text(result):
+    return result.stdout + result.stderr
+
+
+def escaped_diagnostic(text):
+    return "".join(
+        character
+        if character in "\n\r\t" or ord(character) >= 0x20
+        else f"\\x{ord(character):02x}"
+        for character in text
+    )
+
+
+def assert_rejected(result, *, context, expected):
+    if result.returncode == 0:
+        raise AssertionError(f"unsupported {context} was accepted")
+    output = diagnostic_text(result)
+    expected_fragments = (expected,) if isinstance(expected, str) else expected
+    normalized_output = " ".join(output.split())
+    if not any(
+        fragment in output
+        or " ".join(fragment.split()) in normalized_output
+        for fragment in expected_fragments
+    ):
+        raise AssertionError(
+            f"{context} rejection did not mention {expected_fragments!r}:\n"
+            f"{escaped_diagnostic(output)}"
+        )
+    return output
+
+
 def assert_configure_rejected(cmake, source, build_directory, compiler, arguments, text):
     result = configure(
         cmake,
@@ -829,13 +2279,840 @@ def assert_configure_rejected(cmake, source, build_directory, compiler, argument
         *arguments,
         check=False,
     )
+    assert_rejected(
+        result,
+        context=f"configure route {arguments!r}",
+        expected=text,
+    )
+
+
+def assert_configure_or_build_rejected(
+    cmake,
+    source,
+    build_directory,
+    compiler,
+    arguments,
+    expected,
+    *,
+    config=None,
+    target=None,
+    environment=None,
+):
+    result = configure(
+        cmake,
+        source,
+        build_directory,
+        compiler,
+        *arguments,
+        check=False,
+    )
+    stage = "configure"
     if result.returncode == 0:
-        raise AssertionError(f"unsupported configure route was accepted: {arguments!r}")
-    output = result.stdout + result.stderr
-    if text not in output:
-        raise AssertionError(
-            f"configure rejection did not mention {text!r}:\n{output}"
+        result = build(
+            cmake,
+            build_directory,
+            config=config,
+            target=target,
+            check=False,
+            environment=environment,
         )
+        stage = "build"
+    output = assert_rejected(
+        result,
+        context=f"{stage} route {arguments!r}",
+        expected=expected,
+    )
+    return stage, output
+
+
+def test_hipblas_receipt_rejections(
+    cmake, source, workdir, real_compiler
+):
+    (
+        provider_root,
+        include_directory,
+        provider_library,
+        package_directory,
+    ) = create_hipblas_provider(workdir)
+    common_arguments = [
+        "-DDEAC_FIXTURE_HIPBLAS_MODE=imported_target",
+        f"-DDEAC_FIXTURE_HIPBLAS_INCLUDE_DIR={include_directory}",
+        f"-DDEAC_FIXTURE_HIPBLAS_LIBRARY={provider_library}",
+        f"-DDEAC_FIXTURE_HIPBLAS_PACKAGE_DIR={package_directory}",
+        f"-DHIP_RUNTIME_INCLUDE_DIR={include_directory}",
+        f"-Dhipblas_ROOT={provider_root}",
+    ]
+    attacks = (
+        (
+            "duplicate-contract-provider",
+            "-DDEAC_FIXTURE_HIPBLAS_CONTRACT_ATTACK=duplicate-provider",
+            "provider once",
+        ),
+        (
+            "unequal-link-lists",
+            "-DDEAC_FIXTURE_LINK_LIBRARY_ATTACK=unequal-lists",
+            "equal",
+        ),
+        (
+            "duplicate-link-name",
+            "-DDEAC_FIXTURE_LINK_LIBRARY_ATTACK=duplicate-name",
+            "must be unique:",
+        ),
+        (
+            "duplicate-link-artifact",
+            "-DDEAC_FIXTURE_LINK_LIBRARY_ATTACK=duplicate-artifact",
+            "required link-library artifacts must be unique",
+        ),
+        (
+            "missing-link-artifact",
+            "-DDEAC_FIXTURE_LINK_LIBRARY_ATTACK=missing-artifact",
+            "regular file:",
+        ),
+    )
+    for name, attack_argument, expected in attacks:
+        assert_configure_rejected(
+            cmake,
+            source,
+            workdir / f"rejected-hipblas-{name}",
+            real_compiler,
+            [*common_arguments, attack_argument],
+            expected,
+        )
+
+
+def test_control_byte_link_artifact_rejections(
+    cmake, source, workdir, real_compiler
+):
+    artifact_root = workdir / "control-byte-link-artifacts"
+    artifact_root.mkdir()
+    controls = (
+        ("tab", "\t"),
+        ("escape", chr(0x1B)),
+        ("delete", chr(0x7F)),
+    )
+    for name, control in controls:
+        artifact = artifact_root / f"libbefore{control}after.a"
+        artifact.write_bytes(b"fixture link artifact\n")
+        if not artifact.is_file():
+            raise AssertionError(f"{name} control artifact was not created")
+
+        build_directory = workdir / f"rejected-control-artifact-{name}"
+        result = configure(
+            cmake,
+            source,
+            build_directory,
+            real_compiler,
+            f"-DDEAC_FIXTURE_CONTROL_LINK_ARTIFACT:STRING={artifact}",
+            check=False,
+        )
+        output = assert_rejected(
+            result,
+            context=f"{name} control artifact",
+            expected="control byte",
+        )
+        if control in output:
+            raise AssertionError(
+                f"{name} artifact control was echoed raw:\n"
+                f"{escaped_diagnostic(output)}"
+            )
+        receipt_path = (
+            build_directory / "receipt" / "Release" / "build-receipt.json"
+        )
+        if receipt_path.exists():
+            raise AssertionError(f"{name} control artifact produced a receipt")
+
+
+def test_effective_shell_input_rejections(
+    cmake, source, workdir, real_compiler
+):
+    dollar_build = workdir / "rejected-effective-flags-dollar-variable"
+    configure(
+        cmake,
+        source,
+        dollar_build,
+        real_compiler,
+        "-DDEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK=dollar-variable",
+    )
+    for value in ("-DDEAC_ENV_PROBE=one", "-DDEAC_ENV_PROBE=two"):
+        environment = os.environ.copy()
+        environment["DEAC_UNATTESTED_FLAGS"] = value
+        result = build(
+            cmake,
+            dollar_build,
+            target="deac_fixture_generate_receipt",
+            check=False,
+            environment=environment,
+        )
+        assert_rejected(
+            result,
+            context=f"effective CMAKE_CXX_FLAGS under {value}",
+            expected="contains unsafe POSIX shell syntax",
+        )
+        receipt_path = (
+            dollar_build / "receipt" / "Release" / "build-receipt.json"
+        )
+        if receipt_path.exists():
+            raise AssertionError(
+                "changed environment reused an unattested configured identity"
+            )
+
+    attacks = (
+        "braced-variable",
+        "glob",
+        "redirection",
+        "comment",
+        "command-substitution",
+        "backtick-substitution",
+        "process-substitution",
+        "quoted-dollar",
+        "escaped-dollar",
+    )
+    for attack in attacks:
+        build_directory = workdir / f"rejected-effective-flags-{attack}"
+        assert_configure_or_build_rejected(
+            cmake,
+            source,
+            build_directory,
+            real_compiler,
+            [f"-DDEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK={attack}"],
+            "contains unsafe POSIX shell syntax",
+            target="deac_fixture_generate_receipt",
+        )
+        receipt_path = (
+            build_directory / "receipt" / "Release" / "build-receipt.json"
+        )
+        if receipt_path.exists():
+            raise AssertionError(f"effective {attack} flags produced a receipt")
+
+    # Globs remain data when their protection survives both CMake's generator
+    # and the POSIX shell.  Dollar signs have separate Make/Ninja expansion
+    # semantics and are rejected even when shell quoting alone would protect
+    # them.
+    for accepted in ("safe-quoted", "safe-escaped"):
+        accepted_build = workdir / f"accepted-effective-flags-{accepted}"
+        configure(
+            cmake,
+            source,
+            accepted_build,
+            real_compiler,
+            f"-DDEAC_FIXTURE_EFFECTIVE_CXX_FLAGS_ATTACK={accepted}",
+        )
+        build(cmake, accepted_build)
+
+
+def test_deferred_seal_rejections(cmake, source, workdir, real_compiler):
+    attacks = (
+        ("launcher", "CXX_COMPILER_LAUNCHER"),
+        ("rule", "CXX rule templates changed after registration"),
+        ("ipo", "INTERPROCEDURAL_OPTIMIZATION_RELEASE"),
+        ("link-what-you-use", "LINK_WHAT_YOU_USE"),
+        ("interface-literal", "interface dependencies"),
+        (
+            "interface-conditional",
+            "has an unsupported generator-expression link item",
+        ),
+        ("archive-tool", "CMAKE_AR"),
+        ("archive-index-tool", "CMAKE_RANLIB"),
+        (
+            "build-type",
+            "generator configuration state changed after registration",
+        ),
+        (
+            "shadowed-build-type-cache",
+            (
+                "CMAKE_BUILD_TYPE cache value disagrees with effective "
+                "directory state"
+            ),
+        ),
+    )
+    for attack, expected in attacks:
+        assert_configure_rejected(
+            cmake,
+            source,
+            workdir / f"rejected-deferred-{attack}",
+            real_compiler,
+            [f"-DDEAC_FIXTURE_LATE_ATTACK={attack}"],
+            expected,
+        )
+
+
+def test_parent_deferred_seal_rejection(
+    cmake, ninja, solver_source, workdir, real_compiler
+):
+    source = workdir / "parent-mutation-source"
+    create_parent_mutation_fixture_source(solver_source, source)
+    attacks = (
+        ("launcher", [], "CXX_COMPILER_LAUNCHER"),
+        (
+            "build-type",
+            ["-DDEAC_FIXTURE_PARENT_MUTATION=build-type"],
+            "generator configuration state changed after registration",
+        ),
+        (
+            "configuration-list",
+            [
+                "-G",
+                "Ninja Multi-Config",
+                f"-DCMAKE_MAKE_PROGRAM={ninja}",
+                "-DCMAKE_CONFIGURATION_TYPES=Debug;Release",
+                "-DDEAC_FIXTURE_PARENT_MUTATION=configuration-list",
+            ],
+            "generator configuration state changed after registration",
+        ),
+    )
+    for name, arguments, expected in attacks:
+        assert_configure_rejected(
+            cmake,
+            source,
+            workdir / f"rejected-parent-mutation-{name}",
+            real_compiler,
+            arguments,
+            expected,
+        )
+
+
+def test_subdirectory_dependency_directory_attribution(
+    cmake, source, workdir, real_compiler
+):
+    normal_build = workdir / "subdirectory-dependency-normal"
+    configure(
+        cmake,
+        source,
+        normal_build,
+        real_compiler,
+        "-G",
+        "Unix Makefiles",
+        "-DDEAC_FIXTURE_SUBDIRECTORY_DEPENDENCY_MODE=normal",
+    )
+    # The exported primary refresh output must be directly buildable even when
+    # a recorded dependency was declared in another source directory.  This
+    # specifically guards the Unix Makefiles portability regression that
+    # occurred when the convenience target depended on a generated-source
+    # BYPRODUCT owned by the real consumer's build.make.
+    build(
+        cmake,
+        normal_build,
+        target="deac_fixture_generate_receipt",
+    )
+    receipt_path = (
+        normal_build / "receipt" / "Release" / "build-receipt.json"
+    )
+    refresh_document = parse_receipt(receipt_path)
+    assert_static_dependency(
+        refresh_document, receipt_fingerprint(refresh_document)
+    )
+    if (normal_build / "receipt_probe").exists():
+        raise AssertionError("receipt-only target built the consumer executable")
+    refresh_digest = refresh_document["receipt_sha256"]
+
+    # Building the real consumer must embed the same attributed receipt.
+    build(cmake, normal_build)
+    document = parse_receipt(receipt_path)
+    assert_static_dependency(document, receipt_fingerprint(document))
+    if document["receipt_sha256"] != refresh_digest:
+        raise AssertionError("consumer build changed the refresh-only receipt")
+    assert_embedded_matches(normal_build / "receipt_probe", receipt_path)
+
+    attacks = (
+        ("launcher", "RULE_LAUNCH_COMPILE"),
+        ("rule", "differ from the receipt registration directory"),
+        ("compiler", "CMAKE_CXX_COMPILER"),
+    )
+    for attack, expected in attacks:
+        assert_configure_rejected(
+            cmake,
+            source,
+            workdir / f"rejected-subdirectory-dependency-{attack}",
+            real_compiler,
+            [f"-DDEAC_FIXTURE_SUBDIRECTORY_DEPENDENCY_MODE={attack}"],
+            expected,
+        )
+
+
+def test_dependency_fingerprint_rejections(
+    cmake, source, workdir, real_compiler
+):
+    # First exercise the integration route: registration injects the reserved
+    # macro, then a late target mutation removes it before File API generation.
+    removed_build = workdir / "rejected-dependency-fingerprint-remove"
+    assert_configure_or_build_rejected(
+        cmake,
+        source,
+        removed_build,
+        real_compiler,
+        ["-DDEAC_FIXTURE_DEPENDENCY_FINGERPRINT_ATTACK=remove"],
+        "toolchain fingerprint",
+        target="deac_fixture_generate_receipt",
+    )
+    removed_receipt = (
+        removed_build / "receipt" / "Release" / "build-receipt.json"
+    )
+    if removed_receipt.exists():
+        raise AssertionError("late fingerprint removal produced a receipt")
+
+    # CMake may de-duplicate identical definitions or discard function-style
+    # definitions.  Mutate a fresh reply so every exact-name adversarial shape
+    # reaches the receipt generator independent of generator normalization.
+    reply_build = workdir / "rejected-dependency-fingerprint-replies"
+    configure(
+        cmake,
+        source,
+        reply_build,
+        real_compiler,
+    )
+    target_reply = file_api_target_reply(reply_build, "receipt_dependency")
+    original = json.loads(target_reply.read_text(encoding="utf-8"))
+    fingerprint_name = "DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256"
+    definitions = original["compileGroups"][0]["defines"]
+    fingerprints = [
+        definition
+        for definition in definitions
+        if definition["define"].startswith(f"{fingerprint_name}=")
+    ]
+    if len(fingerprints) != 1:
+        raise AssertionError(
+            f"fixture dependency has unexpected fingerprints: {definitions!r}"
+        )
+
+    mutations = (
+        ("duplicate", fingerprints[0]["define"]),
+        ("conflict", f"{fingerprint_name}=" + "0" * 64),
+        ("function-conflict", f"{fingerprint_name}(x)=bad"),
+        ("spaced-conflict", f"{fingerprint_name} =bad"),
+    )
+    reply_receipt = (
+        reply_build / "receipt" / "Release" / "build-receipt.json"
+    )
+    expected = (
+        "exactly one configured toolchain fingerprint without a duplicate "
+        "or conflicting macro definition"
+    )
+    for name, extra_definition in mutations:
+        document = json.loads(json.dumps(original))
+        document["compileGroups"][0]["defines"].append(
+            {"define": extra_definition}
+        )
+        write(
+            target_reply,
+            json.dumps(document, ensure_ascii=False, separators=(",", ":"))
+            + "\n",
+        )
+        result = build(
+            cmake,
+            reply_build,
+            target="deac_fixture_generate_receipt",
+            check=False,
+        )
+        assert_rejected(result, context=f"{name} fingerprint", expected=expected)
+        if reply_receipt.exists():
+            raise AssertionError(f"{name} fingerprint produced a receipt")
+
+    # Definitions are also present in the effective command fragments.  Edit
+    # the reply directly so compiler- and generator-specific normalization
+    # cannot hide attached, split, or slash-D spellings from this check.
+    original_fragments = original["compileGroups"][0].get(
+        "compileCommandFragments"
+    )
+    if not isinstance(original_fragments, list):
+        raise TypeError("fixture dependency compile fragments are malformed")
+    conflicting_definition = f"{fingerprint_name}=" + "0" * 64
+    fragment_mutations = (
+        ("fragment-d-duplicate", f" -D{fingerprints[0]['define']}"),
+        ("fragment-d-conflict", f" -D{conflicting_definition}"),
+        ("fragment-split-d-duplicate", f" -D {fingerprints[0]['define']}"),
+        ("fragment-split-d-conflict", f" -D {conflicting_definition}"),
+        ("fragment-slash-d-duplicate", f" /D{fingerprints[0]['define']}"),
+        ("fragment-split-slash-d-conflict", f" /D {conflicting_definition}"),
+    )
+    for name, extra_fragment in fragment_mutations:
+        document = json.loads(json.dumps(original))
+        document["compileGroups"][0]["compileCommandFragments"].append(
+            {"fragment": extra_fragment}
+        )
+        write(
+            target_reply,
+            json.dumps(document, ensure_ascii=False, separators=(",", ":"))
+            + "\n",
+        )
+        result = build(
+            cmake,
+            reply_build,
+            target="deac_fixture_generate_receipt",
+            check=False,
+        )
+        assert_rejected(
+            result,
+            context=name,
+            expected="reserved fingerprint fragment conflict",
+        )
+        if reply_receipt.exists():
+            raise AssertionError(f"{name} fingerprint produced a receipt")
+
+    # Identifier-prefix matching must not turn a distinct longer macro into a
+    # false conflict with the reserved fingerprint name in either source of
+    # effective compile definitions.
+    longer_document = json.loads(json.dumps(original))
+    longer_definition = f"{fingerprint_name}_EXTRA=allowed"
+    longer_document["compileGroups"][0]["defines"].append(
+        {"define": longer_definition}
+    )
+    longer_fragments = (
+        f" -D{longer_definition}",
+        f" -D {longer_definition}",
+        f" /D{longer_definition}",
+        f" /D {longer_definition}",
+    )
+    longer_document["compileGroups"][0]["compileCommandFragments"].extend(
+        {"fragment": fragment} for fragment in longer_fragments
+    )
+    write(
+        target_reply,
+        json.dumps(longer_document, ensure_ascii=False, separators=(",", ":"))
+        + "\n",
+    )
+    build(
+        cmake,
+        reply_build,
+        target="deac_fixture_generate_receipt",
+    )
+    document = parse_receipt(reply_receipt)
+    assert_static_dependency(document, receipt_fingerprint(document))
+    dependency = next(
+        entry
+        for entry in document["receipt"]["target_dependencies"]
+        if entry["name"] == "receipt_dependency"
+    )
+    recorded_definitions = [
+        definition
+        for group in dependency["compile_groups"]
+        for definition in group["definitions"]
+    ]
+    if longer_definition not in recorded_definitions:
+        raise AssertionError("longer fingerprint-like definition was discarded")
+    recorded_fragments = [
+        fragment["fragment"]
+        for group in dependency["compile_groups"]
+        for fragment in group["command_fragments"]
+    ]
+    missing_fragments = [
+        fragment
+        for fragment in longer_fragments
+        if fragment not in recorded_fragments
+    ]
+    if missing_fragments:
+        raise AssertionError(
+            "longer fingerprint-like command fragments were discarded: "
+            f"{missing_fragments!r}"
+        )
+
+
+def test_json_control_encoding(cmake, source, workdir, real_compiler):
+    controls = (
+        ("escape", chr(0x1B), b"\\u001b"),
+        ("vertical-tab", chr(0x0B), b"\\u000b"),
+    )
+    for name, control, encoded in controls:
+        build_directory = workdir / f"json-control-{name}"
+        configure_result = configure(
+            cmake,
+            source,
+            build_directory,
+            real_compiler,
+            f"-DDEAC_FIXTURE_CONTROL_CACHE:STRING=before{control}after",
+        )
+        build_result = build(cmake, build_directory)
+        output = diagnostic_text(configure_result) + diagnostic_text(build_result)
+        if control in output:
+            raise AssertionError(
+                f"{name} control was copied into a build-receipt diagnostic"
+            )
+        receipt_path = (
+            build_directory / "receipt" / "Release" / "build-receipt.json"
+        )
+        raw_receipt = receipt_path.read_bytes()
+        if control.encode() in raw_receipt:
+            raise AssertionError(
+                f"{name} control was copied raw into build-receipt JSON"
+            )
+        if encoded not in raw_receipt:
+            raise AssertionError(
+                f"{name} control did not use canonical lowercase JSON escaping"
+            )
+        document = parse_receipt(receipt_path)
+        if cache_value(document, "DEAC_FIXTURE_CONTROL_CACHE") != (
+            f"before{control}after"
+        ):
+            raise AssertionError(f"{name} cache control did not round-trip")
+        assert_embedded_matches(build_directory / "receipt_probe", receipt_path)
+
+
+def file_api_target_reply(build_directory, target_name):
+    reply_directory = build_directory / ".cmake" / "api" / "v1" / "reply"
+    indices = sorted(reply_directory.glob("index-*.json"))
+    if not indices:
+        raise AssertionError("configured fixture has no File API index")
+    index = json.loads(indices[-1].read_text(encoding="utf-8"))
+    codemodel_reference = index["reply"]["codemodel-v2"]
+    codemodel = json.loads(
+        (reply_directory / codemodel_reference["jsonFile"]).read_text(
+            encoding="utf-8"
+        )
+    )
+    target_references = [
+        target
+        for configuration in codemodel["configurations"]
+        for target in configuration["targets"]
+        if target["name"] == target_name
+    ]
+    if len(target_references) != 1:
+        raise AssertionError(
+            f"expected one {target_name} File API target, got "
+            f"{target_references!r}"
+        )
+    return reply_directory / target_references[0]["jsonFile"]
+
+
+def file_api_toolchains_reply(build_directory):
+    reply_directory = build_directory / ".cmake" / "api" / "v1" / "reply"
+    indices = sorted(reply_directory.glob("index-*.json"))
+    if not indices:
+        raise AssertionError("configured fixture has no File API index")
+    index = json.loads(indices[-1].read_text(encoding="utf-8"))
+    reference = index["reply"].get("toolchains-v1")
+    if not isinstance(reference, dict) or not isinstance(
+        reference.get("jsonFile"), str
+    ):
+        raise AssertionError(
+            f"fixture toolchains reference is malformed: {reference!r}"
+        )
+    return reply_directory / reference["jsonFile"]
+
+
+def cxx_toolchain(document):
+    matches = [
+        toolchain
+        for toolchain in document.get("toolchains", [])
+        if toolchain.get("language") == "CXX"
+    ]
+    if len(matches) != 1 or not isinstance(matches[0].get("compiler"), dict):
+        raise AssertionError(f"fixture CXX toolchain is malformed: {matches!r}")
+    return matches[0]
+
+
+def test_file_api_shape_rejections(cmake, source, workdir, real_compiler):
+    build_directory = workdir / "rejected-file-api-shapes"
+    configure(cmake, source, build_directory, real_compiler)
+    target_reply = file_api_target_reply(build_directory, "receipt_probe")
+    original = json.loads(target_reply.read_text(encoding="utf-8"))
+
+    malformed_documents = []
+    missing_compile_groups = json.loads(json.dumps(original))
+    missing_compile_groups.pop("compileGroups", None)
+    malformed_documents.append(
+        ("missing compileGroups", missing_compile_groups, "has no compile groups")
+    )
+    wrong_compile_groups = json.loads(json.dumps(original))
+    wrong_compile_groups["compileGroups"] = {}
+    malformed_documents.append(
+        (
+            "malformed compileGroups",
+            wrong_compile_groups,
+            "compile groups must be an array",
+        )
+    )
+    malformed_optional_parent = json.loads(json.dumps(original))
+    malformed_optional_parent.setdefault("link", {})["sysroot"] = "not-an-object"
+    malformed_documents.append(
+        (
+            "malformed optional link.sysroot",
+            malformed_optional_parent,
+            "link sysroot is malformed",
+        )
+    )
+
+    receipt_path = (
+        build_directory / "receipt" / "Release" / "build-receipt.json"
+    )
+    for name, document, expected in malformed_documents:
+        write(
+            target_reply,
+            json.dumps(document, ensure_ascii=False, separators=(",", ":"))
+            + "\n",
+        )
+        result = build(
+            cmake,
+            build_directory,
+            target="deac_fixture_generate_receipt",
+            check=False,
+        )
+        assert_rejected(
+            result,
+            context=name,
+            expected=expected,
+        )
+        if receipt_path.exists():
+            raise AssertionError(f"{name} produced a build receipt")
+
+    # CMake's JSON decoder can materialize a semantic NUL from a valid escape.
+    # Exercise the raw reply scanner directly, with adjacent UTF-8 text proving
+    # that this is byte-parity validation rather than an ASCII-only shortcut.
+    semantic_nul_document = json.loads(json.dumps(original))
+    semantic_nul_document["deacRawJsonProbe"] = "pré\x00后"
+    semantic_nul_json = (
+        json.dumps(
+            semantic_nul_document,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    if "\\u0000" not in semantic_nul_json or "\\\\u0000" in semantic_nul_json:
+        raise AssertionError("semantic NUL fixture does not use one JSON escape")
+    write(target_reply, semantic_nul_json)
+    result = build(
+        cmake,
+        build_directory,
+        target="deac_fixture_generate_receipt",
+        check=False,
+    )
+    assert_rejected(result, context="semantic JSON NUL", expected="NUL")
+    if receipt_path.exists():
+        raise AssertionError("semantic JSON NUL produced a build receipt")
+
+    # Two source backslashes encode string data containing the literal
+    # characters backslash-u0000.  That is not a semantic NUL and must remain
+    # accepted by the raw scanner.
+    literal_escape_document = json.loads(json.dumps(original))
+    literal_escape_document["deacRawJsonProbe"] = "pré\\u0000后"
+    literal_escape_json = (
+        json.dumps(
+            literal_escape_document,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    if "\\\\u0000" not in literal_escape_json:
+        raise AssertionError(
+            "literal backslash-u0000 fixture does not use an even escape"
+        )
+    write(target_reply, literal_escape_json)
+    build(
+        cmake,
+        build_directory,
+        target="deac_fixture_generate_receipt",
+    )
+    document = parse_receipt(receipt_path)
+    assert_static_dependency(document, receipt_fingerprint(document))
+
+    write(
+        target_reply,
+        json.dumps(original, ensure_ascii=False, separators=(",", ":")) + "\n",
+    )
+
+
+def test_compiler_target_reply_rejections(
+    cmake, source, workdir, real_compiler
+):
+    target_result = run([real_compiler, "-dumpmachine"], source)
+    configured_target = target_result.stdout.strip()
+    if (
+        not configured_target
+        or len(target_result.stdout.splitlines()) != 1
+        or any(character.isspace() for character in configured_target)
+    ):
+        raise AssertionError(
+            f"compiler returned an unsafe target triple: {target_result.stdout!r}"
+        )
+
+    present_build = workdir / "compiler-target-present"
+    configure(
+        cmake,
+        source,
+        present_build,
+        real_compiler,
+        f"-DCMAKE_CXX_COMPILER_TARGET:STRING={configured_target}",
+    )
+    present_reply = file_api_toolchains_reply(present_build)
+    present_original = json.loads(present_reply.read_text(encoding="utf-8"))
+    present_compiler = cxx_toolchain(present_original)["compiler"]
+    if present_compiler.get("target") != configured_target:
+        raise AssertionError("File API omitted the configured compiler target")
+    present_receipt = (
+        present_build / "receipt" / "Release" / "build-receipt.json"
+    )
+    for name, replacement in (("missing", None), ("mismatch", "-mismatch")):
+        document = json.loads(json.dumps(present_original))
+        compiler = cxx_toolchain(document)["compiler"]
+        if replacement is None:
+            compiler.pop("target")
+        else:
+            compiler["target"] = configured_target + replacement
+        write(
+            present_reply,
+            json.dumps(document, ensure_ascii=False, separators=(",", ":"))
+            + "\n",
+        )
+        result = build(
+            cmake,
+            present_build,
+            target="deac_fixture_generate_receipt",
+            check=False,
+        )
+        assert_rejected(
+            result,
+            context=f"{name} configured compiler target",
+            expected=(
+                "CXX compiler target disagrees with configure-time identity"
+            ),
+        )
+        if present_receipt.exists():
+            raise AssertionError(f"{name} compiler target produced a receipt")
+
+    write(
+        present_reply,
+        json.dumps(present_original, ensure_ascii=False, separators=(",", ":"))
+        + "\n",
+    )
+    build(cmake, present_build, target="deac_fixture_generate_receipt")
+    present_document = parse_receipt(present_receipt)
+    recorded_target = next(
+        toolchain["compiler"]["target"]
+        for toolchain in present_document["receipt"]["toolchains"]
+        if toolchain["language"] == "CXX"
+    )
+    if recorded_target != configured_target:
+        raise AssertionError("receipt changed the configured compiler target")
+
+    absent_build = workdir / "compiler-target-absent"
+    configure(cmake, source, absent_build, real_compiler)
+    absent_reply = file_api_toolchains_reply(absent_build)
+    absent_document = json.loads(absent_reply.read_text(encoding="utf-8"))
+    absent_compiler = cxx_toolchain(absent_document)["compiler"]
+    if "target" in absent_compiler:
+        raise AssertionError("fixture compiler unexpectedly has a target field")
+    absent_compiler["target"] = configured_target
+    write(
+        absent_reply,
+        json.dumps(absent_document, ensure_ascii=False, separators=(",", ":"))
+        + "\n",
+    )
+    result = build(
+        cmake,
+        absent_build,
+        target="deac_fixture_generate_receipt",
+        check=False,
+    )
+    assert_rejected(
+        result,
+        context="unexpected compiler target",
+        expected="CXX compiler target disagrees with configure-time identity",
+    )
+    absent_receipt = (
+        absent_build / "receipt" / "Release" / "build-receipt.json"
+    )
+    if absent_receipt.exists():
+        raise AssertionError("unexpected compiler target produced a receipt")
 
 
 def test_rule_override_rejections(
@@ -888,8 +3165,19 @@ def test_rule_override_rejections(
         ("link-or", "CMAKE_CXX_LINK_EXECUTABLE"),
         ("archive-pipe", "CMAKE_CXX_ARCHIVE_CREATE"),
         ("compile-semicolon", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("escaped-semicolon", "CMAKE_CXX_COMPILE_OBJECT"),
         ("compile-dollar-paren", "CMAKE_CXX_COMPILE_OBJECT"),
         ("compile-backtick", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("escaped-backtick", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("compile-dollar-variable", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("quoted-dollar", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("escaped-dollar", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("compile-glob", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("compile-redirection", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("compile-comment", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("compile-process-substitution", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("link-dollar-variable", "CMAKE_CXX_LINK_EXECUTABLE"),
+        ("archive-glob", "CMAKE_CXX_ARCHIVE_CREATE"),
     ]
     for attack, expected in project_rule_attacks:
         assert_configure_rejected(
@@ -901,9 +3189,15 @@ def test_rule_override_rejections(
             expected,
         )
 
-    # A literal operator inside a quoted or escaped argument remains one
-    # represented command and must not be confused with active shell control.
-    for accepted in ("quoted-pipe", "quoted-semicolon", "escaped-semicolon"):
+    # These protected operators survive both CMake's build-file generation and
+    # POSIX shell parsing as one literal argument.
+    for accepted in (
+        "quoted-pipe",
+        "quoted-semicolon",
+        "quoted-backtick",
+        "quoted-glob",
+        "escaped-glob",
+    ):
         accepted_build = workdir / f"accepted-{accepted}"
         configure(
             cmake,
@@ -913,6 +3207,19 @@ def test_rule_override_rejections(
             f"-DDEAC_FIXTURE_RULE_ATTACK={accepted}",
         )
         build(cmake, accepted_build)
+
+    quoted_backtick_ninja = workdir / "accepted-quoted-backtick-ninja"
+    configure(
+        cmake,
+        source,
+        quoted_backtick_ninja,
+        real_compiler,
+        "-G",
+        "Ninja",
+        f"-DCMAKE_MAKE_PROGRAM={ninja}",
+        "-DDEAC_FIXTURE_RULE_ATTACK=quoted-backtick",
+    )
+    build(cmake, quoted_backtick_ninja)
 
     assert_configure_rejected(
         cmake,
@@ -1015,6 +3322,9 @@ def main():
     compiler_shim = workdir / "compiler-shim"
     create_fixture_source(solver_source, source)
 
+    test_single_config_configuration_rejections(
+        args.cmake, source, workdir, real_compiler
+    )
     test_single_config_refresh_and_replacement(
         args.cmake, source, workdir, compiler_shim, real_compiler
     )
@@ -1022,6 +3332,9 @@ def main():
         args.cmake, ninja, source, workdir, real_compiler
     )
     test_material_flag_reconfiguration(
+        args.cmake, source, workdir, real_compiler
+    )
+    test_backend_reconfiguration(
         args.cmake, source, workdir, real_compiler
     )
     test_archive_tool_reconfiguration(
@@ -1032,6 +3345,60 @@ def main():
     )
     test_parallel_receipt_consumers(
         args.cmake, ninja, solver_source, workdir, real_compiler
+    )
+    test_shared_dependency_receipt_consumers(
+        args.cmake, ninja, solver_source, workdir, real_compiler
+    )
+    test_nested_build_root_canonicalization(
+        args.cmake, ninja, solver_source, workdir, real_compiler
+    )
+    test_mapped_hipblas_multi_config(
+        args.cmake, ninja, solver_source, workdir, real_compiler
+    )
+    test_selected_config_provider_collision(
+        args.cmake, ninja, solver_source, workdir, real_compiler
+    )
+    test_configless_mapped_hipblas(
+        args.cmake, ninja, source, workdir, real_compiler
+    )
+    test_hipblas_receipt_contract(
+        args.cmake, ninja, source, workdir, real_compiler
+    )
+    test_hipblas_receipt_rejections(
+        args.cmake, source, workdir, real_compiler
+    )
+    test_control_byte_link_artifact_rejections(
+        args.cmake, source, workdir, real_compiler
+    )
+    test_effective_shell_input_rejections(
+        args.cmake, source, workdir, real_compiler
+    )
+    test_deferred_seal_rejections(
+        args.cmake, source, workdir, real_compiler
+    )
+    test_parent_deferred_seal_rejection(
+        args.cmake, ninja, solver_source, workdir, real_compiler
+    )
+    test_subdirectory_dependency_directory_attribution(
+        args.cmake, source, workdir, real_compiler
+    )
+    test_dependency_fingerprint_rejections(
+        args.cmake, source, workdir, real_compiler
+    )
+    test_json_control_encoding(
+        args.cmake, source, workdir, real_compiler
+    )
+    test_file_api_shape_rejections(
+        args.cmake, source, workdir, real_compiler
+    )
+    test_compiler_target_reply_rejections(
+        args.cmake, source, workdir, real_compiler
+    )
+    test_hidden_receipt_config_rejection(
+        args.cmake, ninja, source, workdir, real_compiler
+    )
+    test_output_path_symlink_rejections(
+        args.cmake, source, workdir, real_compiler
     )
     test_rule_override_rejections(
         args.cmake, ninja, source, workdir, real_compiler

--- a/test/deac_build_receipt_fixture_test.py
+++ b/test/deac_build_receipt_fixture_test.py
@@ -149,15 +149,32 @@ elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "archive-pipe")
     string(APPEND CMAKE_CXX_ARCHIVE_CREATE
         " | \\\"${CMAKE_COMMAND}\\\" -E true")
 elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "quoted-pipe")
-    string(APPEND CMAKE_CXX_COMPILE_OBJECT " \\\"literal|argument\\\"")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " \\\"-DDEAC_RULE_LITERAL=literal|argument\\\"")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "compile-semicolon")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT " ; deac_receipt_attack")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "quoted-semicolon")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " \\\"-DDEAC_RULE_LITERAL=literal\\\\;argument\\\"")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "escaped-semicolon")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT
+        " -DDEAC_RULE_LITERAL=literal\\\\\\\\;argument")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "compile-dollar-paren")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT " $(deac_receipt_attack)")
+elseif(DEAC_FIXTURE_RULE_ATTACK STREQUAL "compile-backtick")
+    string(APPEND CMAKE_CXX_COMPILE_OBJECT " `deac_receipt_attack`")
 elseif(NOT DEAC_FIXTURE_RULE_ATTACK STREQUAL "")
     message(FATAL_ERROR "unknown fixture rule attack")
 endif()
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/DeacBuildReceipt.cmake")
 if(DEAC_FIXTURE_NATIVE_LANGUAGE_SHAPE MATCHES "^(CUDA|HIP)$")
-    _deac_build_receipt_reject_unsupported_languages(
-        CXX "${DEAC_FIXTURE_NATIVE_LANGUAGE_SHAPE}")
+    # Native toolchains are unavailable in this fixture environment.  Shape
+    # the internal query, then exercise the normal target integration below.
+    function(_deac_build_receipt_query_enabled_languages output)
+        set(${output}
+            "CXX;${DEAC_FIXTURE_NATIVE_LANGUAGE_SHAPE}" PARENT_SCOPE)
+    endfunction()
 elseif(NOT DEAC_FIXTURE_NATIVE_LANGUAGE_SHAPE STREQUAL "")
     message(FATAL_ERROR "invalid native language shape")
 endif()
@@ -205,10 +222,11 @@ def compiler_shim_contents(real_compiler, marker):
     )
 
 
-def archive_shim_contents(real_archiver, marker):
+def archive_shim_contents(real_archiver, marker, invocation_log):
     return (
         "#!/bin/sh\n"
         f"# receipt fixture archiver marker: {marker}\n"
+        f"printf '%s\\n' \"$*\" >> {shlex.quote(str(invocation_log))}\n"
         f"exec {shlex.quote(str(real_archiver))} \"$@\"\n"
     )
 
@@ -523,7 +541,12 @@ def test_material_flag_reconfiguration(cmake, source, workdir, real_compiler):
         raise AssertionError("material flags unexpectedly changed the tool fingerprint")
     if cache_value(changed_receipt, "CMAKE_CXX_FLAGS") != flag:
         raise AssertionError("material flag is absent from the receipt cache")
-    if flag not in json.dumps(changed_receipt, separators=(",", ":")):
+    effective_compile_fragments = [
+        fragment["fragment"]
+        for group in changed_receipt["receipt"]["compile_groups"]
+        for fragment in group["command_fragments"]
+    ]
+    if not any(flag in fragment for fragment in effective_compile_fragments):
         raise AssertionError("material flag is absent from effective command data")
     assert_no_git_source(changed_receipt, "1.2.4")
     assert_embedded_matches(build_directory / "receipt_probe", receipt_path)
@@ -536,14 +559,16 @@ def test_archive_tool_reconfiguration(
     tool_directory = workdir / "archive-tools"
     ar_one = tool_directory / "ar-one"
     ar_two = tool_directory / "ar-two"
+    ar_one_log = tool_directory / "ar-one.invocations"
+    ar_two_log = tool_directory / "ar-two.invocations"
     write(
         ar_one,
-        archive_shim_contents(real_archiver, "one"),
+        archive_shim_contents(real_archiver, "one", ar_one_log),
         executable=True,
     )
     write(
         ar_two,
-        archive_shim_contents(real_archiver, "two"),
+        archive_shim_contents(real_archiver, "two", ar_two_log),
         executable=True,
     )
 
@@ -557,8 +582,18 @@ def test_archive_tool_reconfiguration(
     first_build = build(cmake, build_directory)
     assert_build_actions(
         first_build,
-        [str(ar_one), "Linking CXX static library libreceipt_dependency.a"],
+        [
+            f"{ar_one} qc libreceipt_dependency.a",
+            "Linking CXX static library libreceipt_dependency.a",
+        ],
     )
+    if not ar_one_log.is_file() or not any(
+        invocation.startswith("qc libreceipt_dependency.a ")
+        for invocation in ar_one_log.read_text(encoding="utf-8").splitlines()
+    ):
+        raise AssertionError("ar-one did not create the fixture static archive")
+    if ar_two_log.exists():
+        raise AssertionError("ar-two ran before the archiver reconfiguration")
     receipt_path = build_directory / "receipt" / "Release" / "build-receipt.json"
     first_receipt = parse_receipt(receipt_path)
     first_ar = archive_tool(first_receipt, "CMAKE_AR")
@@ -570,7 +605,7 @@ def test_archive_tool_reconfiguration(
 
     write(
         ar_one,
-        archive_shim_contents(real_archiver, "tampered"),
+        archive_shim_contents(real_archiver, "tampered", ar_one_log),
         executable=True,
     )
     rejected = build(cmake, build_directory, check=False)
@@ -594,12 +629,17 @@ def test_archive_tool_reconfiguration(
     assert_build_actions(
         second_build,
         [
-            str(ar_two),
+            f"{ar_two} qc libreceipt_dependency.a",
             "dependency.cpp.o",
             "Linking CXX static library libreceipt_dependency.a",
             "Linking CXX executable receipt_probe",
         ],
     )
+    if not ar_two_log.is_file() or not any(
+        invocation.startswith("qc libreceipt_dependency.a ")
+        for invocation in ar_two_log.read_text(encoding="utf-8").splitlines()
+    ):
+        raise AssertionError("ar-two did not recreate the fixture static archive")
     second_receipt = parse_receipt(receipt_path)
     second_ar = archive_tool(second_receipt, "CMAKE_AR")
     if second_ar["path"] != str(ar_two) or second_ar["sha256"] != sha256_file(ar_two):
@@ -847,6 +887,9 @@ def test_rule_override_rejections(
         ("compile-and", "CMAKE_CXX_COMPILE_OBJECT"),
         ("link-or", "CMAKE_CXX_LINK_EXECUTABLE"),
         ("archive-pipe", "CMAKE_CXX_ARCHIVE_CREATE"),
+        ("compile-semicolon", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("compile-dollar-paren", "CMAKE_CXX_COMPILE_OBJECT"),
+        ("compile-backtick", "CMAKE_CXX_COMPILE_OBJECT"),
     ]
     for attack, expected in project_rule_attacks:
         assert_configure_rejected(
@@ -858,15 +901,18 @@ def test_rule_override_rejections(
             expected,
         )
 
-    # A literal operator inside a quoted argument remains one represented
-    # command and must not be confused with an active shell pipeline.
-    configure(
-        cmake,
-        source,
-        workdir / "accepted-quoted-pipe",
-        real_compiler,
-        "-DDEAC_FIXTURE_RULE_ATTACK=quoted-pipe",
-    )
+    # A literal operator inside a quoted or escaped argument remains one
+    # represented command and must not be confused with active shell control.
+    for accepted in ("quoted-pipe", "quoted-semicolon", "escaped-semicolon"):
+        accepted_build = workdir / f"accepted-{accepted}"
+        configure(
+            cmake,
+            source,
+            accepted_build,
+            real_compiler,
+            f"-DDEAC_FIXTURE_RULE_ATTACK={accepted}",
+        )
+        build(cmake, accepted_build)
 
     assert_configure_rejected(
         cmake,

--- a/test/deac_build_receipt_fixture_test.py
+++ b/test/deac_build_receipt_fixture_test.py
@@ -2003,11 +2003,24 @@ def test_nested_build_root_canonicalization(
 ):
     source = workdir / "nested-build-source"
     create_fixture_source(solver_source, source)
+    # Cover a two-byte ASCII component and a two-byte UTF-8 code point.
+    source_prefixes = [
+        source / "src" / component / "prefix"
+        for component in ("ab", "é")
+    ]
+    for prefix in source_prefixes:
+        prefix.mkdir(parents=True)
     receipts = []
     for suffix in ("a", "b"):
         # Put the build inside CMAKE_SOURCE_DIR so both canonical roots match;
         # BUILD_ROOT must win as the more-specific containing root.
         build_directory = source / "src" / f"nested-build-{suffix}"
+        build_prefixes = [
+            build_directory / component / "prefix"
+            for component in ("xy", "ü")
+        ]
+        for prefix in build_prefixes:
+            prefix.mkdir(parents=True)
         configure(
             cmake,
             source,
@@ -2016,6 +2029,8 @@ def test_nested_build_root_canonicalization(
             "-G",
             "Ninja",
             f"-DCMAKE_MAKE_PROGRAM={ninja}",
+            "-DCMAKE_PREFIX_PATH="
+            + ";".join(str(path) for path in source_prefixes + build_prefixes),
         )
         build(cmake, build_directory)
         receipt_path = (
@@ -2034,6 +2049,20 @@ def test_nested_build_root_canonicalization(
             raise AssertionError(
                 "nested generated source did not prefer the most-specific "
                 f"build root: {generated_sources!r}"
+            )
+        cache_entries = {
+            entry["name"]: entry["value"]
+            for entry in document["receipt"]["cache_entries"]
+        }
+        expected_prefix_path = (
+            "<SOURCE_ROOT>/ab/prefix;<SOURCE_ROOT>/é/prefix;"
+            "<BUILD_ROOT>/xy/prefix;<BUILD_ROOT>/ü/prefix"
+        )
+        if cache_entries.get("CMAKE_PREFIX_PATH") != expected_prefix_path:
+            raise AssertionError(
+                "two-byte path components were not tokenized against the "
+                "most-specific canonical root: "
+                f"{cache_entries.get('CMAKE_PREFIX_PATH')!r}"
             )
         receipts.append(receipt_path.read_bytes())
     if receipts[0] != receipts[1]:

--- a/test/deac_build_receipt_test.py
+++ b/test/deac_build_receipt_test.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 TOP_LEVEL_KEYS = ["schema_version", "receipt_sha256", "receipt"]
 RECEIPT_KEYS = [
+    "archive_tools",
     "backend",
     "build_system",
     "cache_entries",
@@ -149,6 +150,31 @@ def validate_receipt(
     expected_dependency_target,
 ):
     receipt = document["receipt"]
+    archive_tools = receipt["archive_tools"]
+    if not isinstance(archive_tools, list):
+        raise TypeError("archive tools must be a list")
+    archive_tool_names = []
+    for tool in archive_tools:
+        if list(tool) != ["name", "path", "real_path", "sha256"]:
+            raise AssertionError(f"noncanonical archive tool: {tool!r}")
+        for key in ("name", "path", "real_path", "sha256"):
+            assert_string(tool[key], f"archive tool {key}")
+        archive_tool_names.append(tool["name"])
+        if not is_sha256(tool["sha256"]):
+            raise AssertionError("archive tool digest is not lowercase SHA-256")
+        if not tool["real_path"].startswith("<"):
+            if (
+                not tool["path"].startswith("<")
+                and Path(tool["path"]).resolve() != Path(tool["real_path"])
+            ):
+                raise AssertionError("archive tool path and real path disagree")
+            if sha256_file(tool["real_path"]) != tool["sha256"]:
+                raise AssertionError("archive tool digest disagrees with current bytes")
+    if archive_tool_names != ["CMAKE_AR", "CMAKE_RANLIB"]:
+        raise AssertionError(
+            f"unexpected archive tool identities: {archive_tool_names!r}"
+        )
+
     if receipt["backend"] != expected_backend:
         raise AssertionError(
             f"receipt backend {receipt['backend']!r} != {expected_backend!r}"

--- a/test/deac_build_receipt_test.py
+++ b/test/deac_build_receipt_test.py
@@ -1,0 +1,342 @@
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+TOP_LEVEL_KEYS = ["schema_version", "receipt_sha256", "receipt"]
+RECEIPT_KEYS = [
+    "backend",
+    "build_system",
+    "cache_entries",
+    "compile_groups",
+    "link",
+    "source_identity",
+    "target",
+    "target_dependencies",
+    "toolchains",
+]
+SOURCE_IDENTITY_KEYS = [
+    "schema_version",
+    "semantic_version",
+    "source_sha",
+    "source_state",
+]
+
+
+def run(command, cwd, *, check=True):
+    result = subprocess.run(
+        [str(part) for part in command],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"command failed with exit {result.returncode}: {command}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def canonical_json(value):
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def parse_receipt(raw):
+    try:
+        document = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise AssertionError(f"invalid build-receipt JSON: {raw!r}") from error
+    if list(document) != TOP_LEVEL_KEYS:
+        raise AssertionError(
+            f"expected ordered receipt keys {TOP_LEVEL_KEYS}, got {list(document)}"
+        )
+    if document["schema_version"] != 1:
+        raise AssertionError(f"unsupported build-receipt schema: {document!r}")
+    receipt = document["receipt"]
+    if list(receipt) != RECEIPT_KEYS:
+        raise AssertionError(
+            f"expected ordered payload keys {RECEIPT_KEYS}, got {list(receipt)}"
+        )
+    expected_digest = hashlib.sha256(canonical_json(receipt).encode()).hexdigest()
+    if document["receipt_sha256"] != expected_digest:
+        raise AssertionError(
+            "build-receipt digest does not bind its canonical payload: "
+            f"expected {expected_digest}, got {document['receipt_sha256']}"
+        )
+    expected_raw = canonical_json(document) + "\n"
+    if raw != expected_raw:
+        raise AssertionError("build receipt is valid JSON but not canonical")
+    return document
+
+
+def assert_string(value, label, *, nonempty=True):
+    if not isinstance(value, str) or (nonempty and not value):
+        raise AssertionError(f"{label} must be a string")
+
+
+def is_sha256(value):
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def validate_compile_groups(compile_groups, *, label, fingerprint=None):
+    if not isinstance(compile_groups, list) or not compile_groups:
+        raise AssertionError(f"{label} has no effective compile groups")
+    compiled_sources = []
+    used_languages = set()
+    for group in compile_groups:
+        if list(group) != [
+            "command_fragments",
+            "definitions",
+            "frameworks",
+            "includes",
+            "language",
+            "language_standard",
+            "precompiled_headers",
+            "sources",
+            "sysroot",
+        ]:
+            raise AssertionError(f"noncanonical {label} compile group: {group!r}")
+        assert_string(group["language"], f"{label} compile language")
+        used_languages.add(group["language"])
+        if not isinstance(group["command_fragments"], list):
+            raise TypeError(f"{label} compile fragments must be a list")
+        for fragment in group["command_fragments"]:
+            assert_string(
+                fragment.get("fragment"),
+                f"{label} compile fragment",
+                nonempty=False,
+            )
+            if fragment.get("role") is not None:
+                assert_string(fragment["role"], f"{label} compile fragment role")
+        if not isinstance(group["definitions"], list):
+            raise TypeError(f"{label} definitions must be a list")
+        if fingerprint is not None:
+            expected = f"DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256={fingerprint}"
+            if group["definitions"].count(expected) != 1:
+                raise AssertionError(
+                    f"{label} compile group does not bind the toolchain fingerprint"
+                )
+        if not isinstance(group["sources"], list) or not group["sources"]:
+            raise AssertionError(f"{label} compile group has no sources")
+        compiled_sources.extend(group["sources"])
+    return compiled_sources, used_languages
+
+
+def validate_receipt(
+    document,
+    *,
+    exe,
+    build_dir,
+    source_dir,
+    expected_backend,
+    expected_target,
+    expected_dependency_target,
+):
+    receipt = document["receipt"]
+    if receipt["backend"] != expected_backend:
+        raise AssertionError(
+            f"receipt backend {receipt['backend']!r} != {expected_backend!r}"
+        )
+    target = receipt["target"]
+    if list(target) != [
+        "name",
+        "name_on_disk",
+        "toolchain_fingerprint_sha256",
+        "type",
+    ]:
+        raise AssertionError(f"noncanonical target receipt: {target!r}")
+    if (
+        target["name"] != expected_target
+        or target["name_on_disk"] != exe.name
+        or target["type"] != "EXECUTABLE"
+    ):
+        raise AssertionError(f"unexpected target receipt: {target!r}")
+    fingerprint = target["toolchain_fingerprint_sha256"]
+    if not is_sha256(fingerprint):
+        raise AssertionError("target toolchain fingerprint is not lowercase SHA-256")
+
+    source_identity = receipt["source_identity"]
+    if list(source_identity) != SOURCE_IDENTITY_KEYS:
+        raise AssertionError(f"noncanonical source identity: {source_identity!r}")
+    identity = run([exe, "--build-identity"], exe.parent)
+    if identity.stderr:
+        raise AssertionError(f"--build-identity wrote to stderr: {identity.stderr!r}")
+    if json.loads(identity.stdout) != source_identity:
+        raise AssertionError("build receipt and embedded source identity disagree")
+
+    build_system = receipt["build_system"]
+    assert_string(build_system.get("configuration"), "configuration")
+    generator = build_system.get("generator")
+    if not isinstance(generator, dict) or not isinstance(
+        generator.get("multi_config"), bool
+    ):
+        raise TypeError("receipt generator metadata is malformed")
+    assert_string(generator.get("name"), "generator name")
+    cmake = build_system.get("cmake")
+    if not isinstance(cmake, dict):
+        raise TypeError("receipt CMake identity is malformed")
+    for key in ("path", "real_path", "sha256", "version"):
+        assert_string(cmake.get(key), f"CMake {key}")
+    if Path(cmake["path"]).resolve() != Path(cmake["real_path"]):
+        raise AssertionError("receipt CMake path and real path disagree")
+    if sha256_file(cmake["real_path"]) != cmake["sha256"]:
+        raise AssertionError("receipt CMake digest disagrees with current bytes")
+
+    cache_entries = receipt["cache_entries"]
+    if not isinstance(cache_entries, list) or not cache_entries:
+        raise AssertionError("receipt cache entries must be a nonempty list")
+    names = [entry.get("name") for entry in cache_entries]
+    if names != sorted(set(names)):
+        raise AssertionError("receipt cache entries are not unique and sorted")
+    for entry in cache_entries:
+        if list(entry) != ["name", "type", "value"]:
+            raise AssertionError(f"noncanonical cache entry: {entry!r}")
+        assert_string(entry["name"], "cache entry name")
+        if (entry["type"] is None) != (entry["value"] is None):
+            raise AssertionError(f"partial cache entry: {entry!r}")
+        if entry["type"] is not None:
+            assert_string(entry["type"], "cache entry type")
+            assert_string(entry["value"], "cache entry value", nonempty=False)
+    backend_entries = [entry for entry in cache_entries if entry["name"] == "GPU_BACKEND"]
+    if len(backend_entries) != 1 or backend_entries[0]["value"] != expected_backend:
+        raise AssertionError("receipt cache does not bind the selected backend")
+    home_entries = [
+        entry for entry in cache_entries if entry["name"] == "CMAKE_HOME_DIRECTORY"
+    ]
+    if len(home_entries) != 1 or home_entries[0]["value"] != "<SOURCE_ROOT>":
+        raise AssertionError("CMake source root was not canonicalized in the cache")
+
+    compiled_sources, used_languages = validate_compile_groups(
+        receipt["compile_groups"], label="target", fingerprint=fingerprint
+    )
+    if not any(source.endswith("/deac/src/deac.cpp") for source in compiled_sources):
+        raise AssertionError("receipt does not bind the primary solver source")
+    if not any(source.endswith("_build_receipt.cpp") for source in compiled_sources):
+        raise AssertionError("receipt does not include its embedded receipt object")
+
+    dependencies = receipt["target_dependencies"]
+    if not isinstance(dependencies, list) or len(dependencies) != 1:
+        raise AssertionError("receipt must bind its one direct target dependency")
+    dependency = dependencies[0]
+    if list(dependency) != ["archive", "compile_groups", "link", "name", "type"]:
+        raise AssertionError(f"noncanonical target dependency: {dependency!r}")
+    if dependency["name"] != expected_dependency_target:
+        raise AssertionError(f"unexpected target dependency: {dependency!r}")
+    if dependency["type"] != "OBJECT_LIBRARY":
+        raise AssertionError(f"unexpected dependency target type: {dependency!r}")
+    if dependency["archive"] is not None or dependency["link"] is not None:
+        raise AssertionError("identity object dependency unexpectedly archives or links")
+    dependency_sources, dependency_languages = validate_compile_groups(
+        dependency["compile_groups"], label="dependency"
+    )
+    used_languages.update(dependency_languages)
+    if not any(source.endswith("/deac/src/build_identity.cpp") for source in dependency_sources):
+        raise AssertionError("receipt does not bind the embedded identity object source")
+
+    link = receipt["link"]
+    if list(link) != ["command_fragments", "language", "lto", "sysroot"]:
+        raise AssertionError(f"noncanonical link receipt: {link!r}")
+    assert_string(link["language"], "link language")
+    used_languages.add(link["language"])
+    if not isinstance(link["lto"], bool) or not isinstance(
+        link["command_fragments"], list
+    ):
+        raise TypeError("link receipt has invalid types")
+
+    toolchains = receipt["toolchains"]
+    if not isinstance(toolchains, list) or not toolchains:
+        raise AssertionError("receipt has no bound toolchain")
+    toolchain_languages = []
+    for toolchain in toolchains:
+        if list(toolchain) != ["compiler", "language"]:
+            raise AssertionError(f"noncanonical toolchain: {toolchain!r}")
+        language = toolchain["language"]
+        assert_string(language, "toolchain language")
+        toolchain_languages.append(language)
+        compiler = toolchain["compiler"]
+        for key in ("id", "path", "real_path", "sha256", "version"):
+            assert_string(compiler.get(key), f"compiler {key}")
+        if not is_sha256(compiler["sha256"]):
+            raise AssertionError("compiler digest is not lowercase SHA-256")
+        if not compiler["real_path"].startswith("<"):
+            if Path(compiler["path"]).resolve() != Path(compiler["real_path"]):
+                raise AssertionError("compiler path and real path disagree")
+            if sha256_file(compiler["real_path"]) != compiler["sha256"]:
+                raise AssertionError("compiler digest disagrees with current bytes")
+    if toolchain_languages != sorted(set(toolchain_languages)):
+        raise AssertionError("toolchains are not unique and sorted")
+    if set(toolchain_languages) != used_languages:
+        raise AssertionError("receipt does not bind every effective language toolchain")
+    if str(build_dir.resolve()) in canonical_json(document):
+        raise AssertionError("receipt leaked its relocatable build-tree pathname")
+    if str(source_dir.resolve()) in canonical_json(document):
+        raise AssertionError("receipt leaked its relocatable source-tree pathname")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exe", required=True)
+    parser.add_argument("--receipt", required=True)
+    parser.add_argument("--build-dir", required=True)
+    parser.add_argument("--source-dir", required=True)
+    parser.add_argument("--workdir", required=True)
+    parser.add_argument("--cmake", required=True)
+    parser.add_argument("--expected-backend", required=True)
+    parser.add_argument("--expected-target", required=True)
+    parser.add_argument("--expected-dependency-target", required=True)
+    parser.add_argument("--build-config")
+    args = parser.parse_args()
+
+    exe = Path(args.exe).resolve()
+    receipt_path = Path(args.receipt).resolve()
+    first = run([exe, "--build-receipt"], exe.parent)
+    second = run([exe, "--build-receipt"], exe.parent)
+    if first.stderr or second.stderr:
+        raise AssertionError("--build-receipt must not write to stderr")
+    if first.stdout != second.stdout:
+        raise AssertionError("repeated --build-receipt output changed")
+    if receipt_path.read_text(encoding="utf-8") != first.stdout:
+        raise AssertionError("adjacent and embedded build receipts differ byte-for-byte")
+    document = parse_receipt(first.stdout)
+    validate_receipt(
+        document,
+        exe=exe,
+        build_dir=Path(args.build_dir),
+        source_dir=Path(args.source_dir),
+        expected_backend=args.expected_backend,
+        expected_target=args.expected_target,
+        expected_dependency_target=args.expected_dependency_target,
+    )
+
+    workdir = Path(args.workdir)
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    install_prefix = workdir / "install"
+    command = [args.cmake, "--install", args.build_dir, "--prefix", install_prefix]
+    if args.build_config is not None:
+        command.extend(["--config", args.build_config])
+    run(command, args.build_dir)
+    installed = install_prefix / "bin" / exe.name
+    installed_receipt = run([installed, "--build-receipt"], installed.parent)
+    if installed_receipt.stdout != first.stdout or installed_receipt.stderr:
+        raise AssertionError("installed executable did not retain its embedded receipt")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/deac_build_receipt_test.py
+++ b/test/deac_build_receipt_test.py
@@ -1,6 +1,8 @@
 import argparse
 import hashlib
 import json
+import os
+import shlex
 import shutil
 import subprocess
 from pathlib import Path
@@ -27,6 +29,15 @@ SOURCE_IDENTITY_KEYS = [
 INVALID_NORMALIZATION_DEFINITION = (
     "DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS=1"
 )
+POISON_GPU_FITNESS_DEFINITION = "DEAC_TEST_POISON_GPU_FITNESS=1"
+HIPBLAS_CACHE_KEYS = {
+    "CMAKE_DISABLE_FIND_PACKAGE_hipblas",
+    "DEAC_HIPBLAS_INCLUDE_DIR",
+    "DEAC_HIPBLAS_LIBRARY",
+    "HIP_RUNTIME_INCLUDE_DIR",
+    "hipblas_DIR",
+    "hipblas_ROOT",
+}
 
 
 def run(command, cwd, *, check=True):
@@ -55,6 +66,103 @@ def sha256_file(path):
 
 def canonical_json(value):
     return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def normalized_absolute_native_arguments(fragment):
+    if os.name != "posix":
+        raise AssertionError(
+            "native-command link-fragment validation requires POSIX shell syntax"
+        )
+    try:
+        arguments = shlex.split(fragment, posix=True)
+    except ValueError as error:
+        raise AssertionError(
+            f"invalid native-command link fragment: {fragment!r}"
+        ) from error
+    return [
+        os.path.normpath(argument)
+        for argument in arguments
+        if os.path.isabs(argument)
+    ]
+
+
+def validate_expected_link_library(command_fragments, expected_link_library):
+    library_arguments = [
+        argument
+        for fragment in command_fragments
+        if fragment["role"] == "libraries"
+        for argument in normalized_absolute_native_arguments(fragment["fragment"])
+    ]
+    if expected_link_library is None:
+        return library_arguments
+    if not os.path.isabs(expected_link_library):
+        raise AssertionError(
+            "expected link-library path must be absolute: "
+            f"{expected_link_library!r}"
+        )
+    expected_library = os.path.normpath(expected_link_library)
+    if library_arguments.count(expected_library) != 1:
+        raise AssertionError(
+            "HIP+BLAS receipt must contain its resolved provider library "
+            f"exactly once; expected {expected_link_library!r}, got "
+            f"normalized absolute arguments {library_arguments!r}"
+        )
+    return library_arguments
+
+
+def validate_native_link_fragment_regression():
+    fixture_root = os.path.abspath("native link fragment fixture")
+    provider = os.path.join(fixture_root, "provider archives", "libprovider.a")
+    decoys = [
+        os.path.join(fixture_root, "libhipblas-decoy-one.a"),
+        os.path.join(fixture_root, "libhipblas-decoy-two.a"),
+    ]
+    fragments = [
+        {
+            "fragment": f"{shlex.quote(provider)} {shlex.quote(decoys[0])}",
+            "role": "libraries",
+        },
+        {"fragment": shlex.quote(decoys[1]), "role": "libraries"},
+    ]
+    observed = validate_expected_link_library(fragments, provider)
+    expected = [os.path.normpath(path) for path in (provider, *decoys)]
+    if observed != expected:
+        raise AssertionError(
+            "native-command link-fragment regression: expected "
+            f"{expected!r}, got {observed!r}"
+        )
+    if validate_expected_link_library(fragments, None) != expected:
+        raise AssertionError(
+            "native-command link-fragment regression changed the no-provider case"
+        )
+
+    rejection_cases = [
+        (
+            "missing",
+            fragments,
+            os.path.join(fixture_root, "provider archives", "missing-provider.a"),
+        ),
+        (
+            "duplicate",
+            [
+                *fragments,
+                {"fragment": shlex.quote(provider), "role": "libraries"},
+            ],
+            provider,
+        ),
+    ]
+    for label, rejected_fragments, rejected_provider in rejection_cases:
+        try:
+            validate_expected_link_library(rejected_fragments, rejected_provider)
+        except AssertionError as error:
+            if "exactly once" not in str(error):
+                raise AssertionError(
+                    f"native-command {label} regression failed unexpectedly"
+                ) from error
+        else:
+            raise AssertionError(
+                f"native-command link-fragment regression accepted {label} provider"
+            )
 
 
 def parse_receipt(raw):
@@ -104,6 +212,7 @@ def validate_compile_groups(
     label,
     fingerprint=None,
     expect_invalid_normalization_definition=False,
+    expect_poison_gpu_fitness_definition=False,
 ):
     if not isinstance(compile_groups, list) or not compile_groups:
         raise AssertionError(f"{label} has no effective compile groups")
@@ -136,18 +245,21 @@ def validate_compile_groups(
                 assert_string(fragment["role"], f"{label} compile fragment role")
         if not isinstance(group["definitions"], list):
             raise TypeError(f"{label} definitions must be a list")
-        expected_invalid_definition_count = (
-            1 if expect_invalid_normalization_definition else 0
-        )
-        if (
-            group["definitions"].count(INVALID_NORMALIZATION_DEFINITION)
-            != expected_invalid_definition_count
-        ):
-            expectation = "exactly once" if expected_invalid_definition_count else "never"
-            raise AssertionError(
-                f"{label} compile group must contain the test-only invalid "
-                f"normalization definition {expectation}"
-            )
+        expected_test_definitions = {
+            INVALID_NORMALIZATION_DEFINITION: (
+                1 if expect_invalid_normalization_definition else 0
+            ),
+            POISON_GPU_FITNESS_DEFINITION: (
+                1 if expect_poison_gpu_fitness_definition else 0
+            ),
+        }
+        for definition, expected_count in expected_test_definitions.items():
+            if group["definitions"].count(definition) != expected_count:
+                expectation = "exactly once" if expected_count else "never"
+                raise AssertionError(
+                    f"{label} compile group must contain the test-only "
+                    f"definition {definition} {expectation}"
+                )
         if fingerprint is not None:
             expected = f"DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256={fingerprint}"
             observed_fingerprints = [
@@ -178,7 +290,9 @@ def validate_receipt(
     expected_backend,
     expected_target,
     expected_dependency_target,
+    expected_link_library,
     expect_invalid_normalization_definition,
+    expect_poison_gpu_fitness_definition,
 ):
     receipt = document["receipt"]
     archive_tools = receipt["archive_tools"]
@@ -278,6 +392,12 @@ def validate_receipt(
     ]
     if len(home_entries) != 1 or home_entries[0]["value"] != "<SOURCE_ROOT>":
         raise AssertionError("CMake source root was not canonicalized in the cache")
+    missing_hipblas_keys = HIPBLAS_CACHE_KEYS.difference(names)
+    if missing_hipblas_keys:
+        raise AssertionError(
+            "receipt omits material HIP/hipBLAS cache keys: "
+            f"{sorted(missing_hipblas_keys)!r}"
+        )
 
     compiled_sources, used_languages = validate_compile_groups(
         receipt["compile_groups"],
@@ -286,6 +406,9 @@ def validate_receipt(
         expect_invalid_normalization_definition=(
             expect_invalid_normalization_definition
         ),
+        expect_poison_gpu_fitness_definition=(
+            expect_poison_gpu_fitness_definition
+        ),
     )
     if not any(source.endswith("/deac/src/deac.cpp") for source in compiled_sources):
         raise AssertionError("receipt does not bind the primary solver source")
@@ -293,25 +416,59 @@ def validate_receipt(
         raise AssertionError("receipt does not include its embedded receipt object")
 
     dependencies = receipt["target_dependencies"]
-    if not isinstance(dependencies, list) or len(dependencies) != 1:
-        raise AssertionError("receipt must bind its one direct target dependency")
-    dependency = dependencies[0]
-    if list(dependency) != ["archive", "compile_groups", "link", "name", "type"]:
-        raise AssertionError(f"noncanonical target dependency: {dependency!r}")
-    if dependency["name"] != expected_dependency_target:
-        raise AssertionError(f"unexpected target dependency: {dependency!r}")
-    if dependency["type"] != "OBJECT_LIBRARY":
-        raise AssertionError(f"unexpected dependency target type: {dependency!r}")
+    if not isinstance(dependencies, list):
+        raise TypeError("receipt target dependencies must be a list")
+    dependency_names = [dependency.get("name") for dependency in dependencies]
+    if dependency_names != sorted(set(dependency_names)):
+        raise AssertionError("receipt dependencies are not unique and sorted")
+    expected_dependencies = {expected_dependency_target: "OBJECT_LIBRARY"}
+    if expected_link_library is not None:
+        expected_dependencies["deac_hipblas_link_contract"] = "INTERFACE_LIBRARY"
+    if set(dependency_names) != set(expected_dependencies):
+        raise AssertionError(
+            "receipt dependency names changed: expected "
+            f"{sorted(expected_dependencies)!r}, got {dependency_names!r}"
+        )
+    dependency_by_name = {
+        dependency["name"]: dependency for dependency in dependencies
+    }
+    for dependency_name, dependency_type in expected_dependencies.items():
+        dependency = dependency_by_name[dependency_name]
+        if list(dependency) != [
+            "archive",
+            "compile_groups",
+            "link",
+            "name",
+            "type",
+        ]:
+            raise AssertionError(f"noncanonical target dependency: {dependency!r}")
+        if dependency["type"] != dependency_type:
+            raise AssertionError(f"unexpected dependency target type: {dependency!r}")
+
+    dependency = dependency_by_name[expected_dependency_target]
     if dependency["archive"] is not None or dependency["link"] is not None:
         raise AssertionError("identity object dependency unexpectedly archives or links")
     dependency_sources, dependency_languages = validate_compile_groups(
         dependency["compile_groups"],
         label="dependency",
         fingerprint=fingerprint,
+        expect_invalid_normalization_definition=False,
+        expect_poison_gpu_fitness_definition=False,
     )
     used_languages.update(dependency_languages)
     if not any(source.endswith("/deac/src/build_identity.cpp") for source in dependency_sources):
         raise AssertionError("receipt does not bind the embedded identity object source")
+    if expected_link_library is not None:
+        interface_dependency = dependency_by_name["deac_hipblas_link_contract"]
+        if (
+            interface_dependency["archive"] is not None
+            or interface_dependency["compile_groups"] != []
+            or interface_dependency["link"] is not None
+        ):
+            raise AssertionError(
+                "hipBLAS interface dependency has nonempty build artifacts: "
+                f"{interface_dependency!r}"
+            )
 
     link = receipt["link"]
     if list(link) != ["command_fragments", "language", "lto", "sysroot"]:
@@ -322,6 +479,15 @@ def validate_receipt(
         link["command_fragments"], list
     ):
         raise TypeError("link receipt has invalid types")
+    for fragment in link["command_fragments"]:
+        if list(fragment) != ["fragment", "role"]:
+            raise AssertionError(f"noncanonical link fragment: {fragment!r}")
+        assert_string(fragment["fragment"], "link fragment", nonempty=False)
+        if fragment["role"] is not None:
+            assert_string(fragment["role"], "link fragment role")
+    validate_expected_link_library(
+        link["command_fragments"], expected_link_library
+    )
 
     toolchains = receipt["toolchains"]
     if not isinstance(toolchains, list) or not toolchains:
@@ -362,7 +528,9 @@ def validate_receipt_endpoint(
     expected_backend,
     expected_target,
     expected_dependency_target,
+    expected_link_library,
     expect_invalid_normalization_definition,
+    expect_poison_gpu_fitness_definition,
 ):
     first = run([exe, "--build-receipt"], exe.parent)
     second = run([exe, "--build-receipt"], exe.parent)
@@ -381,14 +549,19 @@ def validate_receipt_endpoint(
         expected_backend=expected_backend,
         expected_target=expected_target,
         expected_dependency_target=expected_dependency_target,
+        expected_link_library=expected_link_library,
         expect_invalid_normalization_definition=(
             expect_invalid_normalization_definition
+        ),
+        expect_poison_gpu_fitness_definition=(
+            expect_poison_gpu_fitness_definition
         ),
     )
     return first.stdout
 
 
 def main():
+    validate_native_link_fragment_regression()
     parser = argparse.ArgumentParser()
     parser.add_argument("--exe", required=True)
     parser.add_argument("--receipt", required=True)
@@ -399,6 +572,7 @@ def main():
     parser.add_argument("--expected-backend", required=True)
     parser.add_argument("--expected-target", required=True)
     parser.add_argument("--expected-dependency-target", required=True)
+    parser.add_argument("--expected-link-library")
     parser.add_argument("--helper-exe")
     parser.add_argument("--helper-receipt")
     parser.add_argument("--expected-helper-target")
@@ -428,7 +602,9 @@ def main():
         expected_backend=args.expected_backend,
         expected_target=args.expected_target,
         expected_dependency_target=args.expected_dependency_target,
+        expected_link_library=args.expected_link_library,
         expect_invalid_normalization_definition=False,
+        expect_poison_gpu_fitness_definition=False,
     )
     if args.helper_exe is not None:
         validate_receipt_endpoint(
@@ -439,7 +615,9 @@ def main():
             expected_backend=args.expected_backend,
             expected_target=args.expected_helper_target,
             expected_dependency_target=args.expected_dependency_target,
+            expected_link_library=args.expected_link_library,
             expect_invalid_normalization_definition=True,
+            expect_poison_gpu_fitness_definition=(args.expected_backend != "none"),
         )
 
     workdir = Path(args.workdir)

--- a/test/deac_build_receipt_test.py
+++ b/test/deac_build_receipt_test.py
@@ -24,6 +24,9 @@ SOURCE_IDENTITY_KEYS = [
     "source_sha",
     "source_state",
 ]
+INVALID_NORMALIZATION_DEFINITION = (
+    "DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS=1"
+)
 
 
 def run(command, cwd, *, check=True):
@@ -95,7 +98,13 @@ def is_sha256(value):
     )
 
 
-def validate_compile_groups(compile_groups, *, label, fingerprint=None):
+def validate_compile_groups(
+    compile_groups,
+    *,
+    label,
+    fingerprint=None,
+    expect_invalid_normalization_definition=False,
+):
     if not isinstance(compile_groups, list) or not compile_groups:
         raise AssertionError(f"{label} has no effective compile groups")
     compiled_sources = []
@@ -127,11 +136,32 @@ def validate_compile_groups(compile_groups, *, label, fingerprint=None):
                 assert_string(fragment["role"], f"{label} compile fragment role")
         if not isinstance(group["definitions"], list):
             raise TypeError(f"{label} definitions must be a list")
+        expected_invalid_definition_count = (
+            1 if expect_invalid_normalization_definition else 0
+        )
+        if (
+            group["definitions"].count(INVALID_NORMALIZATION_DEFINITION)
+            != expected_invalid_definition_count
+        ):
+            expectation = "exactly once" if expected_invalid_definition_count else "never"
+            raise AssertionError(
+                f"{label} compile group must contain the test-only invalid "
+                f"normalization definition {expectation}"
+            )
         if fingerprint is not None:
             expected = f"DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256={fingerprint}"
-            if group["definitions"].count(expected) != 1:
+            observed_fingerprints = [
+                definition
+                for definition in group["definitions"]
+                if definition.startswith(
+                    "DEAC_BUILD_TOOLCHAIN_FINGERPRINT_SHA256="
+                )
+            ]
+            if observed_fingerprints != [expected]:
                 raise AssertionError(
-                    f"{label} compile group does not bind the toolchain fingerprint"
+                    f"{label} compile group must bind exactly one expected "
+                    "toolchain fingerprint; observed "
+                    f"{observed_fingerprints!r}"
                 )
         if not isinstance(group["sources"], list) or not group["sources"]:
             raise AssertionError(f"{label} compile group has no sources")
@@ -148,6 +178,7 @@ def validate_receipt(
     expected_backend,
     expected_target,
     expected_dependency_target,
+    expect_invalid_normalization_definition,
 ):
     receipt = document["receipt"]
     archive_tools = receipt["archive_tools"]
@@ -249,7 +280,12 @@ def validate_receipt(
         raise AssertionError("CMake source root was not canonicalized in the cache")
 
     compiled_sources, used_languages = validate_compile_groups(
-        receipt["compile_groups"], label="target", fingerprint=fingerprint
+        receipt["compile_groups"],
+        label="target",
+        fingerprint=fingerprint,
+        expect_invalid_normalization_definition=(
+            expect_invalid_normalization_definition
+        ),
     )
     if not any(source.endswith("/deac/src/deac.cpp") for source in compiled_sources):
         raise AssertionError("receipt does not bind the primary solver source")
@@ -269,7 +305,9 @@ def validate_receipt(
     if dependency["archive"] is not None or dependency["link"] is not None:
         raise AssertionError("identity object dependency unexpectedly archives or links")
     dependency_sources, dependency_languages = validate_compile_groups(
-        dependency["compile_groups"], label="dependency"
+        dependency["compile_groups"],
+        label="dependency",
+        fingerprint=fingerprint,
     )
     used_languages.update(dependency_languages)
     if not any(source.endswith("/deac/src/build_identity.cpp") for source in dependency_sources):
@@ -315,22 +353,17 @@ def validate_receipt(
         raise AssertionError("receipt leaked its relocatable source-tree pathname")
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--exe", required=True)
-    parser.add_argument("--receipt", required=True)
-    parser.add_argument("--build-dir", required=True)
-    parser.add_argument("--source-dir", required=True)
-    parser.add_argument("--workdir", required=True)
-    parser.add_argument("--cmake", required=True)
-    parser.add_argument("--expected-backend", required=True)
-    parser.add_argument("--expected-target", required=True)
-    parser.add_argument("--expected-dependency-target", required=True)
-    parser.add_argument("--build-config")
-    args = parser.parse_args()
-
-    exe = Path(args.exe).resolve()
-    receipt_path = Path(args.receipt).resolve()
+def validate_receipt_endpoint(
+    *,
+    exe,
+    receipt_path,
+    build_dir,
+    source_dir,
+    expected_backend,
+    expected_target,
+    expected_dependency_target,
+    expect_invalid_normalization_definition,
+):
     first = run([exe, "--build-receipt"], exe.parent)
     second = run([exe, "--build-receipt"], exe.parent)
     if first.stderr or second.stderr:
@@ -343,12 +376,71 @@ def main():
     validate_receipt(
         document,
         exe=exe,
+        build_dir=build_dir,
+        source_dir=source_dir,
+        expected_backend=expected_backend,
+        expected_target=expected_target,
+        expected_dependency_target=expected_dependency_target,
+        expect_invalid_normalization_definition=(
+            expect_invalid_normalization_definition
+        ),
+    )
+    return first.stdout
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exe", required=True)
+    parser.add_argument("--receipt", required=True)
+    parser.add_argument("--build-dir", required=True)
+    parser.add_argument("--source-dir", required=True)
+    parser.add_argument("--workdir", required=True)
+    parser.add_argument("--cmake", required=True)
+    parser.add_argument("--expected-backend", required=True)
+    parser.add_argument("--expected-target", required=True)
+    parser.add_argument("--expected-dependency-target", required=True)
+    parser.add_argument("--helper-exe")
+    parser.add_argument("--helper-receipt")
+    parser.add_argument("--expected-helper-target")
+    parser.add_argument("--build-config")
+    args = parser.parse_args()
+
+    helper_arguments = (
+        args.helper_exe,
+        args.helper_receipt,
+        args.expected_helper_target,
+    )
+    if any(argument is not None for argument in helper_arguments) and not all(
+        argument is not None for argument in helper_arguments
+    ):
+        parser.error(
+            "--helper-exe, --helper-receipt, and --expected-helper-target "
+            "must be provided together"
+        )
+
+    exe = Path(args.exe).resolve()
+    receipt_path = Path(args.receipt).resolve()
+    embedded_receipt = validate_receipt_endpoint(
+        exe=exe,
+        receipt_path=receipt_path,
         build_dir=Path(args.build_dir),
         source_dir=Path(args.source_dir),
         expected_backend=args.expected_backend,
         expected_target=args.expected_target,
         expected_dependency_target=args.expected_dependency_target,
+        expect_invalid_normalization_definition=False,
     )
+    if args.helper_exe is not None:
+        validate_receipt_endpoint(
+            exe=Path(args.helper_exe).resolve(),
+            receipt_path=Path(args.helper_receipt).resolve(),
+            build_dir=Path(args.build_dir),
+            source_dir=Path(args.source_dir),
+            expected_backend=args.expected_backend,
+            expected_target=args.expected_helper_target,
+            expected_dependency_target=args.expected_dependency_target,
+            expect_invalid_normalization_definition=True,
+        )
 
     workdir = Path(args.workdir)
     if workdir.exists():
@@ -360,7 +452,7 @@ def main():
     run(command, args.build_dir)
     installed = install_prefix / "bin" / exe.name
     installed_receipt = run([installed, "--build-receipt"], installed.parent)
-    if installed_receipt.stdout != first.stdout or installed_receipt.stderr:
+    if installed_receipt.stdout != embedded_receipt or installed_receipt.stderr:
         raise AssertionError("installed executable did not retain its embedded receipt")
 
 


### PR DESCRIPTION
## Summary

- emit a canonical schema-1 receipt from the effective CMake File API target graph and bind it into each solver executable
- attest clean source identity, exact compiler/CMake/archive-tool bytes, compile groups, link inputs, dependencies, backend, generator/configuration, and material cache state
- fail closed on stale reconfiguration, unsupported rule shapes, ambiguous providers, unsafe paths, configuration collisions, and receipt/fingerprint conflicts
- reject known explicit routes whose input bytes schema 1 cannot bind: response files, forced includes, PCH/modules/header units, config/specs, VFS overlays, plugins, tool redirects, and compiler/offload/link forwarding
- canonicalize ASCII and UTF-8 two-byte path components correctly
- give the 146-subcase build-receipt integration fixture a 600-second per-test CTest timeout while ordinary tests retain caller timeouts
- support CPU and real SYCL builds now while retaining representable CUDA/HIP fields without making unvalidated release claims

## Stack and tracking

This PR is intentionally stacked on #52, after #50 and #51. The receipt graph consumes the accelerator correctness and hipBLAS contract changes from that stack.

Closes #42.

Superproject integration remains tracked by nscottnichols/deac-cpp-project#23. Runtime loader/library/device closure is separately tracked by nscottnichols/deac-cpp-project#37. Compiler default-config/specs/environment/helper closure is tracked by nscottnichols/deac-cpp-project#39. Schema 1 binds the exact compiler artifact and declared explicit graph; it is not a hermetic compiler-execution transcript.

## Exact candidate

Head: `1d0c34b5d3ac83ffd66a1244a2b05addf7bc21de`

- receipt feature `cf76084a18a6d8ff44063f1f55f72db65be99ddc`; binary commit-diff SHA-256 `ed23ac7713f47fbb83402c477667127ce8353ab20f7c08352aeb4a047dd9b79b`
- path canonicalization `0bca09bdc433e750c3d17874c80fbd8190c20e28`; binary commit-diff SHA-256 `1200a8f279369048255744d438a3028e6d5bfeab6a39f5f6be2ca239c41fb103`
- explicit-input hardening `568da11404eb9236274834bf0f9478270a1921eb`; binary commit-diff SHA-256 `18a59d7f9a8ea622b7e982e40c2f8e977e86d1f1002412ca9cede1990c016fcc`
- fixture timeout `1d0c34b5d3ac83ffd66a1244a2b05addf7bc21de`; binary commit-diff SHA-256 `18cb187d50f58779a660571abe88905569a968d3221037964bb557a2b0b5e663`
- cumulative binary diff from #52 head `f6a6b65756fb9e53d4ef5e519b4a32a5bb5714dc`; SHA-256 `87ecdae157486e7e9bb443e09a0de0607e7b68f47c519c81cdac01b6ef091f6f`

## Validation at final head

- producer File API fixture matrix: 146 subcases passed
- IntelLLVM 2026.1 detailed-balance CPU Release: 73/73 CTests; receipt `f95c39ebc6faac40770d2de99831755af008938e984c96e2be097c6eaa2d0dfc`; executable `524b64ac36c13d487f22e1efad3092ffa5867c29a5f18ae2a8ba31d57f415e0c`
- IntelLLVM 2026.1 SYCL Release on Intel Data Center GPU Max 1550 through Level Zero: 76/76 CTests, including GPU tests and explicit CPU-reference parity; receipt `3672741215f1bdbc363e7668a4d32db237f4ddab8c82f351d439c40dfa8f4611`; executable `cf1347629bd1e0cbfd83a4f0b32e836bcac5a086363f9cdfe5d5902b18dddcd5`
- GCC 14.2 Release: 73/73 CTests
- GCC 14.2 Debug ASan+UBSan: 73/73 CTests with leak/error halting and no sanitizer finding
- superproject consumer: 710 passed, 1 intentional gated skip; focused adapter hardening 170 passed; real CPU and real SYCL adapter execution passed
- final normalized SYCL prediction remained byte-identical to both earlier accepted runs

The original feature received three independent exact-checksum adversarial reviews. The final producer/consumer hardening and complete CPU/SYCL evidence received a separate publication review with no material finding.