### PR TITLE
refactor: unify population observable scoring

### DIFF
--- a/src/deac/CMakeLists.txt
+++ b/src/deac/CMakeLists.txt
@@ -513,6 +513,14 @@ add_test(
     NAME deac_unit_moment_fitness
     COMMAND deac_moment_fitness_test)
 
+add_executable(deac_population_scoring_test
+    ${CMAKE_SOURCE_DIR}/../test/population_scoring_test.cpp)
+target_include_directories(deac_population_scoring_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_test(
+    NAME deac_unit_population_scoring
+    COMMAND deac_population_scoring_test)
+
 add_executable(deac_population_projection_test
     ${CMAKE_SOURCE_DIR}/../test/population_projection_test.cpp)
 target_include_directories(deac_population_projection_test PRIVATE
@@ -581,7 +589,8 @@ if(NOT USE_ALLOW_NEGATIVE_SPECTRAL_WEIGHT)
         deac_invalid_normalization_evolution_test_exe)
     target_compile_definitions(
         deac_invalid_normalization_evolution_test_exe PRIVATE
-        DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS=1)
+        DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS=1
+        DEAC_TEST_SCORE_IDENTICAL_POPULATION=1)
     if(NOT "${GPU_BACKEND}" STREQUAL "none")
         target_compile_definitions(
             deac_invalid_normalization_evolution_test_exe PRIVATE
@@ -816,6 +825,16 @@ if(Python3_Interpreter_FOUND)
                 --workdir ${CMAKE_CURRENT_BINARY_DIR}/invalid-normalization-evolution
                 ${DEAC_SMOKE_VARIANT_ARGS}
                 ${DEAC_INVALID_NORMALIZATION_TEST_ARGS}
+        )
+        add_test(
+            NAME deac_identical_population_scoring
+            COMMAND
+                ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/../test/deac_identical_population_scoring_test.py
+                --reference-exe $<TARGET_FILE:${exe}>
+                --seam-exe $<TARGET_FILE:deac_invalid_normalization_evolution_test_exe>
+                --workdir ${CMAKE_CURRENT_BINARY_DIR}/identical-population-scoring
+                ${DEAC_SMOKE_VARIANT_ARGS}
         )
     endif()
 

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -9,6 +9,7 @@
 #include <algorithm> // std::none_of
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <exception>
 #include <limits>
 #include <span>
@@ -17,7 +18,7 @@
 #include "evolution_controls.hpp"
 #include "moment_fitness.hpp"
 #include "normalization.hpp"
-#include "population_projection.hpp"
+#include "population_scoring.hpp"
 #include "result_io.hpp"
 #include "trial_population.hpp"
 #include "zero_temperature_kernel.hpp"
@@ -356,6 +357,24 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         population_old_negative_frequency = (double*) malloc(bytes_population);
         population_new_negative_frequency = (double*) malloc(bytes_population);
     #endif
+    #ifndef USE_GPU
+        const deac_numerics::PopulationView population_old{
+                population_old_positive_frequency,
+                #ifdef DEAC_TWO_SIDED_POPULATION
+                    population_old_negative_frequency
+                #else
+                    nullptr
+                #endif
+                };
+        const deac_numerics::PopulationView population_new{
+                population_new_positive_frequency,
+                #ifdef DEAC_TWO_SIDED_POPULATION
+                    population_new_negative_frequency
+                #else
+                    nullptr
+                #endif
+                };
+    #endif
     for (size_t i=0; i<population_size; i++) {
         for (size_t j=0; j<genome_size; j++) {
             #ifdef USE_GPU
@@ -402,6 +421,117 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             GPU_ASSERT(deac_memcpy_host_to_device(d_population_old_negative_frequency, population_old_negative_frequency, bytes_population, default_stream));
         #endif
         GPU_ASSERT(deac_wait(default_stream));
+
+        const deac_numerics::PopulationView d_population_old{
+                d_population_old_positive_frequency,
+                #ifdef DEAC_TWO_SIDED_POPULATION
+                    d_population_old_negative_frequency
+                #else
+                    nullptr
+                #endif
+                };
+        const deac_numerics::PopulationView d_population_new{
+                d_population_new_positive_frequency,
+                #ifdef DEAC_TWO_SIDED_POPULATION
+                    d_population_new_negative_frequency
+                #else
+                    nullptr
+                #endif
+                };
+
+        const auto project_device_population_scalar_moment = [&] (
+                double* projected_moment,
+                const deac_numerics::PopulationView& population,
+                double* positive_frequency_terms,
+                double* negative_frequency_terms) {
+            #ifdef USE_BLAS
+                gpu_blas_gemv(
+                        default_blas_handle, population_size, genome_size,
+                        1.0, population.positive_frequency,
+                        positive_frequency_terms, 0.0, projected_moment);
+                GPU_ASSERT(deac_wait(default_stream));
+                if (population.negative_frequency != nullptr) {
+                    gpu_blas_gemv(
+                            default_blas_handle, population_size, genome_size,
+                            1.0, population.negative_frequency,
+                            negative_frequency_terms, 1.0, projected_moment);
+                    GPU_ASSERT(deac_wait(default_stream));
+                }
+            #else
+                gpu_deac_gemv(
+                        default_stream, population_size, genome_size,
+                        1.0, population.positive_frequency,
+                        positive_frequency_terms, 0.0, projected_moment);
+                GPU_ASSERT(deac_wait(default_stream));
+                if (population.negative_frequency != nullptr) {
+                    gpu_deac_gemv(
+                            default_stream, population_size, genome_size,
+                            1.0, population.negative_frequency,
+                            negative_frequency_terms, 1.0, projected_moment);
+                    GPU_ASSERT(deac_wait(default_stream));
+                }
+            #endif
+        };
+
+        const auto project_device_population_forward_model = [&] (
+                double* modeled_isf,
+                const deac_numerics::PopulationView& population) {
+            #ifdef USE_BLAS
+                gpu_blas_gemm(
+                        default_blas_handle, population_size,
+                        number_of_timeslices, genome_size,
+                        1.0, population.positive_frequency,
+                        d_isf_term_positive_frequency, 0.0, modeled_isf);
+                GPU_ASSERT(deac_wait(default_stream));
+                #ifdef DEAC_TWO_SIDED_POPULATION
+                    if (population.negative_frequency != nullptr) {
+                        gpu_blas_gemm(
+                                default_blas_handle, population_size,
+                                number_of_timeslices, genome_size,
+                                1.0, population.negative_frequency,
+                                d_isf_term_negative_frequency, 1.0, modeled_isf);
+                        GPU_ASSERT(deac_wait(default_stream));
+                    }
+                #endif
+            #else
+                gpu_matmul(
+                        default_stream, population_size,
+                        number_of_timeslices, genome_size,
+                        1.0, population.positive_frequency,
+                        d_isf_term_positive_frequency, 0.0, modeled_isf);
+                GPU_ASSERT(deac_wait(default_stream));
+                #ifdef DEAC_TWO_SIDED_POPULATION
+                    if (population.negative_frequency != nullptr) {
+                        gpu_matmul(
+                                default_stream, population_size,
+                                number_of_timeslices, genome_size,
+                                1.0, population.negative_frequency,
+                                d_isf_term_negative_frequency, 1.0, modeled_isf);
+                        GPU_ASSERT(deac_wait(default_stream));
+                    }
+                #endif
+            #endif
+        };
+
+        #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            const auto project_device_modeled_isf_moment = [&] (
+                    double* projected_moment,
+                    double* modeled_isf,
+                    double* terms) {
+                #ifdef USE_BLAS
+                    gpu_blas_gemv(
+                            default_blas_handle, population_size,
+                            number_of_timeslices, 1.0, modeled_isf, terms,
+                            0.0, projected_moment);
+                #else
+                    gpu_deac_gemv(
+                            default_stream, population_size,
+                            number_of_timeslices, 1.0, modeled_isf, terms,
+                            0.0, projected_moment);
+                #endif
+                GPU_ASSERT(deac_wait(default_stream));
+            };
+        #endif
     #endif
 
     // Normalize population
@@ -635,31 +765,25 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
 
             GPU_ASSERT(deac_memset(d_first_moments, 0, bytes_first_moments, default_stream));
             GPU_ASSERT(deac_wait(default_stream));
-            #ifdef USE_BLAS
-                gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_old_positive_frequency, d_first_moments_term_positive_frequency, 0.0, d_first_moments);
-                GPU_ASSERT(deac_wait(default_stream));
-                #ifdef DEAC_TWO_SIDED_POPULATION
-                    gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_old_negative_frequency, d_first_moments_term_negative_frequency, 1.0, d_first_moments);
-                    GPU_ASSERT(deac_wait(default_stream));
-                #endif
-            #else
-                gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_old_positive_frequency, d_first_moments_term_positive_frequency, 0.0, d_first_moments);
-                GPU_ASSERT(deac_wait(default_stream));
-                #ifdef DEAC_TWO_SIDED_POPULATION
-                    gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_old_negative_frequency, d_first_moments_term_negative_frequency, 1.0, d_first_moments);
-                    GPU_ASSERT(deac_wait(default_stream));
-                #endif
-            #endif
+            project_device_population_scalar_moment(
+                    d_first_moments, d_population_old,
+                    d_first_moments_term_positive_frequency,
+                    #ifdef DEAC_TWO_SIDED_POPULATION
+                        d_first_moments_term_negative_frequency
+                    #else
+                        nullptr
+                    #endif
+                    );
         #else
