### PR TITLE
feat: expose first-moment uncertainty

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,13 @@ the incumbent population or its statistics.
 
 When `--first_moment` is non-negative, it is an active constraint, including
 the valid target value zero. The fitness contribution is
-`((candidate_first_moment - target_first_moment) / 1.0)^2` on every backend.
-The unit standard deviation is fixed because the CLI does not yet expose a
-first-moment uncertainty; negative `--first_moment` values disable the
-constraint.
+`((candidate_first_moment - target_first_moment) / first_moment_error)^2` on
+every backend. `--first_moment_error` is a standard deviation, defaults to
+`1.0` for backward compatibility, and must be finite and strictly positive
+when the constraint is active. Negative `--first_moment` values disable the
+constraint; explicitly supplying `--first_moment_error` in that state is
+rejected rather than silently ignored. The effective uncertainty is recorded
+in the run log whenever the constraint is active.
 	
 The general recommendation is to generate several spectra using different seeds (`--seed`) and average the final results. A sample bash script to generate a command file with multiple seeds can be found in the tools directory `tools/generate_commands.sh`.
 	

--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -739,6 +739,7 @@ if(Python3_Interpreter_FOUND)
             normalize_nonfinite_target
             missing_isf
             positive_isf_single_particle
+            bad_first_moment_error
             bad_third_moment_error
             bad_crossover_probability
             bad_self_adapting_crossover_probability

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -167,7 +167,8 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         double * const isf, double * const isf_error, double * frequency,
         double temperature, size_t number_of_generations, size_t number_of_timeslices, size_t population_size,
         size_t genome_size, bool normalize, bool use_negative_first_moment, 
-        double first_moment, double third_moment, double third_moment_error,
+        double first_moment, double first_moment_error,
+        double third_moment, double third_moment_error,
         double crossover_probability,
         double self_adapting_crossover_probability,
         double differential_weight, 
@@ -585,11 +586,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         #endif
     #endif
 
-    // The CLI does not yet expose an uncertainty for the first moment. Use a
-    // unit standard deviation consistently on every backend until it does.
-    constexpr double first_moment_error = 1.0;
     if (use_first_moment) {
-        std::cout << "WARNING: setting first_moment_error to 1.0." << std::endl;
         first_moments_term_positive_frequency = (double*) malloc(bytes_first_moments_term);
         #ifdef DEAC_TWO_SIDED_POPULATION
             first_moments_term_negative_frequency = (double*) malloc(bytes_first_moments_term);
@@ -2097,6 +2094,12 @@ int deac_main (int argc, char *argv[]) {
         .help("Set first frequency moment and use in fitness function.")
         .default_value(-1.0)
         .action([](const std::string& value) { return std::stod(value); });
+    program.add_argument("--first_moment_error")
+        .help("Set the finite, positive standard deviation for an active "
+              "first frequency moment. Defaults to 1.0 and must not be "
+              "supplied when first_moment is negative.")
+        .default_value(1.0)
+        .action([](const std::string& value) { return std::stod(value); });
     program.add_argument("--third_moment")
         .help("Set third frequency moment and use in fitness function.")
         .default_value(-1.0)
@@ -2175,6 +2178,23 @@ int deac_main (int argc, char *argv[]) {
                 stop_minimum_fitness});
     } catch (const std::invalid_argument& error) {
         fail_with_error(error.what());
+    }
+
+    double first_moment = program.get<double>("--first_moment");
+    double first_moment_error = program.get<double>("--first_moment_error");
+    if (!std::isfinite(first_moment)) {
+        fail_with_error("first_moment must be finite");
+    }
+    if (first_moment >= 0.0
+            && (!std::isfinite(first_moment_error)
+                || first_moment_error <= 0.0)) {
+        fail_with_error(
+                "first_moment_error must be finite and positive when "
+                "first_moment is used");
+    }
+    if (first_moment < 0.0 && program.is_used("--first_moment_error")) {
+        fail_with_error(
+                "--first_moment_error requires an active --first_moment");
     }
 
     std::string uuid_str = program.get<std::string>("--uuid");