-            for (size_t i=0; i<population_size; i++) {
-                first_moments[i] = 0.0;
-            }
-            matrix_multiply_MxN_by_Nx1(first_moments, population_old_positive_frequency,
-                    first_moments_term_positive_frequency, population_size, genome_size);
-            #ifdef DEAC_TWO_SIDED_POPULATION
-                matrix_multiply_MxN_by_Nx1(first_moments, population_old_negative_frequency,
-                        first_moments_term_negative_frequency, population_size, genome_size);
-            #endif
+            deac_numerics::project_population_scalar_moment(
+                    first_moments, population_old,
+                    first_moments_term_positive_frequency,
+                    #ifdef DEAC_TWO_SIDED_POPULATION
+                        first_moments_term_negative_frequency,
+                    #else
+                        nullptr,
+                    #endif
+                    genome_size, population_size);
         #endif
     }
 
@@ -735,31 +859,25 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
 
             GPU_ASSERT(deac_memset(d_third_moments, 0, bytes_third_moments, default_stream));
             GPU_ASSERT(deac_wait(default_stream));
-            #ifdef USE_BLAS
-                gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_old_positive_frequency, d_third_moments_term_positive_frequency, 0.0, d_third_moments);
-                GPU_ASSERT(deac_wait(default_stream));
-                #ifdef DEAC_TWO_SIDED_POPULATION
-                    gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_old_negative_frequency, d_third_moments_term_negative_frequency, 1.0, d_third_moments);
-                    GPU_ASSERT(deac_wait(default_stream));
-                #endif
-            #else
-                gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_old_positive_frequency, d_third_moments_term_positive_frequency, 0.0, d_third_moments);
-                GPU_ASSERT(deac_wait(default_stream));
-                #ifdef DEAC_TWO_SIDED_POPULATION
-                    gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_old_negative_frequency, d_third_moments_term_negative_frequency, 1.0, d_third_moments);
-                    GPU_ASSERT(deac_wait(default_stream));
-                #endif
-            #endif
+            project_device_population_scalar_moment(
+                    d_third_moments, d_population_old,
+                    d_third_moments_term_positive_frequency,
+                    #ifdef DEAC_TWO_SIDED_POPULATION
+                        d_third_moments_term_negative_frequency
+                    #else
+                        nullptr
+                    #endif
+                    );
         #else
-            for (size_t i=0; i<population_size; i++) {
-                third_moments[i] = 0.0;
-            }
-            matrix_multiply_MxN_by_Nx1(third_moments, population_old_positive_frequency,
-                    third_moments_term_positive_frequency, population_size, genome_size);
-            #ifdef DEAC_TWO_SIDED_POPULATION
-                matrix_multiply_MxN_by_Nx1(third_moments, population_old_negative_frequency,
-                        third_moments_term_negative_frequency, population_size, genome_size);
-            #endif
+            deac_numerics::project_population_scalar_moment(
+                    third_moments, population_old,
+                    third_moments_term_positive_frequency,
+                    #ifdef DEAC_TWO_SIDED_POPULATION
+                        third_moments_term_negative_frequency,
+                    #else
+                        nullptr,
+                    #endif
+                    genome_size, population_size);
         #endif
     }
 
@@ -775,33 +893,17 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         GPU_ASSERT(deac_wait(default_stream));
         GPU_ASSERT(deac_memset(d_isf_model, 0, bytes_isf_model, default_stream));
         GPU_ASSERT(deac_wait(default_stream));
-        #ifdef USE_BLAS
-            gpu_blas_gemm(default_blas_handle, population_size, number_of_timeslices, genome_size, 1.0, d_population_old_positive_frequency, d_isf_term_positive_frequency, 0.0, d_isf_model);
-            GPU_ASSERT(deac_wait(default_stream));
-            #ifdef DEAC_TWO_SIDED_POPULATION
-                gpu_blas_gemm(default_blas_handle, population_size, number_of_timeslices, genome_size, 1.0, d_population_old_negative_frequency, d_isf_term_negative_frequency, 1.0, d_isf_model);
-                GPU_ASSERT(deac_wait(default_stream));
-            #endif
-        #else
-            gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_old_positive_frequency, d_isf_term_positive_frequency, 0.0, d_isf_model);
-            GPU_ASSERT(deac_wait(default_stream));
-            #ifdef DEAC_TWO_SIDED_POPULATION
-                gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_old_negative_frequency, d_isf_term_negative_frequency, 1.0, d_isf_model);
-                GPU_ASSERT(deac_wait(default_stream));
-            #endif
-        #endif
+        project_device_population_forward_model(d_isf_model, d_population_old);
     #else
-        for (size_t i=0; i<population_size*number_of_timeslices; i++) {
-            isf_model[i] = 0.0;
-        }
-        deac_numerics::accumulate_population_projection(
-                isf_model, isf_term_positive_frequency, population_old_positive_frequency,
+        deac_numerics::project_population_forward_model(
+                isf_model, population_old,
+                isf_term_positive_frequency,
+                #ifdef DEAC_TWO_SIDED_POPULATION
+                    isf_term_negative_frequency,
+                #else
+                    nullptr,
+                #endif
                 number_of_timeslices, genome_size, population_size);
-        #ifdef DEAC_TWO_SIDED_POPULATION
-            deac_numerics::accumulate_population_projection(
-                    isf_model, isf_term_negative_frequency, population_old_negative_frequency,
-                    number_of_timeslices, genome_size, population_size);
-        #endif
     #endif
 
     #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
@@ -837,19 +939,14 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
 
                 GPU_ASSERT(deac_memset(d_negative_first_moments, 0, bytes_negative_first_moments, default_stream));
                 GPU_ASSERT(deac_wait(default_stream));
-                #ifdef USE_BLAS
-                    gpu_blas_gemv(default_blas_handle, population_size, number_of_timeslices, 1.0, d_isf_model, d_negative_first_moments_term, 0.0, d_negative_first_moments);
-                    GPU_ASSERT(deac_wait(default_stream));
-                #else
-                    gpu_deac_gemv(default_stream, population_size, number_of_timeslices, 1.0, d_isf_model, d_negative_first_moments_term, 0.0, d_negative_first_moments);
-                    GPU_ASSERT(deac_wait(default_stream));
-                #endif
+                project_device_modeled_isf_moment(
+                        d_negative_first_moments, d_isf_model,
+                        d_negative_first_moments_term);
             #else
-                for (size_t i=0; i<population_size; i++) {
-                    negative_first_moments[i] = 0.0;
-                }
-                matrix_multiply_MxN_by_Nx1(negative_first_moments, isf_model,
-                        negative_first_moments_term, population_size, number_of_timeslices);
+                deac_numerics::project_modeled_isf_moment(
+                        negative_first_moments, isf_model,
+                        negative_first_moments_term,
+                        number_of_timeslices, population_size);
             #endif
         }
     #else