@@ -2312,12 +2332,8 @@ int deac_main (int argc, char *argv[]) {
                     "bosonic detailed-balance build");
         }
     #endif
-    double first_moment = program.get<double>("--first_moment");
     double third_moment = program.get<double>("--third_moment");
     double third_moment_error = program.get<double>("--third_moment_error");
-    if (!std::isfinite(first_moment)) {
-        fail_with_error("first_moment must be finite");
-    }
     if (!std::isfinite(third_moment)) {
         fail_with_error("third_moment must be finite");
     }
@@ -2346,8 +2362,8 @@ int deac_main (int argc, char *argv[]) {
 
     deac( &rng, imaginary_time, isf, isf_error, frequency, temperature,
             number_of_generations, number_of_timeslices, population_size, genome_size,
-            normalize, use_negative_first_moment, first_moment, third_moment,
-            third_moment_error, crossover_probability,
+            normalize, use_negative_first_moment, first_moment, first_moment_error,
+            third_moment, third_moment_error, crossover_probability,
             self_adapting_crossover_probability, differential_weight,
             self_adapting_differential_weight_probability,
             stop_minimum_fitness,

--- a/test/deac_first_moment_fitness_test.py
+++ b/test/deac_first_moment_fitness_test.py
@@ -26,6 +26,7 @@ def run_zero_target(
     detailed_balance,
     zero_temperature,
     run_label=None,
+    first_moment_error=None,
 ):
     save_dir = workdir / f"results-{run_label or seed}"
     command = [
@@ -59,8 +60,10 @@ def run_zero_target(
         seed,
         "--uuid",
         seed,
-        str(fixture),
     ]
+    if first_moment_error is not None:
+        command.extend(["--first_moment_error", first_moment_error])
+    command.append(str(fixture))
     result = subprocess.run(
         command,
         cwd=workdir,
@@ -94,9 +97,21 @@ def run_zero_target(
     log_text = (save_dir / f"{prefix}_log_{seed}.dat").read_text()
     if "first_moment: 0\n" not in log_text:
         raise AssertionError("zero first moment was not recorded as active")
-    if "first_moment_error: 1\n" not in log_text:
-        raise AssertionError("unit first-moment uncertainty was not recorded")
-    return minima[1] < minima[0], minima
+    effective_error = 1.0 if first_moment_error is None else float(first_moment_error)
+    error_lines = [
+        line
+        for line in log_text.splitlines()
+        if line.startswith("first_moment_error: ")
+    ]
+    if len(error_lines) != 1 or float(error_lines[0].split(": ", 1)[1]) != effective_error:
+        raise AssertionError(
+            "effective first-moment uncertainty was not recorded exactly once: "
+            f"expected={effective_error}, lines={error_lines}"
+        )
+    binary_artifacts = {
+        path.name: path.read_bytes() for path in sorted(save_dir.glob("*.bin"))
+    }
+    return minima[1] < minima[0], minima, binary_artifacts
 
 
 def main():
@@ -131,8 +146,10 @@ def main():
 
     accepted_improved_trial = False
     first_minima = None
+    first_artifacts = None
+    unit_runs = {}
     for seed in args.seeds:
-        improved, minima = run_zero_target(
+        improved, minima, artifacts = run_zero_target(
             exe,
             workdir,
             fixture,
@@ -141,14 +158,16 @@ def main():
             args.zero_temperature,
         )
         accepted_improved_trial |= improved
+        unit_runs[seed] = (minima, artifacts)
         if first_minima is None:
             first_minima = minima
+            first_artifacts = artifacts
     if not accepted_improved_trial:
         raise AssertionError(
             "zero first-moment regression did not accept an improved evolved trial"
         )
 
-    _, repeated_minima = run_zero_target(
+    _, repeated_minima, repeated_artifacts = run_zero_target(
         exe,
         workdir,
         fixture,
@@ -157,10 +176,59 @@ def main():
         args.zero_temperature,
         run_label=f"{args.seeds[0]}-repeat",
     )
-    if repeated_minima != first_minima:
+    if repeated_minima != first_minima or repeated_artifacts != first_artifacts:
         raise AssertionError(
             "zero first-moment fitness was not deterministic for a fixed seed: "
             f"first={first_minima}, repeated={repeated_minima}"
+        )
+
+    _, explicit_unit_minima, explicit_unit_artifacts = run_zero_target(
+        exe,
+        workdir,
+        fixture,
+        args.seeds[0],
+        args.detailed_balance,
+        args.zero_temperature,
+        run_label=f"{args.seeds[0]}-explicit-unit",
+        first_moment_error="1.0",
+    )
+    if (
+        explicit_unit_minima != first_minima
+        or explicit_unit_artifacts != first_artifacts
+    ):
+        raise AssertionError(
+            "omitting --first_moment_error did not preserve the unit-error "
+            "fitness and binary artifacts"
+        )
+
+    scaled_improved_trial = False
+    for seed in args.seeds:
+        improved, scaled_minima, _ = run_zero_target(
+            exe,
+            workdir,
+            fixture,
+            seed,
+            args.detailed_balance,
+            args.zero_temperature,
+            run_label=f"{seed}-scaled",
+            first_moment_error="0.25",
+        )
+        if not improved:
+            continue
+        scaled_improved_trial = True
+        unit_minima, _ = unit_runs[seed]
+        if scaled_minima[0] == unit_minima[0]:
+            raise AssertionError(
+                "custom first-moment uncertainty did not affect initial fitness"
+            )
+        if scaled_minima[1] == unit_minima[1]:
+            raise AssertionError(
+                "custom first-moment uncertainty did not affect accepted evolved fitness"
+            )
+    if not scaled_improved_trial:
+        raise AssertionError(
+            "custom first-moment uncertainty regression did not accept an "
+            "improved evolved trial"
         )
 
 

--- a/test/deac_first_moment_fitness_test.py
+++ b/test/deac_first_moment_fitness_test.py
@@ -6,6 +6,9 @@ import struct
 import subprocess
 from pathlib import Path
 
+NUMBER_OF_GENERATIONS = 2
+POPULATION_SIZE = 4
+
 
 def write_doubles(path, values):
     path.write_bytes(struct.pack("<" + "d" * len(values), *values))
@@ -18,6 +21,68 @@ def read_doubles(path):
     return struct.unpack("<" + "d" * (len(data) // 8), data)
 
 
+def reduction_slack(*values):
+    return 64 * math.ulp(max([1.0, *(abs(value) for value in values)]))
+
+
+def materially_less(value, reference):
+    return value < reference - reduction_slack(value, reference)
+
+
+def read_fitness_statistics(save_dir, prefix, seed):
+    statistics = {
+        "minimum": read_doubles(
+            save_dir / f"{prefix}_stats_fitness-minimum_{seed}.bin"
+        ),
+        "mean": read_doubles(save_dir / f"{prefix}_stats_fitness-mean_{seed}.bin"),
+        "squared_mean": read_doubles(
+            save_dir / f"{prefix}_stats_fitness-squared-mean_{seed}.bin"
+        ),
+    }
+    for name, values in statistics.items():
+        if len(values) != NUMBER_OF_GENERATIONS:
+            raise AssertionError(
+                f"{name} must contain initial and evolved values: {values}"
+            )
+        if any(not math.isfinite(value) or value < 0.0 for value in values):
+            raise AssertionError(
+                f"{name} contains a non-finite or negative fitness: {values}"
+            )
+    return statistics
+
+
+def assert_power_of_two_scaling(unit_statistics, scaled_statistics):
+    scales = {"minimum": 16.0, "mean": 16.0, "squared_mean": 256.0}
+    for name, scale in scales.items():
+        for generation, (unit_value, scaled_value) in enumerate(
+            zip(unit_statistics[name], scaled_statistics[name])
+        ):
+            expected = unit_value * scale
+            if abs(scaled_value - expected) > reduction_slack(
+                scaled_value, expected
+            ):
+                raise AssertionError(
+                    "first-moment uncertainty did not scale fitness exactly: "
+                    f"statistic={name}, generation={generation}, "
+                    f"unit={unit_value}, scaled={scaled_value}, "
+                    f"expected={expected}"
+                )
+
+
+def published_spectrum_artifacts(artifacts):
+    selected = {
+        name: data
+        for name, data in artifacts.items()
+        if "_dsf_" in name or "_frequency_" in name
+    }
+    if len(selected) != 2:
+        raise AssertionError(
+            "expected exactly one DSF and frequency artifact: "
+            f"{sorted(selected)}"
+        )
+    return selected
+
+
 def run_zero_target(
     exe,
     workdir,
@@ -27,6 +92,7 @@ def run_zero_target(
     zero_temperature,
     run_label=None,
     first_moment_error=None,
+    use_first_moment=True,
 ):
     save_dir = workdir / f"results-{run_label or seed}"
     command = [
@@ -34,15 +100,13 @@ def run_zero_target(
         "--temperature",
         "0" if zero_temperature else "1",
         "--number_of_generations",
-        "2",
+        str(NUMBER_OF_GENERATIONS),
         "--population_size",
-        "4",
+        str(POPULATION_SIZE),
         "--genome_size",
         "8",
         "--omega_max",
         "4",
-        "--first_moment",
-        "0",
         "--crossover_probability",
         "1",
         "--self_adapting_crossover_probability",
@@ -61,6 +125,8 @@ def run_zero_target(
         "--uuid",
         seed,
     ]
+    if use_first_moment:
+        command.extend(["--first_moment", "0"])
     if first_moment_error is not None:
         command.extend(["--first_moment_error", first_moment_error])
     command.append(str(fixture))
@@ -89,13 +155,9 @@ def run_zero_target(
         if detailed_balance
         else "deac-spfsf"
     )
-    minima = read_doubles(save_dir / f"{prefix}_stats_fitness-minimum_{seed}.bin")
-    if len(minima) != 2 or any(not math.isfinite(value) for value in minima):
-        raise AssertionError(
-            f"seed {seed} produced non-finite initial/evolved fitness: {minima}"
-        )
+    statistics = read_fitness_statistics(save_dir, prefix, seed)
     log_text = (save_dir / f"{prefix}_log_{seed}.dat").read_text()
-    if "first_moment: 0\n" not in log_text:
+    if use_first_moment and "first_moment: 0\n" not in log_text:
         raise AssertionError("zero first moment was not recorded as active")
     effective_error = 1.0 if first_moment_error is None else float(first_moment_error)
     error_lines = [
@@ -103,15 +165,23 @@ def run_zero_target(
         for line in log_text.splitlines()
         if line.startswith("first_moment_error: ")
     ]
-    if len(error_lines) != 1 or float(error_lines[0].split(": ", 1)[1]) != effective_error:
+    if use_first_moment and (
+        len(error_lines) != 1
+        or float(error_lines[0].split(": ", 1)[1]) != effective_error
+    ):
         raise AssertionError(
             "effective first-moment uncertainty was not recorded exactly once: "
             f"expected={effective_error}, lines={error_lines}"
         )
+    if not use_first_moment and error_lines:
+        raise AssertionError(
+            "inactive first-moment control recorded an uncertainty: "
+            f"{error_lines}"
+        )
     binary_artifacts = {
         path.name: path.read_bytes() for path in sorted(save_dir.glob("*.bin"))
     }
-    return minima[1] < minima[0], minima, binary_artifacts
+    return statistics, binary_artifacts
 
 
 def main():
@@ -144,56 +214,46 @@ def main():
     fixture = workdir / "tiny-isf.bin"
     write_doubles(fixture, tau + observed + [0.05, 0.05, 0.05, 0.05])
 
-    accepted_improved_trial = False
-    first_minima = None
-    first_artifacts = None
-    unit_runs = {}
-    for seed in args.seeds:
-        improved, minima, artifacts = run_zero_target(
-            exe,
-            workdir,
-            fixture,
-            seed,
-            args.detailed_balance,
-            args.zero_temperature,
-        )
-        accepted_improved_trial |= improved
-        unit_runs[seed] = (minima, artifacts)
-        if first_minima is None:
-            first_minima = minima
-            first_artifacts = artifacts
-    if not accepted_improved_trial:
-        raise AssertionError(
-            "zero first-moment regression did not accept an improved evolved trial"
-        )
-
-    _, repeated_minima, repeated_artifacts = run_zero_target(
+    first_seed = args.seeds[0]
+    first_statistics, first_artifacts = run_zero_target(
         exe,
         workdir,
         fixture,
-        args.seeds[0],
+        first_seed,
         args.detailed_balance,
         args.zero_temperature,
-        run_label=f"{args.seeds[0]}-repeat",
     )
-    if repeated_minima != first_minima or repeated_artifacts != first_artifacts:
+
+    repeated_statistics, repeated_artifacts = run_zero_target(
+        exe,
+        workdir,
+        fixture,
+        first_seed,
+        args.detailed_balance,
+        args.zero_temperature,
+        run_label=f"{first_seed}-repeat",
+    )
+    if (
+        repeated_statistics != first_statistics
+        or repeated_artifacts != first_artifacts
+    ):
         raise AssertionError(
             "zero first-moment fitness was not deterministic for a fixed seed: "
-            f"first={first_minima}, repeated={repeated_minima}"
+            f"first={first_statistics}, repeated={repeated_statistics}"
         )
 
-    _, explicit_unit_minima, explicit_unit_artifacts = run_zero_target(
+    explicit_unit_statistics, explicit_unit_artifacts = run_zero_target(
         exe,
         workdir,
         fixture,
-        args.seeds[0],
+        first_seed,
         args.detailed_balance,
         args.zero_temperature,
-        run_label=f"{args.seeds[0]}-explicit-unit",
+        run_label=f"{first_seed}-explicit-unit",
         first_moment_error="1.0",
     )
     if (
-        explicit_unit_minima != first_minima
+        explicit_unit_statistics != first_statistics
         or explicit_unit_artifacts != first_artifacts
     ):
         raise AssertionError(
@@ -201,34 +261,82 @@ def main():
             "fitness and binary artifacts"
         )
 
-    scaled_improved_trial = False
+    # With this exact power-of-two finite data error, every data-residual
+    # contribution underflows to positive zero. An explicit data-only control
+    # below verifies that isolation before the moment-weight assertions.
+    # Fitness is therefore only the first-moment penalty.
+    # Changing its error from 1.0 to 0.25 multiplies every candidate fitness by
+    # exactly 16 (and squared-fitness statistics by 256), so selection and the
+    # published best-spectrum artifacts must remain identical. This gives a
+    # deterministic initial/evolved-path check without relying on a particular
+    # row becoming the global minimum.
+    penalty_fixture = workdir / "first-moment-only.bin"
+    write_doubles(
+        penalty_fixture,
+        tau + observed + [math.ldexp(1.0, 1023)] * len(tau),
+    )
+
+    accepted_evolved_trial = False
     for seed in args.seeds:
-        improved, scaled_minima, _ = run_zero_target(
+        control_statistics, _ = run_zero_target(
             exe,
             workdir,
-            fixture,
+            penalty_fixture,
             seed,
             args.detailed_balance,
             args.zero_temperature,
-            run_label=f"{seed}-scaled",
+            run_label=f"{seed}-data-only-control",
+            use_first_moment=False,
+        )
+        if any(
+            value != 0.0
+            for values in control_statistics.values()
+            for value in values
+        ):
+            raise AssertionError(
+                "data-only isolation control produced nonzero fitness: "
+                f"seed={seed}, statistics={control_statistics}"
+            )
+        unit_statistics, unit_artifacts = run_zero_target(
+            exe,
+            workdir,
+            penalty_fixture,
+            seed,
+            args.detailed_balance,
+            args.zero_temperature,
+            run_label=f"{seed}-penalty-unit",
+            first_moment_error="1.0",
+        )
+        scaled_statistics, scaled_artifacts = run_zero_target(
+            exe,
+            workdir,
+            penalty_fixture,
+            seed,
+            args.detailed_balance,
+            args.zero_temperature,
+            run_label=f"{seed}-penalty-scaled",
             first_moment_error="0.25",
         )
-        if not improved:
-            continue
-        scaled_improved_trial = True
-        unit_minima, _ = unit_runs[seed]
-        if scaled_minima[0] == unit_minima[0]:
+        assert_power_of_two_scaling(unit_statistics, scaled_statistics)
+        unit_spectrum = published_spectrum_artifacts(unit_artifacts)
+        scaled_spectrum = published_spectrum_artifacts(scaled_artifacts)
+        if scaled_spectrum != unit_spectrum:
             raise AssertionError(
-                "custom first-moment uncertainty did not affect initial fitness"
+                "uniform first-moment fitness scaling changed published "
+                f"best-spectrum artifacts for seed {seed}"
             )
-        if scaled_minima[1] == unit_minima[1]:
-            raise AssertionError(
-                "custom first-moment uncertainty did not affect accepted evolved fitness"
+        accepted_evolved_trial |= (
+            materially_less(
+                unit_statistics["mean"][1], unit_statistics["mean"][0]
             )
-    if not scaled_improved_trial:
+            and materially_less(
+                unit_statistics["squared_mean"][1],
+                unit_statistics["squared_mean"][0],
+            )
+        )
+    if not accepted_evolved_trial:
         raise AssertionError(
-            "custom first-moment uncertainty regression did not accept an "
-            "improved evolved trial"
+            "first-moment-only regression did not accept an evolved population row"
         )
 
 

--- a/test/deac_parity_test.py
+++ b/test/deac_parity_test.py
@@ -52,6 +52,7 @@ def run_deac(
     normalize=False,
     negative_first_moment=False,
     first_moment=False,
+    first_moment_error=None,
     population_size="8",
     zero_temperature=False,
     detailed_balance=False,
@@ -89,6 +90,8 @@ def run_deac(
         command.append("--use_negative_first_moment")
     if first_moment:
         command.extend(["--first_moment", "0"])
+        if first_moment_error is not None:
+            command.extend(["--first_moment_error", first_moment_error])
     command.append(str(fixture))
     run_command(command, workdir)
     return save_dir
@@ -137,6 +140,8 @@ def assert_outputs_match(
     detailed_balance=False,
     zero_temperature=False,
     normalize=False,
+    first_moment=False,
+    first_moment_error=None,
 ):
     if zero_temperature:
         prefix = "deac-zT"
@@ -170,6 +175,16 @@ def assert_outputs_match(
             f"generation mismatch: reference={reference_generation}, "
             f"candidate={candidate_generation}"
         )
+
+    if first_moment:
+        expected_error = 1.0 if first_moment_error is None else float(first_moment_error)
+        for log_path in (reference_log, candidate_log):
+            actual_error = float(read_log_value(log_path, "first_moment_error"))
+            if actual_error != expected_error:
+                raise AssertionError(
+                    f"{log_path} recorded first_moment_error={actual_error}, "
+                    f"expected {expected_error}"
+                )
 
     reference_fitness = float(read_log_value(reference_log, "minimum_fitness"))
     candidate_fitness = float(read_log_value(candidate_log, "minimum_fitness"))
@@ -225,17 +240,20 @@ def main():
     write_doubles(frequency_file, [0.0, 0.7, 1.8, 3.0])
 
     cases = [
-        ("default", "17", False, False, False, "8"),
+        ("default", "17", False, False, False, None, "8"),
         # A zero-valued first moment is active. It previously divided the CPU
         # fitness by the target while GPU backends used a unit uncertainty.
-        ("first_moment_zero", "29", False, False, True, "8"),
+        ("first_moment_zero", "29", False, False, True, None, "8"),
+        # A non-unit uncertainty must reach the shared CPU and accelerator
+        # initial-population fitness paths with the same weighting.
+        ("first_moment_scaled", "31", False, False, True, "0.25", "8"),
         # Exercise both GEMV beta paths and a partial second work-group even
         # with the default GPU_BLOCK_SIZE=1024.
-        ("normalize_large_population", "19", True, False, False, "1028"),
+        ("normalize_large_population", "19", True, False, False, None, "1028"),
     ]
     if args.detailed_balance and not args.zero_temperature:
         cases.append(
-            ("negative_first_moment", "23", False, True, False, "8")
+            ("negative_first_moment", "23", False, True, False, None, "8")
         )
     for (
         case_name,
@@ -243,6 +261,7 @@ def main():
         normalize,
         negative_first_moment,
         first_moment,
+        first_moment_error,
         population_size,
     ) in cases:
         case_fixture = positive_fixture if normalize else fixture
@@ -255,6 +274,7 @@ def main():
             normalize=normalize,
             negative_first_moment=negative_first_moment,
             first_moment=first_moment,
+            first_moment_error=first_moment_error,
             population_size=population_size,
             zero_temperature=args.zero_temperature,
             detailed_balance=args.detailed_balance,
@@ -268,6 +288,7 @@ def main():
             normalize=normalize,
             negative_first_moment=negative_first_moment,
             first_moment=first_moment,
+            first_moment_error=first_moment_error,
             population_size=population_size,
             zero_temperature=args.zero_temperature,
             detailed_balance=args.detailed_balance,
@@ -278,9 +299,11 @@ def main():
             seed,
             args.absolute_tolerance,
             args.relative_tolerance,
-            args.detailed_balance,
-            args.zero_temperature,
-            normalize,
+            detailed_balance=args.detailed_balance,
+            zero_temperature=args.zero_temperature,
+            normalize=normalize,
+            first_moment=first_moment,
+            first_moment_error=first_moment_error,
         )
 
 

--- a/test/deac_smoke_test.py
+++ b/test/deac_smoke_test.py
@@ -430,6 +430,13 @@ def run_validation_case(
             "first_moment is used"
         )
         for invalid_error in ("0", "-0", "-1", "nan", "inf", "-inf"):
+            # The bundled parser classifies a standalone -inf value as an
+            # option. std::stod accepts leading whitespace, which keeps this
+            # one edge case on the solver's semantic validation path while the
+            # other spellings retain canonical CLI coverage.
+            argument_value = (
+                f" {invalid_error}" if invalid_error == "-inf" else invalid_error
+            )
             command = deac_command(
                 exe,
                 workdir,
@@ -438,7 +445,7 @@ def run_validation_case(
                     "--first_moment",
                     "0",
                     "--first_moment_error",
-                    invalid_error,
+                    argument_value,
                 ],
                 zero_temperature=zero_temperature,
             )

--- a/test/deac_smoke_test.py
+++ b/test/deac_smoke_test.py
@@ -40,6 +40,7 @@ VALIDATION_CASES = [
     "normalize_signed_weights",
     "missing_isf",
     "positive_isf_single_particle",
+    "bad_first_moment_error",
     "bad_third_moment_error",
     "bad_crossover_probability",
     "bad_self_adapting_crossover_probability",
@@ -218,7 +219,9 @@ def run_deac_case(
         if case_name == "normalize_large_population":
             population_size = "1028"
     elif case_name == "first_moment":
-        extra_args.extend(["--first_moment", "0.5"])
+        extra_args.extend(
+            ["--first_moment", "0.5", "--first_moment_error", "0.25"]
+        )
     elif case_name == "third_moment":
         extra_args.extend(
             ["--third_moment", "0.5", "--third_moment_error", "0.1"]
@@ -304,6 +307,14 @@ def run_deac_case(
             )
         if "temperature: 0" not in log_text:
             raise AssertionError(f"expected {log_path} to record zero temperature")
+
+    if (
+        case_name == "first_moment"
+        and "first_moment_error: 0.25\n" not in log_text
+    ):
+        raise AssertionError(
+            f"expected {log_path} to record the effective first-moment error"
+        )
 
     if detailed_balance and case_name == "negative_first_moment":
         error_line = next(
@@ -411,6 +422,38 @@ def run_validation_case(
             expected_output = "minimum_fitness:"
         else:
             expected_output = "positive ISF values are not supported for single-particle spectra"
+    elif case_name == "bad_first_moment_error":
+        write_fixture(fixture)
+        save_dir = workdir / "results"
+        expected_output = (
+            "first_moment_error must be finite and positive when "
+            "first_moment is used"
+        )
+        for invalid_error in ("0", "-0", "-1", "nan", "inf", "-inf"):
+            command = deac_command(
+                exe,
+                workdir,
+                fixture,
+                extra_args=[
+                    "--first_moment",
+                    "0",
+                    "--first_moment_error",
+                    invalid_error,
+                ],
+                zero_temperature=zero_temperature,
+            )
+            run_command(
+                command,
+                workdir,
+                expected_returncode=1,
+                expected_output=expected_output,
+            )
+            if save_dir.exists():
+                raise AssertionError(
+                    "invalid active first-moment error created output directory "
+                    f"{save_dir}"
+                )
+        return
     elif case_name == "bad_third_moment_error":
         write_fixture(fixture)
         extra_args = ["--third_moment", "1.0", "--third_moment_error", "0.0"]
@@ -450,6 +493,7 @@ def run_validation_case(
             ["--self_adapting_differential_weight_shift", "0.1"],
             ["-m", "0.9"],
             ["--self_adapting_differential_weight", "0.9"],
+            ["--first_moment_error", "0.5"],
         ):
             command = deac_command(
                 exe,
@@ -688,6 +732,9 @@ def main():
         )
         for expected_output in (
             "--build-identity",
+            "--first_moment_error",
+            "finite, positive standard deviation",
+            "Defaults to 1.0",
             "--self_adapting_differential_weight_probability",
             "Must be finite and in [0, 2].",
             "Negative values are allowed.",


### PR DESCRIPTION
Depends on #53 and advances #36.

## Summary

- add `--first_moment_error` with backward-compatible default `1.0`
- require a finite positive uncertainty for active first moments and reject explicit inactive use
- apply the same squared standardized penalty in initial and evolved CPU/SYCL/CUDA/HIP paths
- record the effective uncertainty in logs and document the public contract
- add deterministic weighting, compatibility, invalid-boundary, and CPU/accelerator parity coverage

## Validation

Exact clean head: `1efb64b959267b36e6a958df372a5c534b777f89`

- GCC 14.2 Release: 74/74
- GCC 14.2 detailed balance: 74/74
- GCC 14.2 ZeroT: 74/74
- GCC 14.2 ASan+UBSan: 74/74, no diagnostics
- IntelLLVM 2026.1 CPU detailed balance: 74/74
- IntelLLVM 2026.1 SYCL detailed balance on Level Zero / Intel Data Center GPU Max 1550: 77/77, including evolved first-moment weighting and CPU/SYCL parity
- Ruff on changed tests, Python parsing, and `git diff --check`: pass
- Independent final review: PUBLISH, no findings

Receipt payloads:
- CPU: `27992a694995a99d8a132d2056a344173ef2bce0a1b6123b57d08640791c8aeb`
- SYCL: `060d4ba471ea41f0d395520605a9d8ce42155e7a949945d22a0fdac872fc7b72`

Both receipts bind the exact clean source SHA above. This PR remains draft while its receipt dependency is stacked.