@@ -994,6 +1091,179 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
         for (size_t i=0; i<population_size; i++) {
             fitness_old[i] = score_host_population_objective(i);
         }
+    #endif
+
+    #ifdef USE_GPU
+        const auto project_evolved_population_observables = [&] (
+                const deac_numerics::PopulationView& population) {
+            project_device_population_forward_model(d_isf_model, population);
+            #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                if (use_negative_first_moment) {
+                    project_device_modeled_isf_moment(
+                            d_negative_first_moments, d_isf_model,
+                            d_negative_first_moments_term);
+                }
+            #endif
+            if (use_first_moment) {
+                project_device_population_scalar_moment(
+                        d_first_moments, population,
+                        d_first_moments_term_positive_frequency,
+                        #ifdef DEAC_TWO_SIDED_POPULATION
+                            d_first_moments_term_negative_frequency
+                        #else
+                            nullptr
+                        #endif
+                        );
+            }
+            if (use_third_moment) {
+                project_device_population_scalar_moment(
+                        d_third_moments, population,
+                        d_third_moments_term_positive_frequency,
+                        #ifdef DEAC_TWO_SIDED_POPULATION
+                            d_third_moments_term_negative_frequency
+                        #else
+                            nullptr
+                        #endif
+                        );
+            }
+        };
+    #else
+        const auto project_evolved_population_observables = [&] (
+                const deac_numerics::PopulationView& population) {
+            deac_numerics::project_population_forward_model(
+                    isf_model, population,
+                    isf_term_positive_frequency,
+                    #ifdef DEAC_TWO_SIDED_POPULATION
+                        isf_term_negative_frequency,
+                    #else
+                        nullptr,
+                    #endif
+                    number_of_timeslices, genome_size, population_size);
+            #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+                if (use_negative_first_moment) {
+                    deac_numerics::project_modeled_isf_moment(
+                            negative_first_moments, isf_model,
+                            negative_first_moments_term,
+                            number_of_timeslices, population_size);
+                }
+            #endif
+            if (use_first_moment) {
+                deac_numerics::project_population_scalar_moment(
+                        first_moments, population,
+                        first_moments_term_positive_frequency,
+                        #ifdef DEAC_TWO_SIDED_POPULATION
+                            first_moments_term_negative_frequency,
+                        #else
+                            nullptr,
+                        #endif
+                        genome_size, population_size);
+            }
+            if (use_third_moment) {
+                deac_numerics::project_population_scalar_moment(
+                        third_moments, population,
+                        third_moments_term_positive_frequency,
+                        #ifdef DEAC_TWO_SIDED_POPULATION
+                            third_moments_term_negative_frequency,
+                        #else
+                            nullptr,
+                        #endif
+                        genome_size, population_size);
+            }
+        };
+    #endif
+
+    #ifdef DEAC_TEST_SCORE_IDENTICAL_POPULATION
+        // Test-only solver seam: bypass mutation RNG by copying the already
+        // normalized incumbent into the candidate buffers, then evaluate it
+        // in the evolved-path observable order.  Production targets do not
+        // compile this block.
+        std::vector<double> initial_population_fitness(population_size);
+        std::vector<double> candidate_population_fitness(population_size);
+        #ifdef USE_GPU
+            GPU_ASSERT(deac_memcpy_device_to_host(
+                    initial_population_fitness.data(), d_fitness_old,
+                    bytes_fitness, default_stream));
+            GPU_ASSERT(deac_memcpy_device_to_host(
+                    population_new_positive_frequency,
+                    d_population_old.positive_frequency,
+                    bytes_population, default_stream));
+            #ifdef DEAC_TWO_SIDED_POPULATION
+                GPU_ASSERT(deac_memcpy_device_to_host(
+                        population_new_negative_frequency,
+                        d_population_old.negative_frequency,
+                        bytes_population, default_stream));
+            #endif
+            GPU_ASSERT(deac_wait(default_stream));
+
+            GPU_ASSERT(deac_memcpy_host_to_device(
+                    d_population_new.positive_frequency,
+                    population_new_positive_frequency,
+                    bytes_population, default_stream));
+            #ifdef DEAC_TWO_SIDED_POPULATION
+                GPU_ASSERT(deac_memcpy_host_to_device(
+                        d_population_new.negative_frequency,
+                        population_new_negative_frequency,
+                        bytes_population, default_stream));
+            #endif
+            GPU_ASSERT(deac_wait(default_stream));
+
+            project_evolved_population_observables(d_population_new);
+            score_device_population_objective(d_fitness_new);
+            GPU_ASSERT(deac_memcpy_device_to_host(
+                    candidate_population_fitness.data(), d_fitness_new,
+                    bytes_fitness, default_stream));
+            GPU_ASSERT(deac_wait(default_stream));
+        #else
+            std::copy(
+                    population_old.positive_frequency,
+                    population_old.positive_frequency
+                        + population_size*genome_size,
+                    population_new.positive_frequency);
+            #ifdef DEAC_TWO_SIDED_POPULATION
+                std::copy(
+                        population_old.negative_frequency,
+                        population_old.negative_frequency
+                            + population_size*genome_size,
+                        population_new.negative_frequency);
+            #endif
+            std::copy(
+                    fitness_old, fitness_old + population_size,
+                    initial_population_fitness.begin());
+
+            project_evolved_population_observables(population_new);
+            for (size_t i=0; i<population_size; ++i) {
+                candidate_population_fitness[i] =
+                        score_host_population_objective(i);
+            }
+        #endif
+
+        if (!std::all_of(
+                    initial_population_fitness.begin(),
+                    initial_population_fitness.end(),
+                    [](double value) { return std::isfinite(value); })
+                || std::memcmp(
+                    initial_population_fitness.data(),
+                    candidate_population_fitness.data(),
+                    bytes_fitness) != 0) {
+            fail_with_error(
+                    "identical incumbent and candidate scoring diverged");
+        }
+
+        #if defined(USE_GPU) && defined(DEAC_TEST_POISON_GPU_FITNESS)
+            // Keep the existing evolved-pass poison regression independent:
+            // the actual generation must still overwrite this destination.
+            std::fill(
+                    fitness_old, fitness_old + population_size,
+                    std::numeric_limits<double>::quiet_NaN());
+            DEAC_TEST_GPU_CALL(deac_memcpy_host_to_device(
+                    d_fitness_new, fitness_old,
+                    bytes_fitness, default_stream));
+            DEAC_TEST_GPU_CALL(deac_wait(default_stream));
+            test_require_poisoned_gpu_fitness(
+                    d_fitness_new, "new after identical scoring seam");
+        #endif
+        std::cout << "test_identical_population_scoring: exact "
+                  << population_size << '\n';
     #endif
 
     size_t bytes_crossover_probabilities = sizeof(double)*population_size;
@@ -1425,118 +1695,12 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             }
         #endif
 
-        //Rejection
-        //Set model isf for new population
+        // Project the evolved population before scoring and rejection.
         #ifdef USE_GPU
-            #ifdef USE_BLAS
-                gpu_blas_gemm(default_blas_handle, population_size, number_of_timeslices, genome_size, 1.0, d_population_new_positive_frequency, d_isf_term_positive_frequency, 0.0, d_isf_model);
-                GPU_ASSERT(deac_wait(default_stream));
-                #ifdef DEAC_TWO_SIDED_POPULATION
-                    gpu_blas_gemm(default_blas_handle, population_size, number_of_timeslices, genome_size, 1.0, d_population_new_negative_frequency, d_isf_term_negative_frequency, 1.0, d_isf_model);
-                    GPU_ASSERT(deac_wait(default_stream));
-                #endif
-            #else
-                gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_new_positive_frequency, d_isf_term_positive_frequency, 0.0, d_isf_model);
-                GPU_ASSERT(deac_wait(default_stream));
-                #ifdef DEAC_TWO_SIDED_POPULATION
-                    gpu_matmul(default_stream, population_size, number_of_timeslices, genome_size, 1.0, d_population_new_negative_frequency, d_isf_term_negative_frequency, 1.0, d_isf_model);
-                    GPU_ASSERT(deac_wait(default_stream));
-                #endif
-            #endif
+            project_evolved_population_observables(d_population_new);
         #else
-            for (size_t i=0; i<population_size*number_of_timeslices; i++) {
-                isf_model[i] = 0.0;
-            }
-            deac_numerics::accumulate_population_projection(
-                    isf_model, isf_term_positive_frequency, population_new_positive_frequency,
-                    number_of_timeslices, genome_size, population_size);
-            #ifdef DEAC_TWO_SIDED_POPULATION
-                deac_numerics::accumulate_population_projection(
-                        isf_model, isf_term_negative_frequency, population_new_negative_frequency,
-                        number_of_timeslices, genome_size, population_size);
-            #endif
+            project_evolved_population_observables(population_new);
         #endif
-
-        //Set moments
-        if (use_negative_first_moment) {
-            #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-                #ifdef USE_GPU
-                    #ifdef USE_BLAS
-                        gpu_blas_gemv(default_blas_handle, population_size, number_of_timeslices, 1.0, d_isf_model, d_negative_first_moments_term, 0.0, d_negative_first_moments);
-                        GPU_ASSERT(deac_wait(default_stream));
-                    #else
-                        gpu_deac_gemv(default_stream, population_size, number_of_timeslices, 1.0, d_isf_model, d_negative_first_moments_term, 0.0, d_negative_first_moments);
-                        GPU_ASSERT(deac_wait(default_stream));
-                    #endif
-                #else
-                    for (size_t i=0; i<population_size; i++) {
-                        negative_first_moments[i] = 0.0;
-                    }
-                    matrix_multiply_MxN_by_Nx1(negative_first_moments, isf_model,
-                            negative_first_moments_term, population_size, number_of_timeslices);
-                #endif
-            #else
-                //FIXME inverse first moment not implemented
-            #endif
-        }
-        if (use_first_moment) {
-            #ifdef USE_GPU
-                #ifdef USE_BLAS
-                    gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_new_positive_frequency, d_first_moments_term_positive_frequency, 0.0, d_first_moments);
-                    GPU_ASSERT(deac_wait(default_stream));
-                    #ifdef DEAC_TWO_SIDED_POPULATION
-                        gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_new_negative_frequency, d_first_moments_term_negative_frequency, 1.0, d_first_moments);
-                        GPU_ASSERT(deac_wait(default_stream));
-                    #endif
-                #else
-                    gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_new_positive_frequency, d_first_moments_term_positive_frequency, 0.0, d_first_moments);
-                    GPU_ASSERT(deac_wait(default_stream));
-                    #ifdef DEAC_TWO_SIDED_POPULATION
-                        gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_new_negative_frequency, d_first_moments_term_negative_frequency, 1.0, d_first_moments);
-                        GPU_ASSERT(deac_wait(default_stream));
-                    #endif
-                #endif
-            #else
-                for (size_t i=0; i<population_size; i++) {
-                    first_moments[i] = 0.0;
-                }
-                matrix_multiply_MxN_by_Nx1(first_moments, population_new_positive_frequency,
-                        first_moments_term_positive_frequency, population_size, genome_size);
-                #ifdef DEAC_TWO_SIDED_POPULATION
-                    matrix_multiply_MxN_by_Nx1(first_moments, population_new_negative_frequency,
-                            first_moments_term_negative_frequency, population_size, genome_size);
-                #endif
-            #endif
-        }
-        if (use_third_moment) {
-            #ifdef USE_GPU
-                #ifdef USE_BLAS
-                    gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_new_positive_frequency, d_third_moments_term_positive_frequency, 0.0, d_third_moments);
-                    GPU_ASSERT(deac_wait(default_stream));
-                    #ifdef DEAC_TWO_SIDED_POPULATION
-                        gpu_blas_gemv(default_blas_handle, population_size, genome_size, 1.0, d_population_new_negative_frequency, d_third_moments_term_negative_frequency, 1.0, d_third_moments);
-                        GPU_ASSERT(deac_wait(default_stream));
-                    #endif
-                #else
-                    gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_new_positive_frequency, d_third_moments_term_positive_frequency, 0.0, d_third_moments);
-                    GPU_ASSERT(deac_wait(default_stream));
-                    #ifdef DEAC_TWO_SIDED_POPULATION
-                        gpu_deac_gemv(default_stream, population_size, genome_size, 1.0, d_population_new_negative_frequency, d_third_moments_term_negative_frequency, 1.0, d_third_moments);
-                        GPU_ASSERT(deac_wait(default_stream));
-                    #endif
-                #endif
-            #else
-                for (size_t i=0; i<population_size; i++) {
-                    third_moments[i] = 0.0;
-                }
-                matrix_multiply_MxN_by_Nx1(third_moments, population_new_positive_frequency,
-                        third_moments_term_positive_frequency, population_size, genome_size);
-                #ifdef DEAC_TWO_SIDED_POPULATION
-                    matrix_multiply_MxN_by_Nx1(third_moments, population_new_negative_frequency,
-                            third_moments_term_negative_frequency, population_size, genome_size);
-                #endif
-            #endif
-        }
 
         //Set fitness for new population
         #ifdef USE_GPU

--- a/src/deac/src/deac.cpp
+++ b/src/deac/src/deac.cpp
@@ -82,14 +82,6 @@ void matrix_multiply_MxN_by_Nx1(double * C, double * A, double * B, size_t M, si
     }
 }
 
-double reduced_chi_square_statistic(double * observed, double * calculated, double * error, size_t length) {
-    double chi_squared = 0.0;
-    for (size_t i=0; i<length; i++) {
-        chi_squared += pow((observed[i] - calculated[i])/error[i],2);
-    }
-    return chi_squared;
-}
-
 double minimum(double * A, size_t length) {
     double _minimum = A[0];
     for (size_t i=0; i<length; i++) {
@@ -813,11 +805,11 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
     #endif
 
     #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-        double * negative_first_moments_term;
-        double * negative_first_moments;
+        double * negative_first_moments_term = nullptr;
+        double * negative_first_moments = nullptr;
         #ifdef USE_GPU
-            double* d_negative_first_moments_term;
-            double* d_negative_first_moments;
+            double* d_negative_first_moments_term = nullptr;
+            double* d_negative_first_moments = nullptr;
         #endif
         size_t bytes_negative_first_moments_term = sizeof(double)*number_of_timeslices;
         size_t bytes_negative_first_moments = sizeof(double)*population_size;
@@ -930,48 +922,77 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             };
         #endif
 
-        gpu_deac_reduced_chi_squared(default_stream, d_isf_model, d_isf, d_isf_error, d_fitness_old, population_size, number_of_timeslices, 0, 0.0);
-        GPU_ASSERT(deac_wait(default_stream));
+        const auto score_device_population_objective = [&](double* device_fitness) {
+            gpu_deac_reduced_chi_squared(
+                    default_stream, d_isf_model, d_isf, d_isf_error,
+                    device_fitness, population_size, number_of_timeslices,
+                    0, 0.0);
+            GPU_ASSERT(deac_wait(default_stream));
 
-        #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-            if (use_negative_first_moment) {
-                gpu_deac_add_scalar_reduced_chi_squared(default_stream, d_negative_first_moments, negative_first_moment, negative_first_moment_error, d_fitness_old, population_size);
-                GPU_ASSERT(deac_wait(default_stream));
-            }
-        #else
-            //FIXME inverse first moment not implemented
-        #endif
-        if (use_first_moment) {
-            gpu_deac_add_scalar_reduced_chi_squared(default_stream, d_first_moments, first_moment, first_moment_error, d_fitness_old, population_size);
-            GPU_ASSERT(deac_wait(default_stream));
-        }
-        if (use_third_moment) {
-            gpu_deac_add_scalar_reduced_chi_squared(default_stream, d_third_moments, third_moment, third_moment_error, d_fitness_old, population_size);
-            GPU_ASSERT(deac_wait(default_stream));
-        }
-        #ifdef DEAC_TEST_POISON_GPU_FITNESS
-            test_require_finite_gpu_fitness(d_fitness_old, "initial");
-        #endif
-    #else
-        for (size_t i=0; i<population_size; i++) {
-            double _fitness = reduced_chi_square_statistic(isf,
-                    isf_model + i*number_of_timeslices, isf_error,
-                    number_of_timeslices)/number_of_timeslices;
             #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
                 if (use_negative_first_moment) {
-                    _fitness += pow((negative_first_moment - negative_first_moments[i])/negative_first_moment_error,2);
+                    gpu_deac_add_scalar_reduced_chi_squared(
+                            default_stream, d_negative_first_moments,
+                            negative_first_moment,
+                            negative_first_moment_error,
+                            device_fitness, population_size);
+                    GPU_ASSERT(deac_wait(default_stream));
                 }
             #else
                 //FIXME inverse first moment not implemented
             #endif
             if (use_first_moment) {
-                _fitness += deac_numerics::scalar_chi_square_penalty(
-                        first_moments[i], first_moment, first_moment_error);
+                gpu_deac_add_scalar_reduced_chi_squared(
+                        default_stream, d_first_moments,
+                        first_moment, first_moment_error,
+                        device_fitness, population_size);
+                GPU_ASSERT(deac_wait(default_stream));
             }
             if (use_third_moment) {
-                _fitness += pow((third_moment - third_moments[i])/third_moment_error,2);
+                gpu_deac_add_scalar_reduced_chi_squared(
+                        default_stream, d_third_moments,
+                        third_moment, third_moment_error,
+                        device_fitness, population_size);
+                GPU_ASSERT(deac_wait(default_stream));
             }
-            fitness_old[i] = _fitness;
+        };
+
+        score_device_population_objective(d_fitness_old);
+        #ifdef DEAC_TEST_POISON_GPU_FITNESS
+            test_require_finite_gpu_fitness(d_fitness_old, "initial");
+        #endif
+    #else
+        #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
+            const deac_numerics::ObjectiveMomentView negative_first_objective{
+                    use_negative_first_moment,
+                    use_negative_first_moment ? negative_first_moments : nullptr,
+                    negative_first_moment,
+                    negative_first_moment_error};
+        #else
+            const deac_numerics::ObjectiveMomentView negative_first_objective{};
+        #endif
+        const deac_numerics::ObjectiveMomentView first_objective{
+                use_first_moment, first_moments,
+                first_moment, first_moment_error};
+        const deac_numerics::ObjectiveMomentView third_objective{
+                use_third_moment, third_moments,
+                third_moment, third_moment_error};
+        const auto score_host_population_objective = [&](size_t population_index) {
+            return deac_numerics::score_population_objective_row(
+                    std::span<const double>(isf, number_of_timeslices),
+                    std::span<const double>(
+                            isf_model
+                                + population_index*number_of_timeslices,
+                            number_of_timeslices),
+                    std::span<const double>(
+                            isf_error, number_of_timeslices),
+                    population_index,
+                    negative_first_objective,
+                    first_objective,
+                    third_objective);
+        };
+        for (size_t i=0; i<population_size; i++) {
+            fitness_old[i] = score_host_population_objective(i);
         }
     #endif
 
@@ -1519,25 +1540,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
 
         //Set fitness for new population
         #ifdef USE_GPU
-            gpu_deac_reduced_chi_squared(default_stream, d_isf_model, d_isf, d_isf_error, d_fitness_new, population_size, number_of_timeslices, 0, 0.0);
-            GPU_ASSERT(deac_wait(default_stream));
-
-            #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-                if (use_negative_first_moment) {
-                    gpu_deac_add_scalar_reduced_chi_squared(default_stream, d_negative_first_moments, negative_first_moment, negative_first_moment_error, d_fitness_new, population_size);
-                    GPU_ASSERT(deac_wait(default_stream));
-                }
-            #else
-                //FIXME inverse first moment not implemented
-            #endif
-            if (use_first_moment) {
-                gpu_deac_add_scalar_reduced_chi_squared(default_stream, d_first_moments, first_moment, first_moment_error, d_fitness_new, population_size);
-                GPU_ASSERT(deac_wait(default_stream));
-            }
-            if (use_third_moment) {
-                gpu_deac_add_scalar_reduced_chi_squared(default_stream, d_third_moments, third_moment, third_moment_error, d_fitness_new, population_size);
-                GPU_ASSERT(deac_wait(default_stream));
-            }
+            score_device_population_objective(d_fitness_new);
             #ifdef DEAC_TEST_POISON_GPU_FITNESS
                 test_require_finite_gpu_fitness(d_fitness_new, "evolved");
             #endif
@@ -1599,23 +1602,7 @@ void deac(struct xoshiro256p_state * rng, double * const imaginary_time,
             GPU_ASSERT(deac_wait(stream_array[0]));
         #else
             for (size_t i=0; i<population_size; i++) {
-                double _fitness = reduced_chi_square_statistic(isf,
-                        isf_model + i*number_of_timeslices, isf_error,
-                        number_of_timeslices)/number_of_timeslices;
-                #ifdef USE_BOSONIC_DETAILED_BALANCE_CONDITION_DSF
-                    if (use_negative_first_moment) {
-                        _fitness += pow((negative_first_moment - negative_first_moments[i])/negative_first_moment_error,2);
-                    }
-                #else
-                    //FIXME inverse first moment not implemented
-                #endif
-                if (use_first_moment) {
-                    _fitness += deac_numerics::scalar_chi_square_penalty(
-                            first_moments[i], first_moment, first_moment_error);
-                }
-                if (use_third_moment) {
-                    _fitness += pow((third_moment - third_moments[i])/third_moment_error,2);
-                }
+                double _fitness = score_host_population_objective(i);
                 // Rejection step
                 if (normalize && !normalization_valid[i]) {
                     _fitness = std::numeric_limits<double>::max();

--- a/src/deac/src/moment_fitness.hpp
+++ b/src/deac/src/moment_fitness.hpp
@@ -1,11 +1,67 @@
 #pragma once
 
+#include <cmath>
+#include <cstddef>
+#include <span>
+
 namespace deac_numerics {
 
 inline double scalar_chi_square_penalty(
         double calculated, double observed, double standard_deviation) {
     const double term = (observed - calculated)/standard_deviation;
     return term*term;
+}
+
+struct ObjectiveMomentView {
+    bool active = false;
+    const double* calculated = nullptr;
+    double observed = 0.0;
+    double standard_deviation = 1.0;
+};
+
+// Score one population row without changing the solver's historical
+// arithmetic order.  The residual is accumulated in timeslice order and
+// divided only after the complete sum.  Moment penalties are then added in
+// negative-first, first, and third order.  Inactive moment pointers are never
+// evaluated.
+inline double score_population_objective_row(
+        std::span<const double> observed_isf,
+        std::span<const double> calculated_isf_row,
+        std::span<const double> isf_error,
+        std::size_t population_index,
+        const ObjectiveMomentView& negative_first_moment,
+        const ObjectiveMomentView& first_moment,
+        const ObjectiveMomentView& third_moment) {
+    double fitness = 0.0;
+    for (std::size_t index=0; index<observed_isf.size(); ++index) {
+        fitness += std::pow(
+                (observed_isf[index] - calculated_isf_row[index])
+                    /isf_error[index],
+                2);
+    }
+    fitness /= observed_isf.size();
+
+    if (negative_first_moment.active) {
+        fitness += std::pow(
+                (negative_first_moment.observed
+                    - negative_first_moment.calculated[population_index])
+                    /negative_first_moment.standard_deviation,
+                2);
+    }
+    if (first_moment.active) {
+        fitness += scalar_chi_square_penalty(
+                first_moment.calculated[population_index],
+                first_moment.observed,
+                first_moment.standard_deviation);
+    }
+    if (third_moment.active) {
+        fitness += std::pow(
+                (third_moment.observed
+                    - third_moment.calculated[population_index])
+                    /third_moment.standard_deviation,
+                2);
+    }
+    return fitness;
 }
 
 } // namespace deac_numerics

--- a/src/deac/src/population_scoring.hpp
+++ b/src/deac/src/population_scoring.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "population_projection.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+namespace deac_numerics {
+
+// Opaque non-owning view whose pointers retain the active backend's existing
+// layout: row-major on CPU and column-major on accelerators.  Only the CPU
+// projection helpers below interpret the pointed-to storage.  The
+// negative-frequency population is absent for one-sided configurations.
+struct PopulationView {
+    double* positive_frequency = nullptr;
+    double* negative_frequency = nullptr;
+};
+
+// Reset and project a population through the forward-model kernels.  Keep the
+// historical arithmetic order: every positive-frequency contribution is
+// accumulated before any negative-frequency contribution, and the underlying
+// projection evaluates kernel*population for each genome entry.
+inline void project_population_forward_model(
+        double* modeled_isf,
+        const PopulationView& population,
+        const double* positive_frequency_kernel,
+        const double* negative_frequency_kernel,
+        std::size_t number_of_timeslices,
+        std::size_t genome_size,
+        std::size_t population_size) {
+    std::fill(
+            modeled_isf,
+            modeled_isf + population_size*number_of_timeslices,
+            0.0);
+    accumulate_population_projection(
+            modeled_isf,
+            positive_frequency_kernel,
+            population.positive_frequency,
+            number_of_timeslices,
+            genome_size,
+            population_size);
+    if (population.negative_frequency != nullptr) {
+        accumulate_population_projection(
+                modeled_isf,
+                negative_frequency_kernel,
+                population.negative_frequency,
+                number_of_timeslices,
+                genome_size,
+                population_size);
+    }
+}
+
+inline void accumulate_population_scalar_projection(
+        double* projected,
+        const double* population,
+        const double* terms,
+        std::size_t genome_size,
+        std::size_t population_size) {
+    for (std::size_t population_index=0;
+            population_index<population_size;
+            ++population_index) {
+        for (std::size_t genome_index=0;
+                genome_index<genome_size;
+                ++genome_index) {
+            projected[population_index] +=
+                    population[population_index*genome_size + genome_index]
+                    *terms[genome_index];
+        }
+    }
+}
+
+// Reset and project a scalar moment from a population.  The positive and
+// optional negative terms use the same population*term operand order as the
+// solver's original CPU matrix-vector helper.
+inline void project_population_scalar_moment(
+        double* projected_moment,
+        const PopulationView& population,
+        const double* positive_frequency_terms,
+        const double* negative_frequency_terms,
+        std::size_t genome_size,
+        std::size_t population_size) {
+    std::fill(
+            projected_moment,
+            projected_moment + population_size,
+            0.0);
+    accumulate_population_scalar_projection(
+            projected_moment,
+            population.positive_frequency,
+            positive_frequency_terms,
+            genome_size,
+            population_size);
+    if (population.negative_frequency != nullptr) {
+        accumulate_population_scalar_projection(
+                projected_moment,
+                population.negative_frequency,
+                negative_frequency_terms,
+                genome_size,
+                population_size);
+    }
+}
+
+// Reset and project the negative-first observable from an already modeled ISF.
+// Modeled ISF rows are population-major, matching the forward-model output.
+inline void project_modeled_isf_moment(
+        double* projected_moment,
+        const double* modeled_isf,
+        const double* terms,
+        std::size_t number_of_timeslices,
+        std::size_t population_size) {
+    std::fill(
+            projected_moment,
+            projected_moment + population_size,
+            0.0);
+    accumulate_population_scalar_projection(
+            projected_moment,
+            modeled_isf,
+            terms,
+            number_of_timeslices,
+            population_size);
+}
+
+} // namespace deac_numerics

--- a/test/deac_build_receipt_test.py
+++ b/test/deac_build_receipt_test.py
@@ -30,6 +30,9 @@ INVALID_NORMALIZATION_DEFINITION = (
     "DEAC_TEST_FORCE_INVALID_NORMALIZATION_TRIALS=1"
 )
 POISON_GPU_FITNESS_DEFINITION = "DEAC_TEST_POISON_GPU_FITNESS=1"
+IDENTICAL_POPULATION_SCORING_DEFINITION = (
+    "DEAC_TEST_SCORE_IDENTICAL_POPULATION=1"
+)
 HIPBLAS_CACHE_KEYS = {
     "CMAKE_DISABLE_FIND_PACKAGE_hipblas",
     "DEAC_HIPBLAS_INCLUDE_DIR",
@@ -213,6 +216,7 @@ def validate_compile_groups(
     fingerprint=None,
     expect_invalid_normalization_definition=False,
     expect_poison_gpu_fitness_definition=False,
+    expect_identical_population_scoring_definition=False,
 ):
     if not isinstance(compile_groups, list) or not compile_groups:
         raise AssertionError(f"{label} has no effective compile groups")
@@ -251,6 +255,9 @@ def validate_compile_groups(
             ),
             POISON_GPU_FITNESS_DEFINITION: (
                 1 if expect_poison_gpu_fitness_definition else 0
+            ),
+            IDENTICAL_POPULATION_SCORING_DEFINITION: (
+                1 if expect_identical_population_scoring_definition else 0
             ),
         }
         for definition, expected_count in expected_test_definitions.items():
@@ -293,6 +300,7 @@ def validate_receipt(
     expected_link_library,
     expect_invalid_normalization_definition,
     expect_poison_gpu_fitness_definition,
+    expect_identical_population_scoring_definition,
 ):
     receipt = document["receipt"]
     archive_tools = receipt["archive_tools"]
@@ -409,6 +417,9 @@ def validate_receipt(
         expect_poison_gpu_fitness_definition=(
             expect_poison_gpu_fitness_definition
         ),
+        expect_identical_population_scoring_definition=(
+            expect_identical_population_scoring_definition
+        ),
     )
     if not any(source.endswith("/deac/src/deac.cpp") for source in compiled_sources):
         raise AssertionError("receipt does not bind the primary solver source")
@@ -454,6 +465,7 @@ def validate_receipt(
         fingerprint=fingerprint,
         expect_invalid_normalization_definition=False,
         expect_poison_gpu_fitness_definition=False,
+        expect_identical_population_scoring_definition=False,
     )
     used_languages.update(dependency_languages)
     if not any(source.endswith("/deac/src/build_identity.cpp") for source in dependency_sources):
@@ -531,6 +543,7 @@ def validate_receipt_endpoint(
     expected_link_library,
     expect_invalid_normalization_definition,
     expect_poison_gpu_fitness_definition,
+    expect_identical_population_scoring_definition,
 ):
     first = run([exe, "--build-receipt"], exe.parent)
     second = run([exe, "--build-receipt"], exe.parent)
@@ -555,6 +568,9 @@ def validate_receipt_endpoint(
         ),
         expect_poison_gpu_fitness_definition=(
             expect_poison_gpu_fitness_definition
+        ),
+        expect_identical_population_scoring_definition=(
+            expect_identical_population_scoring_definition
         ),
     )
     return first.stdout
@@ -605,6 +621,7 @@ def main():
         expected_link_library=args.expected_link_library,
         expect_invalid_normalization_definition=False,
         expect_poison_gpu_fitness_definition=False,
+        expect_identical_population_scoring_definition=False,
     )
     if args.helper_exe is not None:
         validate_receipt_endpoint(
@@ -618,6 +635,7 @@ def main():
             expected_link_library=args.expected_link_library,
             expect_invalid_normalization_definition=True,
             expect_poison_gpu_fitness_definition=(args.expected_backend != "none"),
+            expect_identical_population_scoring_definition=True,
         )
 
     workdir = Path(args.workdir)

--- a/test/deac_identical_population_scoring_test.py
+++ b/test/deac_identical_population_scoring_test.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+import argparse
+import shutil
+import struct
+import subprocess
+from pathlib import Path
+
+MARKER = "test_identical_population_scoring: exact 4"
+EVOLVED_MARKERS = (
+    "test_forced_invalid_normalization_trials:",
+    "test_invalid_normalization_fitness:",
+    "test_poisoned_gpu_fitness_evolved:",
+)
+
+
+def write_doubles(path, values):
+    path.write_bytes(struct.pack("<" + "d" * len(values), *values))
+
+
+def run_solver(
+    exe,
+    workdir,
+    fixture,
+    save_dir,
+    uuid,
+    detailed_balance,
+    zero_temperature,
+):
+    command = [
+        exe,
+        "--temperature",
+        "0" if zero_temperature else "1",
+        "--number_of_generations",
+        "2",
+        "--population_size",
+        "4",
+        "--genome_size",
+        "8",
+        "--omega_max",
+        "4",
+        "--normalize",
+        "--first_moment",
+        "0.5",
+        "--first_moment_error",
+        "0.25",
+        "--third_moment",
+        "0.5",
+        "--third_moment_error",
+        "0.1",
+        "--crossover_probability",
+        "0.9",
+        "--self_adapting_crossover_probability",
+        "0.1",
+        "--differential_weight",
+        "0.9",
+        "--self_adapting_differential_weight_probability",
+        "0.1",
+        "--stop_minimum_fitness",
+        "1e300",
+        "--save_directory",
+        str(save_dir),
+        "--seed",
+        "17",
+        "--uuid",
+        uuid,
+    ]
+    if detailed_balance:
+        command.append("--use_negative_first_moment")
+    elif not zero_temperature:
+        command.extend(["--spectra_type", "bfull"])
+    command.append(str(fixture))
+    result = subprocess.run(
+        command,
+        cwd=workdir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"solver failed with {result.returncode}\n"
+            f"command: {' '.join(map(str, command))}\n"
+            f"output:\n{result.stdout}"
+        )
+    return result.stdout
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reference-exe", required=True)
+    parser.add_argument("--seam-exe", required=True)
+    parser.add_argument("--workdir", required=True)
+    parser.add_argument("--detailed-balance", action="store_true")
+    parser.add_argument("--zero-temperature", action="store_true")
+    args = parser.parse_args()
+
+    workdir = Path(args.workdir)
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+
+    fixture = workdir / "positive-isf.bin"
+    write_doubles(
+        fixture,
+        [0.0, 0.2, 0.4, 0.6]
+        + [1.0, 0.85, 0.72, 0.61]
+        + [0.05, 0.05, 0.05, 0.05],
+    )
+
+    reference_output = run_solver(
+        args.reference_exe,
+        workdir,
+        fixture,
+        workdir / "reference",
+        "reference",
+        args.detailed_balance,
+        args.zero_temperature,
+    )
+    seam_output = run_solver(
+        args.seam_exe,
+        workdir,
+        fixture,
+        workdir / "seam",
+        "seam",
+        args.detailed_balance,
+        args.zero_temperature,
+    )
+
+    if MARKER in reference_output:
+        raise AssertionError(
+            "production solver unexpectedly enabled the identical-population "
+            f"seam:\n{reference_output}"
+        )
+    if seam_output.count(MARKER) != 1:
+        raise AssertionError(
+            "test helper did not prove exact initial/evolved scoring once:\n"
+            f"{seam_output}"
+        )
+    reached_evolved_loop = [
+        marker for marker in EVOLVED_MARKERS if marker in seam_output
+    ]
+    if reached_evolved_loop:
+        raise AssertionError(
+            "identical-population seam did not stop before mutation/evolution: "
+            f"markers={reached_evolved_loop}\n{seam_output}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/moment_fitness_test.cpp
+++ b/test/moment_fitness_test.cpp
@@ -1,7 +1,29 @@
 #include "moment_fitness.hpp"
 
+#include <array>
 #include <cmath>
+#include <cstddef>
 #include <iostream>
+#include <span>
+
+namespace {
+
+using deac_numerics::ObjectiveMomentView;
+
+double score(
+        std::span<const double> observed,
+        std::span<const double> calculated,
+        std::span<const double> error,
+        std::size_t population_index,
+        const ObjectiveMomentView& negative_first = {},
+        const ObjectiveMomentView& first = {},
+        const ObjectiveMomentView& third = {}) {
+    return deac_numerics::score_population_objective_row(
+            observed, calculated, error, population_index,
+            negative_first, first, third);
+}
+
+} // namespace
 
 int main() {
     if (deac_numerics::scalar_chi_square_penalty(2.0, 0.0, 1.0) != 4.0) {
@@ -15,6 +37,72 @@ int main() {
     if (!std::isfinite(
                 deac_numerics::scalar_chi_square_penalty(0.0, 0.0, 1.0))) {
         std::cerr << "matching zero moment produced a non-finite penalty\n";
+        return 1;
+    }
+
+    const std::array<double, 2> observed_isf{1.0, 4.0};
+    const std::array<double, 2> calculated_isf{0.0, 2.0};
+    const std::array<double, 2> isf_error{1.0, 2.0};
+    if (score(observed_isf, calculated_isf, isf_error, 0) != 1.0) {
+        std::cerr << "residual-only objective changed\n";
+        return 1;
+    }
+
+    // Index zero is deliberately different so the test also proves that each
+    // active observable selects the requested population row.
+    const std::array<double, 2> negative_first_calculated{99.0, 4.0};
+    const std::array<double, 2> first_calculated{99.0, 1.0};
+    const std::array<double, 2> third_calculated{99.0, 5.0};
+    const ObjectiveMomentView negative_first{
+            true, negative_first_calculated.data(), 2.0, 2.0};
+    const ObjectiveMomentView first{
+            true, first_calculated.data(), 0.0, 0.5};
+    const ObjectiveMomentView third{
+            true, third_calculated.data(), 1.0, 2.0};
+    const std::array<ObjectiveMomentView, 3> moments{
+            negative_first, first, third};
+    const std::array<double, 3> penalties{1.0, 4.0, 4.0};
+
+    for (unsigned int active_mask=0; active_mask<8; ++active_mask) {
+        std::array<ObjectiveMomentView, 3> selected = moments;
+        double expected = 1.0;
+        for (std::size_t index=0; index<selected.size(); ++index) {
+            selected[index].active = (active_mask & (1U << index)) != 0;
+            if (selected[index].active) {
+                expected += penalties[index];
+            }
+        }
+        const double actual = score(
+                observed_isf, calculated_isf, isf_error, 1,
+                selected[0], selected[1], selected[2]);
+        if (actual != expected) {
+            std::cerr << "active moment combination " << active_mask
+                      << " produced " << actual
+                      << ", expected " << expected << '\n';
+            return 1;
+        }
+    }
+
+    // The negative-first penalty is 2^54, whose ULP is four.  The production
+    // order first loses the residual in that large addition and then loses the
+    // unit first- and third-moment penalties independently.  Regrouping the
+    // three small contributions first changes the result by one ULP.
+    const std::array<double, 1> rounding_observed{1.0};
+    const std::array<double, 1> rounding_calculated{0.0};
+    const std::array<double, 1> rounding_error{1.0};
+    const std::array<double, 1> large_moment{std::ldexp(1.0, 27)};
+    const std::array<double, 1> unit_moment{1.0};
+    const ObjectiveMomentView large_penalty{
+            true, large_moment.data(), 0.0, 1.0};
+    const ObjectiveMomentView unit_penalty{
+            true, unit_moment.data(), 0.0, 1.0};
+    const double ordered = score(
+            rounding_observed, rounding_calculated, rounding_error, 0,
+            large_penalty, unit_penalty, unit_penalty);
+    const double large_penalty_value = std::ldexp(1.0, 54);
+    const double regrouped = large_penalty_value + (1.0 + 1.0 + 1.0);
+    if (ordered != large_penalty_value || regrouped == ordered) {
+        std::cerr << "rounding-sensitive objective addition order changed\n";
         return 1;
     }
     return 0;

--- a/test/population_scoring_test.cpp
+++ b/test/population_scoring_test.cpp
@@ -1,0 +1,193 @@
+#include "moment_fitness.hpp"
+#include "population_scoring.hpp"
+
+#include <array>
+#include <cstddef>
+#include <iostream>
+#include <span>
+
+namespace {
+
+constexpr std::size_t population_size = 2;
+constexpr std::size_t genome_size = 3;
+constexpr std::size_t number_of_timeslices = 2;
+
+using Population = std::array<double, population_size*genome_size>;
+using ModeledIsf = std::array<double, population_size*number_of_timeslices>;
+using Moment = std::array<double, population_size>;
+
+bool check_projection(
+        const char* description,
+        const deac_numerics::PopulationView& population,
+        const double* negative_isf_kernel,
+        const double* negative_first_terms,
+        const double* negative_third_terms,
+        const ModeledIsf& expected_isf,
+        const Moment& expected_first,
+        const Moment& expected_third,
+        const Moment& expected_negative_first,
+        const Moment& expected_fitness) {
+    const std::array<double, number_of_timeslices*genome_size>
+            positive_isf_kernel{1.0, 2.0, 4.0, 0.5, 1.0, 2.0};
+    const std::array<double, genome_size> positive_first_terms{0.0, 1.0, 2.0};
+    const std::array<double, genome_size> positive_third_terms{0.0, 1.0, 4.0};
+    const std::array<double, number_of_timeslices> negative_first_isf_terms{1.0, 2.0};
+
+    ModeledIsf modeled_isf{};
+    Moment first_moment{};
+    Moment third_moment{};
+    Moment negative_first_moment{};
+    modeled_isf.fill(101.0);
+    first_moment.fill(102.0);
+    third_moment.fill(103.0);
+    negative_first_moment.fill(104.0);
+    deac_numerics::project_population_forward_model(
+            modeled_isf.data(),
+            population,
+            positive_isf_kernel.data(),
+            negative_isf_kernel,
+            number_of_timeslices,
+            genome_size,
+            population_size);
+    deac_numerics::project_population_scalar_moment(
+            first_moment.data(),
+            population,
+            positive_first_terms.data(),
+            negative_first_terms,
+            genome_size,
+            population_size);
+    deac_numerics::project_population_scalar_moment(
+            third_moment.data(),
+            population,
+            positive_third_terms.data(),
+            negative_third_terms,
+            genome_size,
+            population_size);
+    deac_numerics::project_modeled_isf_moment(
+            negative_first_moment.data(),
+            modeled_isf.data(),
+            negative_first_isf_terms.data(),
+            number_of_timeslices,
+            population_size);
+
+    if (modeled_isf != expected_isf
+            || first_moment != expected_first
+            || third_moment != expected_third
+            || negative_first_moment != expected_negative_first) {
+        std::cerr << description << " projection changed\n";
+        return false;
+    }
+
+    const std::array<double, number_of_timeslices> observed_isf{1.0, 2.0};
+    const std::array<double, number_of_timeslices> isf_error{1.0, 0.5};
+    const deac_numerics::ObjectiveMomentView negative_first_objective{
+            true, negative_first_moment.data(), 0.0, 2.0};
+    const deac_numerics::ObjectiveMomentView first_objective{
+            true, first_moment.data(), 0.0, 0.5};
+    const deac_numerics::ObjectiveMomentView third_objective{
+            true, third_moment.data(), 0.0, 4.0};
+    Moment fitness{};
+    for (std::size_t population_index=0;
+            population_index<population_size;
+            ++population_index) {
+        fitness[population_index] =
+                deac_numerics::score_population_objective_row(
+                        observed_isf,
+                        std::span<const double>(
+                                modeled_isf.data()
+                                    + population_index*number_of_timeslices,
+                                number_of_timeslices),
+                        isf_error,
+                        population_index,
+                        negative_first_objective,
+                        first_objective,
+                        third_objective);
+    }
+    if (fitness != expected_fitness) {
+        std::cerr << description << " objective changed\n";
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    Population incumbent_positive{1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    Population incumbent_negative{1.0, 7.0, 8.0, 4.0, 9.0, 10.0};
+    Population candidate_positive = incumbent_positive;
+    Population candidate_negative = incumbent_negative;
+    const Population original_incumbent_positive = incumbent_positive;
+    const Population original_incumbent_negative = incumbent_negative;
+    const Population original_candidate_positive = candidate_positive;
+    const Population original_candidate_negative = candidate_negative;
+
+    if (incumbent_positive.data() == candidate_positive.data()
+            || incumbent_negative.data() == candidate_negative.data()) {
+        std::cerr << "incumbent and candidate fixtures alias\n";
+        return 1;
+    }
+
+    const std::array<double, number_of_timeslices*genome_size>
+            negative_isf_kernel{8.0, 4.0, 2.0, 4.0, 2.0, 1.0};
+    const std::array<double, genome_size> negative_first_terms{0.0, -1.0, -2.0};
+    const std::array<double, genome_size> negative_third_terms{0.0, -1.0, -4.0};
+
+    const ModeledIsf one_sided_isf{17.0, 8.5, 38.0, 19.0};
+    const Moment one_sided_first{8.0, 17.0};
+    const Moment one_sided_third{14.0, 29.0};
+    const Moment one_sided_negative_first{34.0, 76.0};
+    const Moment one_sided_fitness{769.75, 3915.0625};
+    const ModeledIsf two_sided_isf{69.0, 34.5, 126.0, 63.0};
+    const Moment two_sided_first{-15.0, -12.0};
+    const Moment two_sided_third{-25.0, -20.0};
+    const Moment two_sided_negative_first{138.0, 252.0};
+    const Moment two_sided_fitness{10124.5625, 31731.5};
+
+    const auto check_both_views = [&](
+            const char* one_sided_description,
+            const char* two_sided_description,
+            Population& positive,
+            Population& negative) {
+        return check_projection(
+                       one_sided_description,
+                       {positive.data(), nullptr},
+                       nullptr,
+                       nullptr,
+                       nullptr,
+                       one_sided_isf,
+                       one_sided_first,
+                       one_sided_third,
+                       one_sided_negative_first,
+                       one_sided_fitness)
+                && check_projection(
+                       two_sided_description,
+                       {positive.data(), negative.data()},
+                       negative_isf_kernel.data(),
+                       negative_first_terms.data(),
+                       negative_third_terms.data(),
+                       two_sided_isf,
+                       two_sided_first,
+                       two_sided_third,
+                       two_sided_negative_first,
+                       two_sided_fitness);
+    };
+
+    if (!check_both_views(
+                "one-sided incumbent", "two-sided incumbent",
+                incumbent_positive, incumbent_negative)
+            || !check_both_views(
+                "one-sided candidate", "two-sided candidate",
+                candidate_positive, candidate_negative)) {
+        return 1;
+    }
+
+    if (incumbent_positive != original_incumbent_positive
+            || incumbent_negative != original_incumbent_negative
+            || candidate_positive != original_candidate_positive
+            || candidate_negative != original_candidate_negative) {
+        std::cerr << "population projections modified their source arrays\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary

- centralize initial and evolved objective scoring behind exact-order helpers
- introduce non-owning incumbent/candidate population views for CPU and accelerator observable projection
- share the production evolved forward/moment orchestration with a compile-time identical-population seam
- keep normalization and acceptance policy outside this stage

## Invariants

This is a correctness refactor, not a performance claim. It preserves RNG calls, CPU row-major and accelerator column-major layouts, positive-before-negative accumulation, arithmetic operand/addition order, allocations, waits, normalization, and candidate tie acceptance.

## Validation

- GCC 14.2.0 Release standard: 76/76
- GCC 14.2.0 Release detailed balance: 76/76
- focused GCC ZeroT and IntelLLVM 2026.1.0 real Level Zero SYCL gates passed
- identical-population seam passed in standard, detailed, ZeroT, and real SYCL configurations
- all 30 fixed-seed binary outputs across standard, detailed, hyperbolic, normalization, ZeroT, and signed variants are byte-identical to base 1efb64b
- independent objective, observable, and solver-seam reviews: PUBLISH

## Stacking

Stacked on #54. The normalization-phase continuation is #56.

Refs #46.